### PR TITLE
Add badges for Discord, license, and Ko-fi link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@
 
 A book collection manager for audiobooks and eBooks.
 
+[![Discord](https://img.shields.io/discord/1376676460647022752?logo=discord&logoColor=white&label=Discord)](https://discord.gg/G9ZbgWS5rp)
+[![License](https://img.shields.io/github/license/Chaptarr/chaptarr)](https://github.com/Chaptarr/chaptarr/blob/main/LICENSE)
+
 </div>
+
+<div align="center"><a href='https://ko-fi.com/chaptarr' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi6.png?v=6' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a></div>
 
 > **Chaptarr is beta software.** It is under active development. Bugs are likely; breaking changes less so, but still possible. Full disclosure: the last data loss event was in pre-alpha, with a tester group of roughly 30 people, about 12 months ago. Over the last 6 months we've grown past 11,000 active users with no reported data loss events. Still, follow good backup practice and avoid pointing it at a library you can't afford to lose.
 


### PR DESCRIPTION
#### Description
The Readme needed the Discord link. Other projects generally have the license and the Ko-fi link in the same area, so I added those as well.

Fixes # (if applicable)

#### Database Migration
NO

#### How was this tested?
I clicked the badges, they led to the correct place.

#### Screenshots (UI changes only)
<img width="432" height="519" alt="Screenshot_20260807_225011" src="https://github.com/user-attachments/assets/5f6ed191-d413-4dc2-861c-736d96a6940d" />