### PR TITLE
Fix: ensure api requests follow the baseURL

### DIFF
--- a/frontend/src/Author/AuthorPoster.js
+++ b/frontend/src/Author/AuthorPoster.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import Icon from 'Components/Icon';
 import { icons } from 'Helpers/Props';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import AuthorImage from './AuthorImage';
 import styles from './AuthorPoster.css';
 
@@ -266,16 +267,15 @@ class AuthorPoster extends Component {
     
     try {
       // Load image on-demand when user selects it
-      const loadResponse = await fetch(`/api/v1/author/${authorId}/loadImage`, {
+      const loadResult = await createAjaxRequest({
+        url: `/author/${authorId}/loadImage`,
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Api-Key': window.Chaptarr.apiKey
-        },
-        body: JSON.stringify({
+        dataType: 'json',
+        contentType: 'application/json',
+        data: JSON.stringify({
           ImageUrl: selectedImage.remoteUrl || selectedImage.url
         })
-      });
+      }).request;
       
       // Check if this is still the latest request
       if (seq !== this.requestSeq) {
@@ -283,7 +283,6 @@ class AuthorPoster extends Component {
         return;
       }
       
-      const loadResult = await loadResponse.json();
       console.log(`[AuthorPoster] Load image result for author ${authorId}:`, loadResult);
       
       if (loadResult.status === 'success' && loadResult.localPath) {
@@ -326,22 +325,15 @@ class AuthorPoster extends Component {
         
         // Persist the selection to the server
         try {
-          const persistResponse = await fetch(`/api/v1/author/${authorId}/primaryPhoto`, {
+          await createAjaxRequest({
+            url: `/author/${authorId}/primaryPhoto`,
             method: 'PUT',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-Api-Key': window.Chaptarr.apiKey
-            },
-            body: JSON.stringify({
+            contentType: 'application/json',
+            data: JSON.stringify({
               PhotoUrl: selectedImage.remoteUrl || selectedImage.url
             })
-          });
-          
-          if (persistResponse.ok) {
-            console.log(`[AuthorPoster] Persisted photo selection for author ${authorId}`);
-          } else {
-            console.warn('[AuthorPoster] Failed to persist photo selection:', await persistResponse.text());
-          }
+          }).request;
+          console.log(`[AuthorPoster] Persisted photo selection for author ${authorId}`);
         } catch (e) {
           console.warn('[AuthorPoster] Failed to persist photo selection:', e);
         }

--- a/frontend/src/Author/Index/AuthorIndexFooter.js
+++ b/frontend/src/Author/Index/AuthorIndexFooter.js
@@ -4,6 +4,7 @@ import React, { PureComponent } from 'react';
 import { ColorImpairedConsumer } from 'App/ColorImpairedContext';
 import DescriptionList from 'Components/DescriptionList/DescriptionList';
 import DescriptionListItem from 'Components/DescriptionList/DescriptionListItem';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import formatBytes from 'Utilities/Number/formatBytes';
 import translate from 'Utilities/String/translate';
 import styles from './AuthorIndexFooter.css';
@@ -54,30 +55,30 @@ class AuthorIndexFooter extends PureComponent {
 
     const authorIds = author.map(a => a.id);
 
-    fetch('/api/v1/author/statistics/aggregate', {
+    const promise = createAjaxRequest({
+      url: '/author/statistics/aggregate',
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Api-Key': window.Chaptarr.apiKey
-      },
-      body: JSON.stringify({
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
         authorIds,
         mediaType: mediaType || 'all'
       })
-    })
-      .then(response => response.json())
-      .then(data => {
-        this.setState({
-          books: data.bookCount || 0,
-          bookFiles: data.fileCount || 0,
-          totalFileSize: data.totalFileSize || 0
-        });
-      })
-      .catch(error => {
-        console.error('Failed to fetch aggregate statistics:', error);
-        // Fallback to client-side calculation on error
-        this.calculateClientSideStats();
+    }).request;
+
+    promise.done((data) => {
+      this.setState({
+        books: data.bookCount || 0,
+        bookFiles: data.fileCount || 0,
+        totalFileSize: data.totalFileSize || 0
       });
+    });
+
+    promise.fail((error) => {
+      console.error('Failed to fetch aggregate statistics:', error);
+      // Fallback to client-side calculation on error
+      this.calculateClientSideStats();
+    });
   }
 
   calculateClientSideStats = () => {

--- a/frontend/src/Settings/MediaManagement/Naming/NamingVisualBuilder/NamingVisualBuilder.js
+++ b/frontend/src/Settings/MediaManagement/Naming/NamingVisualBuilder/NamingVisualBuilder.js
@@ -11,6 +11,7 @@ import ModalBody from 'Components/Modal/ModalBody';
 import ModalFooter from 'Components/Modal/ModalFooter';
 import Button from 'Components/Link/Button';
 import { kinds } from 'Helpers/Props';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import translate from 'Utilities/String/translate';
 import TokenPalette from './TokenPalette';
 import NamingCanvas from './NamingCanvas';
@@ -58,7 +59,7 @@ class NamingVisualBuilder extends Component {
     }
   }
 
-  loadPatternFromProps = async () => {
+  loadPatternFromProps = () => {
     const { initialPattern } = this.props;
     
     if (!initialPattern) {
@@ -69,26 +70,28 @@ class NamingVisualBuilder extends Component {
     }
 
     try {
-      const response = await fetch('/api/v1/config/naming-pattern/decompile', {
+      const promise = createAjaxRequest({
+        url: '/config/naming-pattern/decompile',
         method: 'POST',
-        headers: { 
-          'Content-Type': 'application/json',
-          'X-Api-Key': window.Chaptarr.apiKey
-        },
-        body: JSON.stringify({ pattern: initialPattern })
-      });
+        dataType: 'json',
+        contentType: 'application/json',
+        data: JSON.stringify({ pattern: initialPattern })
+      }).request;
 
-      if (response.ok) {
-        const { ast } = await response.json();
+      promise.done(({ ast }) => {
         this.setState({ ast });
         this.scheduleValidation();
-      }
+      });
+
+      promise.fail((error) => {
+        console.error('Failed to decompile pattern:', error);
+      });
     } catch (error) {
-      console.error('Failed to decompile pattern:', error);
+      console.error('Failed to create decompile request:', error);
     }
   };
 
-  handleSave = async () => {
+  handleSave = () => {
     const { onSave } = this.props;
     const { ast } = this.state;
 
@@ -99,36 +102,32 @@ class NamingVisualBuilder extends Component {
     }
 
     try {
-      const response = await fetch('/api/v1/config/naming-pattern/compile', {
+      const promise = createAjaxRequest({
+        url: '/config/naming-pattern/compile',
         method: 'POST',
-        headers: { 
-          'Content-Type': 'application/json',
-          'X-Api-Key': window.Chaptarr.apiKey
-        },
-        body: JSON.stringify({ ast })
+        dataType: 'json',
+        contentType: 'application/json',
+        data: JSON.stringify({ ast })
+      }).request;
+
+      promise.done(({ pattern }) => {
+        onSave(pattern);
       });
 
-      if (response.ok) {
-        const { pattern } = await response.json();
-        onSave(pattern);
-      } else {
-        let errorMessage = translate('NamingBuilderCompileRequestFailed');
-        try {
-          const error = await response.json();
-          errorMessage = error?.error || errorMessage;
-        } catch (e) {
-          // ignore
-        }
-
+      promise.fail((error) => {
+        console.error('Failed to compile pattern:', error);
         this.setState({
           validation: {
             isValid: false,
-            errors: [{ code: 'VALIDATION_ERROR', message: errorMessage }]
+            errors: [{
+              code: 'EXCEPTION',
+              message: error.status ? translate('NamingBuilderCompileRequestFailed') : translate('NamingBuilderCompileFailed')
+            }]
           }
         });
-      }
+      });
     } catch (error) {
-      console.error('Failed to compile pattern:', error);
+      console.error('Failed to create compile request:', error);
       this.setState({
         validation: {
           isValid: false,
@@ -148,7 +147,7 @@ class NamingVisualBuilder extends Component {
       clearTimeout(this.validationTimeout);
     }
 
-    this.validationTimeout = setTimeout(async () => {
+    this.validationTimeout = setTimeout(() => {
       const clientValidation = validateAst(this.state.ast);
 
       if (!clientValidation.isValid) {
@@ -162,41 +161,35 @@ class NamingVisualBuilder extends Component {
       this.setState({ isValidating: true });
 
       try {
-        const response = await fetch('/api/v1/config/naming-pattern/validate', {
+        const promise = createAjaxRequest({
+          url: '/config/naming-pattern/validate',
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Api-Key': window.Chaptarr.apiKey
-          },
-          body: JSON.stringify({ ast: this.state.ast })
-        });
+          dataType: 'json',
+          contentType: 'application/json',
+          data: JSON.stringify({ ast: this.state.ast })
+        }).request;
 
-        if (response.ok) {
-          const serverValidation = await response.json();
+        promise.done((serverValidation) => {
           const validation = {
             isValid: Boolean(serverValidation.ok),
             errors: serverValidation.errors || []
           };
           this.setState({ validation, isValidating: false });
-          return;
-        }
+        });
 
-        this.setState({
-          validation: {
-            isValid: false,
-            errors: [{ code: 'VALIDATION_ERROR', message: translate('NamingBuilderValidationRequestFailed') }]
-          },
-          isValidating: false
+        promise.fail((error) => {
+          console.error('Validation failed:', error);
+          this.setState({
+            validation: {
+              isValid: false,
+              errors: [{ code: 'VALIDATION_ERROR', message: translate('NamingBuilderValidationFailed') }]
+            },
+            isValidating: false
+          });
         });
       } catch (error) {
-        console.error('Validation failed:', error);
-        this.setState({
-          validation: {
-            isValid: false,
-            errors: [{ code: 'VALIDATION_ERROR', message: translate('NamingBuilderValidationFailed') }]
-          },
-          isValidating: false
-        });
+        console.error('Failed to create validation request:', error);
+        this.setState({ isValidating: false });
       }
     }, 300);
   };

--- a/frontend/src/Store/Actions/Settings/proxies.js
+++ b/frontend/src/Store/Actions/Settings/proxies.js
@@ -1,5 +1,6 @@
 import { createAction } from 'redux-actions';
 import { createThunk, handleThunks } from 'Store/thunks';
+import createAjaxRequest from 'Utilities/createAjaxRequest';
 import { set } from '../baseActions';
 import createFetchHandler from '../Creators/createFetchHandler';
 import createHandleActions from '../Creators/createHandleActions';
@@ -67,14 +68,13 @@ export default {
     [TEST_PROXY]: (getState, payload, dispatch) => {
       dispatch(set({ section, isTesting: true }));
 
-      const promise = fetch('/api/v1/settings/proxy/test', {
+      const promise = createAjaxRequest({
+        url: '/settings/proxy/test',
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Api-Key': window.Chaptarr.apiKey
-        },
-        body: JSON.stringify(payload)
-      });
+        dataType: 'json',
+        contentType: 'application/json',
+        data: JSON.stringify(payload)
+      }).request;
 
       promise.done((data) => {
         dispatch(set({


### PR DESCRIPTION
#### Description
(Copied from the discord support channel)
Hi, I run chaptarr with a URL Base set (/chaptarr) and I've noticed some requests do not honor it. 

I've tested this on version: 0.9.852.0

After a quick search (grepping for fetch) through the frontend js, I've found these:
/api/v1/author/statistics/aggregate
/api/v1/config/naming-pattern/decompile
/api/v1/config/naming-pattern/compile
/api/v1/config/naming-pattern/validate
/api/v1/settings/proxy/test
/api/v1/author/${n}/loadImage
/api/v1/author/${n}/primaryPhoto

Fixes # (if applicable)
https://discord.com/channels/1376676460647022752/1532014785225556058
#### Database Migration
YES / NO. If yes, which tables?
NO
#### How was this tested?
What you ran and on what setup (OS, Docker or native). Include steps to
reproduce if it's a fix.

Tested locally on macOS Tahoe by enabling a base URL and going to each section that has been changed and verifying in devtools that the requests now follow the configured baseURL. 
#### Screenshots (UI changes only)
N/A

#### AI disclosure

This PR was identified and tested by a human, but codex was used to help with the implementation changes. 
All code has been reviewed by a human (me) before opening this PR. 

---

**A note on AI:** We know AI/agentic coding is everywhere and only getting
more popular. We won't insist that you disclose whether you used it or which
models you used, but in the same spirit, please don't take offense if your PR
is scrutinized and changes are requested.

**Review time:** The longer the PR and the more lines changed, the longer the
review will take. Small, focused PRs merge fastest. If yours is big, please be
patient.
