### PR TITLE
Fix: GET /api/v1/bookFile?unmapped=true crashes on every call (duplicated SELECT columns)

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -167,7 +167,12 @@ namespace NzbDrone.Core.MediaFiles
 
         private SqlBuilder BuildUnmappedFilesBuilder(string mediaType)
         {
-            var builder = new SqlBuilder(_database.DatabaseType).Select(typeof(BookFile))
+            // Do not call .Select(typeof(BookFile)) here - SqlMapperExtensions.Query<T>(builder)
+            // already adds the SELECT clause for T, so pre-selecting it here duplicated every
+            // column in the projection (SELECT "BookFiles".*, "BookFiles".*), which made Dapper's
+            // generated row deserializer read misaligned columns and throw (surfacing as a
+            // System.Data.DataException / OutOfMemoryException on GET /api/v1/bookFile?unmapped=true).
+            var builder = new SqlBuilder(_database.DatabaseType)
                 .Where<BookFile>(t => t.EditionId == 0);
 
             if (!string.IsNullOrWhiteSpace(mediaType))


### PR DESCRIPTION
## Summary

`GET /api/v1/bookFile?unmapped=true` (the Unmapped Files endpoint, backing `RetryUnmappedMatchCommand`/`RefreshUnmappedFilesCommand` and the Unmapped Files UI) throws an unhandled exception on **every** call against a non-trivial library. Observed 100% reproducible on a ~9,200-author library.

## Root cause

`MediaFileRepository.BuildUnmappedFilesBuilder()`:

```csharp
private SqlBuilder BuildUnmappedFilesBuilder(string mediaType)
{
    var builder = new SqlBuilder(_database.DatabaseType).Select(typeof(BookFile))
        .Where<BookFile>(t => t.EditionId == 0);
    ...
```

calls `.Select(typeof(BookFile))` itself. But the caller, `GetUnmappedFiles(string mediaType)`, passes this builder into:

```csharp
public static IEnumerable<T> Query<T>(this IDatabase db, SqlBuilder builder)
{
    var type = typeof(T);
    var sql = builder.Select(type).AddSelectTemplate(type);   // <- adds its own SELECT
    return db.Query<T>(sql.RawSql, sql.Parameters);
}
```

(`SqlMapperExtensions.cs`), which **also** calls `.Select(type)`. Every other caller in the codebase (e.g. `MediaFileRepository.Builder()`, used by every other query in this file) relies solely on this generic helper to add the SELECT clause - `BuildUnmappedFilesBuilder` is the only place that pre-selects before handing the builder off.

The result is a query that selects every `BookFile` column twice:

```sql
SELECT "BookFiles".* , "BookFiles".*
 FROM "BookFiles"    WHERE ("BookFiles"."EditionId" = @Clause2_P1)
```

Dapper's generated row deserializer expects one occurrence of each column per row and gets the duplicated set instead, so it reads values out of alignment. On our data this consistently manifested as:

```
[v0.9.925.0] System.Data.DataException: Error parsing column 51 (AllTags=[] - String)
 ---> System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
   at Microsoft.Data.Sqlite.SqliteValueReader.GetValue(Int32 ordinal)
```

i.e. the misaligned read lands on a length/offset value that gets misinterpreted as a huge allocation request. The specific column/exception type will vary by data, but the trigger - duplicated SELECT columns - is deterministic.

## Impact

- `GET /api/v1/bookFile?unmapped=true` (and by extension any UI/feature backed by it) is completely broken - every call throws.
- If the frontend polls this for a badge/count (Unmapped Files indicator), that's a genuine `OutOfMemoryException` thrown repeatedly on a shared ASP.NET Core process. We observed a period of severe unresponsiveness (thread-pool-starvation-like symptoms: near-zero CPU, all requests hanging) while this endpoint was being hit repeatedly under load, though we can't rule out contributing factors from concurrent import activity in our case - flagging it here because a real, repeated server-side `OutOfMemoryException` is a plausible contributor to that kind of instability regardless.

## Fix

Remove the redundant `.Select(typeof(BookFile))` call from `BuildUnmappedFilesBuilder()`, matching the pattern used everywhere else in the file.

## Testing

Verified live against our ~9,200-author library (Docker build from this branch):
- Before: `GET /api/v1/bookFile?unmapped=true` → 500, `System.Data.DataException` / `OutOfMemoryException`, every single call, no exceptions.
- After: `GET /api/v1/bookFile?unmapped=true` → 200, returns the real unmapped-file list (343,805 records in our case) with no errors.