### PR TITLE
Fix: single-author Rescan Folders silently scans the entire library

### DIFF
--- a/src/NzbDrone.Core/Books/Services/RefreshAuthorService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshAuthorService.cs
@@ -2146,26 +2146,65 @@ namespace NzbDrone.Core.Books
                 // (but don't add new authors to reduce repeated searches against api)
                 var requestedMediaType = (mediaType ?? "all").Trim().ToLowerInvariant();
 
-                var rootFolders = _rootFolderService.All();
-                if (requestedMediaType == "audiobook")
-                {
-                    rootFolders = rootFolders.Where(r => r.FolderType == FolderType.Audiobook || r.FolderType == FolderType.Mixed).ToList();
-                }
-                else if (requestedMediaType == "ebook")
-                {
-                    rootFolders = rootFolders.Where(r => r.FolderType == FolderType.Ebook || r.FolderType == FolderType.Mixed).ToList();
-                }
+                // Scope the walk to just the affected authors' own folders. RescanFoldersCommand's
+                // authorIds is only used post-scan to fire "scan completed" notifications - it does
+                // not narrow which folders get walked, so without this every single-author rescan
+                // (e.g. clicking "Rescan Folders" on one author) was silently walking every root
+                // folder in the library, one folder at a time via a blocking Task.Wait, which could
+                // take hours against thousands of author folders and held the shared disk-access
+                // lock the whole time, stalling every other queued command.
+                var folders = GetAuthorScopedRescanFolders(authorIds, requestedMediaType);
 
-                var folders = rootFolders.Select(x => x.Path).ToList();
+                if (folders.Count == 0)
+                {
+                    var rootFolders = _rootFolderService.All();
+                    if (requestedMediaType == "audiobook")
+                    {
+                        rootFolders = rootFolders.Where(r => r.FolderType == FolderType.Audiobook || r.FolderType == FolderType.Mixed).ToList();
+                    }
+                    else if (requestedMediaType == "ebook")
+                    {
+                        rootFolders = rootFolders.Where(r => r.FolderType == FolderType.Ebook || r.FolderType == FolderType.Mixed).ToList();
+                    }
+
+                    folders = rootFolders.Select(x => x.Path).ToList();
+                }
 
                 var command = new RescanFoldersCommand(folders, FilterFilesType.Matched, authorIds)
                 {
                     MediaType = requestedMediaType
                 };
 
-                _logger.Debug("[FLOW-DEBUG] RESCAN-QUEUE: Queueing folder rescan for {0} root folder(s), {1} author(s), mediaType={2}.", folders.Count, authorIds.Count, requestedMediaType);
+                _logger.Debug("[FLOW-DEBUG] RESCAN-QUEUE: Queueing folder rescan for {0} folder(s), {1} author(s), mediaType={2}.", folders.Count, authorIds.Count, requestedMediaType);
                 _commandQueueManager.Push(command);
             }
+        }
+
+        private List<string> GetAuthorScopedRescanFolders(List<int> authorIds, string requestedMediaType)
+        {
+            if (authorIds == null || authorIds.Count == 0)
+            {
+                // No specific authors (e.g. a library-wide refresh) - caller falls back to a full root-folder scan.
+                return new List<string>();
+            }
+
+            var authors = _authorService.GetAuthors(authorIds);
+            var authorFolders = new List<string>();
+
+            foreach (var author in authors)
+            {
+                if (requestedMediaType != "ebook" && !string.IsNullOrWhiteSpace(author.AudiobookPath))
+                {
+                    authorFolders.Add(author.AudiobookPath);
+                }
+
+                if (requestedMediaType != "audiobook" && !string.IsNullOrWhiteSpace(author.EbookPath))
+                {
+                    authorFolders.Add(author.EbookPath);
+                }
+            }
+
+            return authorFolders.Distinct().ToList();
         }
 
         private bool ProcessBulkSync(List<int> authorIds, bool forceRefresh, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary

Clicking "Rescan Folders" for a single author (or triggering a `RefreshAuthor` command with `rescanFolders: true` for one `authorId`) does **not** actually scope the scan to that author. It walks every root folder in the library instead, and only *labels* itself with the author's name in the UI.

## Root cause

In `RefreshAuthorService.Rescan()`:

```csharp
var rootFolders = _rootFolderService.All();
// ...filtered by mediaType only, never by author...
var folders = rootFolders.Select(x => x.Path).ToList();

var command = new RescanFoldersCommand(folders, FilterFilesType.Matched, authorIds)
```

`folders` is built from **every** root folder regardless of `authorIds`. Downstream, `DiskScanService.Execute(RescanFoldersCommand)` → `Scan(folders, filter, authorIds, ...)` only uses `authorIds` for one thing: firing the "scan completed" notification event at the very end. It plays no role in deciding what actually gets walked (`DiskScanService.cs`, `Scan()`, ~line 97-236).

## Impact

On a library with several thousand author folders (mine has ~9,200), a "single-author" rescan silently becomes a full synchronous library walk — each folder processed via a blocking `orchestratorTask.Wait(cancellationToken)` inside the scan loop. Because `RescanFoldersCommand.RequiresDiskAccess = true` and disk-access commands appear to serialize on a shared lock/queue, this also stalls every other queued command (imports, other refreshes) for the entire duration — observed taking well over an hour and, from a user's perspective, indistinguishable from a hang.

This reproduced consistently across different authors on our instance, and matches the "adding an author takes 5 minutes" / "everything stalls behind Rescan Folders" reports we'd been chasing.

## Fix

When `authorIds` is non-empty, scope `folders` to the affected authors' own `AudiobookPath`/`EbookPath` instead of every root folder. Falls back to the existing full root-folder scan only when no authors are specified (e.g. a library-wide refresh) or none have a resolvable path yet.

```csharp
var folders = GetAuthorScopedRescanFolders(authorIds, requestedMediaType);

if (folders.Count == 0)
{
    // existing full root-folder fallback
}
```

## Testing

Verified live against a ~9,200-author library (Docker build from this branch):

- Before: `RescanFolders` command body showed `folders` = full root folder list; the corresponding command sat in `started` for well over an hour before being manually cancelled, blocking everything queued behind it.
- After: triggering `RefreshAuthor` (`authorId`, `rescanFolders: true`) for a single author now produces a `RescanFolders` command with `folders: ["/audiobooks/<AuthorName>"]`, and it completes in under 2 minutes.

Happy to add a fixture to `DiskScanServiceFixture.cs` / a service test for `RefreshAuthorService` covering this if useful — wanted to get eyes on the root cause and approach first.