### PR TITLE
Fix: toolbar button labels with a dynamic count render unreadable

### DIFF
--- a/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
+++ b/frontend/src/Components/Page/Toolbar/PageToolbarButton.css
@@ -2,7 +2,14 @@
   composes: link from '~Components/Link/Link.css';
 
   padding-top: 4px;
-  width: $toolbarButtonWidth;
+  /*
+   * min-width rather than a fixed width: short labels still line up on the
+   * $toolbarButtonWidth grid, but labels that carry a dynamic count (e.g.
+   * "Refresh Files (12 books)" on the Unmapped Files page) would otherwise wrap
+   * onto several overlapping lines inside the fixed 60px box and become unreadable.
+   */
+  min-width: $toolbarButtonWidth;
+  max-width: 130px;
   text-align: center;
 
   &:hover {
@@ -22,7 +29,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 24px;
+  min-height: 24px;
 }
 
 .label {
@@ -30,4 +37,5 @@
   color: var(--toolbarLabelColor);
   font-size: $extraSmallFontSize;
   line-height: calc($extraSmallFontSize + 1px);
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
## Problem

On the Unmapped Files page, the **Refresh Files** and **Retry Match** toolbar buttons append a live count to their labels (e.g. `Refresh Files (12 books)`). `$toolbarButtonWidth` is a fixed `60px`, so those longer labels wrap onto several overlapping lines inside the fixed-width box and become unreadable.

No interaction is needed to reproduce — ticking rows changes the count, and the label overflows immediately.

Most toolbars elsewhere use short static labels ("Refresh", "History", "Search"), which is why the fixed 60px has been fine until now; the dynamic count is what pushes past it.

## Fix

`frontend/src/Components/Page/Toolbar/PageToolbarButton.css`:

- `width` → `min-width`, so short labels keep the existing grid alignment while longer ones can grow. Capped with `max-width: 130px` so a very large count can't stretch the toolbar arbitrarily.
- `overflow-wrap: break-word` on the label, so wrapping happens on sensible boundaries rather than overflowing the box.
- `.labelContainer` `height: 24px` → `min-height: 24px`, so a label that legitimately needs two lines isn't clipped.

Purely presentational — no component or behaviour changes.

## Testing

Built from this branch and deployed to a live instance with a large unmapped backlog (~342k unmapped files / ~44k book groups, so the counts in these labels get long). Labels render readably at both short and long counts, and other toolbars (Library, Activity, Settings) are visually unchanged since their labels fall under the previous fixed width.

I don't have a reference screenshot of the "before" state at a range of viewport widths, so if there's a narrow-viewport case where the `130px` cap is too generous I'm happy to adjust it.