### PR TITLE
fix: links in MoreInfo component for Wiki and GitHub references

### DIFF
--- a/frontend/src/System/Status/MoreInfo/MoreInfo.js
+++ b/frontend/src/System/Status/MoreInfo/MoreInfo.js
@@ -25,10 +25,7 @@ class MoreInfo extends Component {
             <Link to="https://wiki.chaptarr.com">{translate('Wiki')}</Link>
           </DescriptionListItemDescription>
 
-          {/* <DescriptionListItemTitle>{translate('Reddit')}</DescriptionListItemTitle>
-          <DescriptionListItemDescription>
-            <Link to="https://discord.gg/nqFGsGUug2">{'Chaptarr'}</Link>
-          </DescriptionListItemDescription> */}
+          {/* No Reddit entry: r/chaptarr is already taken and not affiliated with Chaptarr, and no official subreddit is planned. */}
 
           <DescriptionListItemTitle>{translate('Discord')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>

--- a/frontend/src/System/Status/MoreInfo/MoreInfo.js
+++ b/frontend/src/System/Status/MoreInfo/MoreInfo.js
@@ -22,13 +22,13 @@ class MoreInfo extends Component {
 
           <DescriptionListItemTitle>{translate('Wiki')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://discord.gg/nqFGsGUug2">{translate('Wiki')}</Link>
+            <Link to="https://wiki.chaptarr.com">{translate('Wiki')}</Link>
           </DescriptionListItemDescription>
 
-          <DescriptionListItemTitle>{translate('Reddit')}</DescriptionListItemTitle>
+          {/* <DescriptionListItemTitle>{translate('Reddit')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>
             <Link to="https://discord.gg/nqFGsGUug2">{'Chaptarr'}</Link>
-          </DescriptionListItemDescription>
+          </DescriptionListItemDescription> */}
 
           <DescriptionListItemTitle>{translate('Discord')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>
@@ -37,12 +37,12 @@ class MoreInfo extends Component {
 
           <DescriptionListItemTitle>{translate('Source')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/robertlordhood/Chaptarr">{'github.com/robertlordhood/Chaptarr'}</Link>
+            <Link to="https://github.com/Chaptarr/chaptarr">{'github.com/Chaptarr/chaptarr'}</Link>
           </DescriptionListItemDescription>
 
           <DescriptionListItemTitle>{translate('FeatureRequests')}</DescriptionListItemTitle>
           <DescriptionListItemDescription>
-            <Link to="https://github.com/robertlordhood/Chaptarr/issues">{'github.com/robertlordhood/Chaptarr/issues'}</Link>
+            <Link to="https://github.com/Chaptarr/chaptarr/issues">{'github.com/Chaptarr/chaptarr/issues'}</Link>
           </DescriptionListItemDescription>
 
         </DescriptionList>


### PR DESCRIPTION
#### Description
Update the `MoreInfo` status card links to point to the correct Chaptarr wiki and GitHub repository URLs. This change fixes stale/outdated links that still referenced the Discord invite for the wiki and the old `robertlordhood/Chaptarr` GitHub path. 

The Reddit entry has also been commented until the subreddit is created.

Fixes # (if applicable):
N/A

#### Database Migration
NO

#### How was this tested?
Since it is a small and isolated URL change and I don't yet have a build setup I did not tested this.

#### Screenshots (UI changes only)
N/A