### PR TITLE
Recall Postgres book candidates per table so the GIN indexes are used

### DIFF
--- a/src/NzbDrone.Core/Books/Repositories/EditionFtsRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/EditionFtsRepository.cs
@@ -755,7 +755,24 @@ namespace NzbDrone.Core.Books
                 parameters.Add("authorId", authorId.Value);
             }
 
+            // Postgres can only combine OR'd index predicates with a BitmapOr when they sit on the
+            // same relation, so recalling the candidate ids per table keeps the GIN indexes from
+            // migration 013 usable. Scoring still runs over the joined row, so results are unchanged.
             var sql = $@"
+                WITH candidates AS (
+                    SELECT e.""BookId"" AS ""Id""
+                    FROM ""Editions"" e
+                    WHERE to_tsvector('simple', COALESCE(e.""MatchingTitle"", '')) @@ to_tsquery('simple', @tsQuery)
+                    UNION
+                    SELECT b.""Id""
+                    FROM ""Books"" b
+                    WHERE to_tsvector('simple', COALESCE(b.""SeriesName"", '')) @@ to_tsquery('simple', @tsQuery)
+                    UNION
+                    SELECT b.""Id""
+                    FROM ""Books"" b
+                    INNER JOIN ""Authors"" a ON a.""Id"" = b.""AuthorId""
+                    WHERE to_tsvector('simple', COALESCE(a.""Name"", '') || ' ' || COALESCE(a.""CleanName"", '') || ' ' || COALESCE(a.""TitleSlug"", '')) @@ to_tsquery('simple', @tsQuery)
+                )
                 SELECT
                     b.""Id"" AS BookId,
                     b.""AuthorId"" AS AuthorId,
@@ -772,11 +789,7 @@ namespace NzbDrone.Core.Books
                 INNER JOIN ""Books"" b ON b.""Id"" = e.""BookId""
                 INNER JOIN ""Authors"" a ON a.""Id"" = b.""AuthorId""
                 WHERE b.""MediaType"" = @mediaType
-                  AND (
-                    to_tsvector('simple', COALESCE(e.""MatchingTitle"", '')) @@ to_tsquery('simple', @tsQuery)
-                    OR to_tsvector('simple', COALESCE(b.""SeriesName"", '')) @@ to_tsquery('simple', @tsQuery)
-                    OR to_tsvector('simple', COALESCE(a.""Name"", '') || ' ' || COALESCE(a.""CleanName"", '') || ' ' || COALESCE(a.""TitleSlug"", '')) @@ to_tsquery('simple', @tsQuery)
-                  )
+                  AND b.""Id"" IN (SELECT ""Id"" FROM candidates)
                   {(authorId.HasValue ? "AND b.\"AuthorId\" = @authorId" : string.Empty)}
                 GROUP BY b.""Id"", b.""AuthorId"", a.""Name"", b.""Title"", b.""SeriesName"", b.""SeriesPosition""
                 ORDER BY MatchScore DESC


### PR DESCRIPTION
#### Description

The stage 1 book recall query in `RecallBooksPostgres` ORs three tsvector predicates that live on three different tables (`Editions.MatchingTitle`, `Books.SeriesName`, and the `Authors` name expression). Postgres can only combine OR'd index predicates with a `BitmapOr` when they are on the same relation, so the planner falls back to a full sequential scan of `Editions` with the OR applied as a join filter. None of the GIN indexes that `013_fix_postgres_matching_fts_indexes.cs` creates for exactly those three expressions can be used, and the query runs on every match attempt.

This recalls the candidate book ids from three single table subqueries combined with `UNION`, then scores those candidates with the existing join and `GROUP BY`. Each branch gets its own bitmap index scan.

Scores come out unchanged. The extra editions the candidate form pulls into the aggregate contribute a `ts_rank` of 0 for the title term, and the series and author terms are constant per book, so the `MAX` is the same. I checked that empirically rather than trusting the reasoning, see below.

#### Database Migration

NO. The indexes this relies on already exist from migration 013.

#### How was this tested?

Docker on Windows 11 with WSL2, Chaptarr 0.9.911.0, Postgres 18. The instance was still importing while I measured, so the figures below are from a database holding 842,809 rows in `Editions` and 199,514 in `Books` at the time of the run, in a 1018 MB `Editions` table.

I ran the old and new queries side by side on that database, in the production shape (`ORDER BY MatchScore DESC LIMIT 20`, which is the `limit: 20` that `FileMatchingService` passes):

```
term       before      after    speedup
raven      1845 ms     21 ms      87.2x
christie   1870 ms    112 ms      16.7x
doyle      2422 ms    138 ms      17.6x
sherlock   2077 ms    112 ms      18.6x
poe        2434 ms    120 ms      20.2x
king       2226 ms    135 ms      16.5x
```

On equivalence, with the `LIMIT` removed so the whole result set is comparable, the book id and `MatchScore` pairs are identical for all six terms, and identical again with the `authorId` filter applied (`sherlock` 1165 rows, `doyle` 2123 rows, `raven` 0 rows). The author-name terms matter here because an author match widens recall to that author's whole catalogue, so they exercise the case where the union brings back the most rows.

Under the real `LIMIT 20` the score at every rank is also identical for all six terms, but for `poe` and `king` the two forms pick different books for some of the tied slots. Every book recalled only through the author branch scores `0 + 0 + ts_rank(author expression)`, so a popular author produces a large block of exactly equal scores, and neither the old nor the new query has a tiebreaker after `MatchScore`. Which equal-scored rows survive the `LIMIT` is therefore plan dependent in both forms rather than something this change breaks. I left it that way to keep the diff to the performance problem, but adding `, b."Id"` to the `ORDER BY` would make it deterministic and I am happy to include that here or in a separate PR if you want it.

`EXPLAIN` before is a `Parallel Seq Scan` on `Editions` with `Rows Removed by Join Filter: 154120` per worker to return 97 rows. After, each branch is a `Bitmap Index Scan` on the matching GIN index.

Timings vary with concurrent load on my instance, and my `shared_buffers` is the 128 MB default against that `Editions` table, so the absolute numbers are worse than a tuned instance would show. The plan shape is the part that does not depend on my tuning.

`dotnet build src/Chaptarr.NoTests.sln --configuration Release` succeeds with 0 warnings, and `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj --configuration Release` passes 2,739 of 2,739.

#### Screenshots (UI changes only)

N/A.

One thing I left alone deliberately. `PostgresTsvectorBackend.cs` has a per field subquery shape that would also solve this, but it guards on `information_schema` reporting tsvector columns on `Authors` and `Editions`, and no migration in the tree adds such a column, so as far as I can tell that path never activates. If that backend is where you want this to end up, say so and I will close this in favour of a migration that adds the columns instead.
