### PR TITLE
Fix: File delete method to use proper root path

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/MediaFileDeletionServiceFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/MediaFileDeletionServiceFixture.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using NLog;
 using NUnit.Framework;
@@ -13,6 +14,7 @@ using NzbDrone.Core.Books;
 using NzbDrone.Core.Books.Calibre;
 using NzbDrone.Core.Books.Events;
 using NzbDrone.Core.Configuration;
+using NzbDrone.Core.Exceptions;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.MediaFiles.Events;
 using NzbDrone.Core.Messaging.Events;
@@ -27,6 +29,7 @@ namespace Chaptarr.Core.Test.MediaFiles
         {
             public List<string> DeletedFolders { get; } = new();
             public List<string> DeletedFiles { get; } = new();
+            public List<string> DeletedFileSubfolders { get; } = new();
 
             public void DeleteFolder(string path)
             {
@@ -36,6 +39,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             public void DeleteFile(string path, string subfolder = "")
             {
                 DeletedFiles.Add(path);
+                DeletedFileSubfolders.Add(subfolder);
             }
             public void Empty() => throw new NotImplementedException();
             public void Cleanup() => throw new NotImplementedException();
@@ -204,6 +208,86 @@ namespace Chaptarr.Core.Test.MediaFiles
 
                 throw new NotImplementedException($"Test proxy does not implement IConfigService.{targetMethod?.Name}");
             }
+        }
+
+        /// <summary>
+        /// Drives <see cref="MediaFileDeletionService.DeleteTrackFile(Author, BookFile)"/>. Routing is decided
+        /// by which configured root actually contains the file, so the interesting knobs are the configured
+        /// roots, which folders exist, and which roots have any children.
+        /// </summary>
+        private class TrackFileDeleteDiskProviderProxy : DispatchProxy
+        {
+            public HashSet<string> ExistingFolders { get; } = new(PathEqualityComparer.Instance);
+            public HashSet<string> ExistingFiles { get; } = new(PathEqualityComparer.Instance);
+            public HashSet<string> FoldersWithSubfolders { get; } = new(PathEqualityComparer.Instance);
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                switch (targetMethod?.Name)
+                {
+                    case nameof(IDiskProvider.FolderExists):
+                        return ExistingFolders.Contains((string)args[0]);
+
+                    case nameof(IDiskProvider.GetDirectories):
+                        return FoldersWithSubfolders.Contains((string)args[0])
+                            ? new[] { Path.Combine(((string)args[0]).TrimEnd(Path.DirectorySeparatorChar), "Some Author") }
+                            : Array.Empty<string>();
+
+                    case nameof(IDiskProvider.GetParentFolder):
+                        return Path.GetDirectoryName(((string)args[0]).TrimEnd(Path.DirectorySeparatorChar));
+
+                    case nameof(IDiskProvider.FileExists):
+                    case nameof(IDiskProvider.FileExistsCanonical):
+                        return ExistingFiles.Contains((string)args[0]);
+                }
+
+                throw new NotImplementedException($"Test proxy does not implement IDiskProvider.{targetMethod?.Name}");
+            }
+        }
+
+        private sealed class TrackFileDeleteSubject
+        {
+            public MediaFileDeletionService Service { get; init; }
+            public TrackFileDeleteDiskProviderProxy Disk { get; init; }
+            public RecordingRecycleBinProvider RecycleBin { get; init; }
+            public RecordingMediaFileServiceProxy MediaFiles { get; init; }
+            public RecordingEventAggregator Events { get; init; }
+        }
+
+        private static TrackFileDeleteSubject BuildTrackFileDeleteSubject(params RootFolder[] rootFolders)
+        {
+            var diskProvider = DispatchProxy.Create<IDiskProvider, TrackFileDeleteDiskProviderProxy>();
+            var diskProxy = (TrackFileDeleteDiskProviderProxy)(object)diskProvider;
+            var mediaFileService = DispatchProxy.Create<IMediaFileService, RecordingMediaFileServiceProxy>();
+            var recycleBinProvider = new RecordingRecycleBinProvider();
+            var eventAggregator = new RecordingEventAggregator();
+
+            // Every configured root exists and has children unless a test says otherwise.
+            foreach (var root in rootFolders)
+            {
+                diskProxy.ExistingFolders.Add(root.Path);
+                diskProxy.FoldersWithSubfolders.Add(root.Path);
+            }
+
+            var service = new MediaFileDeletionService(
+                diskProvider,
+                recycleBinProvider,
+                mediaFileService,
+                DispatchProxy.Create<IAuthorService, ThrowingProxy<IAuthorService>>(),
+                DispatchProxy.Create<IConfigService, ThrowingProxy<IConfigService>>(),
+                eventAggregator,
+                new StubRootFolderService(rootFolders),
+                DispatchProxy.Create<ICalibreProxy, ThrowingProxy<ICalibreProxy>>(),
+                LogManager.GetCurrentClassLogger());
+
+            return new TrackFileDeleteSubject
+            {
+                Service = service,
+                Disk = diskProxy,
+                RecycleBin = recycleBinProvider,
+                MediaFiles = (RecordingMediaFileServiceProxy)(object)mediaFileService,
+                Events = eventAggregator
+            };
         }
 
         private static (MediaFileDeletionService Service, FolderCleanupDiskProviderProxy Disk) BuildFolderCleanupSubject(params string[] authorRoots)
@@ -549,6 +633,311 @@ namespace Chaptarr.Core.Test.MediaFiles
                 Assert.That(mediaProxy.Deleted, Is.EqualTo(new[] { bookFile }));
                 Assert.That(recycleBinProvider.DeletedFiles, Is.Empty);
                 Assert.That(eventAggregator.Events.OfType<DeleteCompletedEvent>(), Has.Exactly(1).Items);
+            });
+        }
+
+        [Test]
+        public void should_route_the_delete_through_the_root_that_actually_contains_the_file()
+        {
+            // Issue #32: the author's stored path is under the audiobook root, the file is under the
+            // ebook root. Routing by author path threw NotParentException and nothing was deleted.
+            var audiobookRoot = new RootFolder { Id = 1, Path = @"C:\spicyaudiobooks".AsOsAgnostic() };
+            var ebookRoot = new RootFolder { Id = 2, Path = @"C:\spicybooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(audiobookRoot, ebookRoot);
+
+            var author = new Author
+            {
+                Id = 1,
+                Name = "Navessa Allen",
+                Path = @"C:\spicyaudiobooks\Navessa Allen".AsOsAgnostic(),
+                AudiobookRootFolderPath = audiobookRoot.Path,
+                EbookRootFolderPath = ebookRoot.Path
+            };
+
+            var filePath = @"C:\spicybooks\Navessa Allen\Ladies of Infamy\Scandal (2014)\scandal.epub".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "ebook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.EqualTo(new[] { filePath }));
+
+                // The recycle subfolder is relative to the root, so the root's own name is not in it.
+                Assert.That(subject.RecycleBin.DeletedFileSubfolders,
+                    Is.EqualTo(new[] { @"Navessa Allen\Ladies of Infamy\Scandal (2014)".AsOsAgnostic() }));
+                Assert.That(subject.RecycleBin.DeletedFileSubfolders.Single(), Does.Not.Contain("spicybooks"));
+
+                Assert.That(subject.MediaFiles.Deleted, Is.EqualTo(new[] { bookFile }));
+                Assert.That(subject.Events.Events.OfType<DeleteCompletedEvent>(), Has.Exactly(1).Items);
+            });
+        }
+
+        [Test]
+        public void should_calculate_the_recycle_subfolder_from_a_root_stored_with_a_trailing_separator()
+        {
+            // Root folder paths are stored verbatim and can carry a trailing separator.
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks\audiobooks\".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author
+            {
+                Id = 1,
+                Name = "Matt Dinniman",
+                Path = @"C:\audiobooks\audiobooks\Matt Dinniman".AsOsAgnostic(),
+                AudiobookRootFolderPath = root.Path
+            };
+
+            var filePath = @"C:\audiobooks\audiobooks\Matt Dinniman\Dungeon Crawler Carl\dcc.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.That(subject.RecycleBin.DeletedFileSubfolders,
+                Is.EqualTo(new[] { @"Matt Dinniman\Dungeon Crawler Carl".AsOsAgnostic() }));
+        }
+
+        [Test]
+        public void should_not_treat_a_name_prefixed_folder_as_the_containing_root()
+        {
+            // "/audiobooks" must not claim a file living in "/audiobooksXYZ".
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author { Id = 1, Name = "Blake Crouch", Path = @"C:\audiobooks\Blake Crouch".AsOsAgnostic() };
+            var filePath = @"C:\audiobooksXYZ\Blake Crouch\Recursion\recursion.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            var exception = Assert.Throws<NzbDroneClientException>(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_refuse_and_keep_the_row_when_no_configured_root_contains_the_file()
+        {
+            // Without a containing root we cannot tell a removed root-folder setting from an
+            // unavailable mount, and cannot choose between Calibre and recycle-bin handling.
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author { Id = 1, Name = "Gillian Flynn", Path = @"C:\audiobooks\Gillian Flynn".AsOsAgnostic() };
+            var filePath = @"C:\elsewhere\Gillian Flynn\Gone Girl\gone-girl.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            var exception = Assert.Throws<NzbDroneClientException>(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+                Assert.That(exception.Message, Is.EqualTo($"Book file ({filePath}) is not inside any configured root folder."));
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.Empty);
+                Assert.That(subject.Events.Events.OfType<DeleteCompletedEvent>(), Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_refuse_an_unmapped_file_outside_every_configured_root_rather_than_guess_calibre()
+        {
+            // The unmapped overload skips the routing method entirely, so the same refusal has to live
+            // in the deletion core. Falling through would silently pick non-Calibre recycle handling.
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var filePath = @"C:\somewhere-else\loose\stray.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            var exception = Assert.Throws<NzbDroneClientException>(() => subject.Service.DeleteTrackFile(bookFile, "Unmapped_Files"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+                Assert.That(exception.Message, Is.EqualTo($"Book file ({filePath}) is not inside any configured root folder."));
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_use_an_empty_recycle_subfolder_for_a_file_sitting_directly_in_the_root()
+        {
+            // The file's parent IS the root. GetRelativePath treats equal paths as unrelated, so without
+            // the PathEquals guard this throws NotParentException and surfaces as a 500.
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author { Id = 1, Name = "Caro Burke", Path = @"C:\audiobooks\Caro Burke".AsOsAgnostic() };
+            var filePath = @"C:\audiobooks\loose.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.EqualTo(new[] { filePath }));
+                Assert.That(subject.RecycleBin.DeletedFileSubfolders, Is.EqualTo(new[] { string.Empty }));
+                Assert.That(subject.MediaFiles.Deleted, Is.EqualTo(new[] { bookFile }));
+            });
+        }
+
+        [Test]
+        public void should_refuse_when_the_containing_root_is_missing_from_disk()
+        {
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            // The mount is gone: the root is still configured but no longer on disk.
+            subject.Disk.ExistingFolders.Clear();
+
+            var author = new Author { Id = 1, Name = "Grady Hendrix", Path = @"C:\audiobooks\Grady Hendrix".AsOsAgnostic() };
+            var filePath = @"C:\audiobooks\Grady Hendrix\Horrorstor\horrorstor.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            var exception = Assert.Throws<NzbDroneClientException>(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+                Assert.That(exception.Message, Is.EqualTo($"Root folder ({root.Path}) doesn't exist."));
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_refuse_when_the_containing_root_is_empty()
+        {
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            // Root exists but has no children — the classic remounted-empty-share shape.
+            subject.Disk.FoldersWithSubfolders.Clear();
+
+            var author = new Author { Id = 1, Name = "Jessica Park", Path = @"C:\audiobooks\Jessica Park".AsOsAgnostic() };
+            var filePath = @"C:\audiobooks\Jessica Park\Flat-Out Love\flat-out-love.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            var exception = Assert.Throws<NzbDroneClientException>(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.StatusCode, Is.EqualTo(HttpStatusCode.Conflict));
+                Assert.That(exception.Message, Is.EqualTo($"Root folder ({root.Path}) is empty."));
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_remove_the_stale_row_when_the_tracked_file_is_gone_under_a_healthy_root()
+        {
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author { Id = 1, Name = "Fiona Cole", Path = @"C:\audiobooks\Fiona Cole".AsOsAgnostic() };
+            var filePath = @"C:\audiobooks\Fiona Cole\Enamor\enamor.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            // File is not on disk; the row still needs to go.
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.Empty);
+                Assert.That(subject.MediaFiles.Deleted, Is.EqualTo(new[] { bookFile }));
+                Assert.That(subject.Events.Events.OfType<DeleteCompletedEvent>(), Has.Exactly(1).Items);
+            });
+        }
+
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("audiobook")]
+        [TestCase("EBOOK")]
+        public void should_follow_the_physical_path_regardless_of_the_stored_media_type(string mediaType)
+        {
+            // Media type is not evidence of containment: it can be blank, stale, differently cased, or
+            // simply wrong for where the file actually sits.
+            var audiobookRoot = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var ebookRoot = new RootFolder { Id = 2, Path = @"C:\ebooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(audiobookRoot, ebookRoot);
+
+            var author = new Author
+            {
+                Id = 1,
+                Name = "Jim Butcher",
+                Path = @"C:\audiobooks\Jim Butcher".AsOsAgnostic(),
+                AudiobookRootFolderPath = audiobookRoot.Path,
+                EbookRootFolderPath = ebookRoot.Path
+            };
+
+            var filePath = @"C:\ebooks\Jim Butcher\Captains Fury\captains-fury.epub".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = mediaType, Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.EqualTo(new[] { filePath }));
+                Assert.That(subject.RecycleBin.DeletedFileSubfolders,
+                    Is.EqualTo(new[] { @"Jim Butcher\Captains Fury".AsOsAgnostic() }));
+                Assert.That(subject.MediaFiles.Deleted, Is.EqualTo(new[] { bookFile }));
+            });
+        }
+
+        [Test]
+        public void should_delete_and_publish_completion_when_the_author_folder_is_missing()
+        {
+            // The author folder is gone but the file is still on disk under a healthy root. The old
+            // author-folder branch skipped the disk delete entirely and never published completion.
+            var root = new RootFolder { Id = 1, Path = @"C:\audiobooks".AsOsAgnostic() };
+            var subject = BuildTrackFileDeleteSubject(root);
+
+            var author = new Author
+            {
+                Id = 1,
+                Name = "Annie Anderson",
+                Path = @"C:\audiobooks\Annie Anderson".AsOsAgnostic(),
+                AudiobookRootFolderPath = root.Path
+            };
+
+            var filePath = @"C:\audiobooks\Loose Files\stray.m4b".AsOsAgnostic();
+            var bookFile = new BookFile { Id = 1, EditionId = 1, MediaType = "audiobook", Path = filePath };
+
+            subject.Disk.ExistingFiles.Add(filePath);
+
+            Assert.DoesNotThrow(() => subject.Service.DeleteTrackFile(author, bookFile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(subject.RecycleBin.DeletedFiles, Is.EqualTo(new[] { filePath }));
+                Assert.That(subject.RecycleBin.DeletedFileSubfolders, Is.EqualTo(new[] { "Loose Files" }));
+                Assert.That(subject.MediaFiles.Deleted, Is.EqualTo(new[] { bookFile }));
+                Assert.That(subject.Events.Events.OfType<DeleteCompletedEvent>(), Has.Exactly(1).Items);
             });
         }
     }

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -66,9 +66,12 @@ namespace NzbDrone.Core.MediaFiles
         {
             var fullPath = bookFile.Path;
 
-            var authorPath = IsNull(bookFile.MediaType) ? author.Path
-                : bookFile.MediaType == "ebook" ? author.EbookRootFolderPath
-                : author.AudiobookRootFolderPath;
+            var authorPath = bookFile.MediaType switch
+            {
+                "ebook" => author.EbookRootFolderPath,
+                "audiobook" => author.AudiobookRootFolderPath,
+                _ => author.Path
+            };
 
             var rootFolder = _diskProvider.GetParentFolder(authorPath);
 

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -65,7 +65,12 @@ namespace NzbDrone.Core.MediaFiles
         public void DeleteTrackFile(Author author, BookFile bookFile)
         {
             var fullPath = bookFile.Path;
-            var rootFolder = _diskProvider.GetParentFolder(author.Path);
+
+            var authorPath = IsNull(bookFile.MediaType) ? author.Path
+                : bookFile.MediaType == "ebook" ? author.EbookRootFolderPath
+                : author.AudiobookRootFolderPath;
+
+            var rootFolder = _diskProvider.GetParentFolder(authorPath);
 
             if (!_diskProvider.FolderExists(rootFolder))
             {
@@ -79,9 +84,9 @@ namespace NzbDrone.Core.MediaFiles
                 throw new NzbDroneClientException(HttpStatusCode.Conflict, "Author's root folder ({0}) is empty.", rootFolder);
             }
 
-            if (_diskProvider.FolderExists(author.Path))
+            if (_diskProvider.FolderExists(authorPath))
             {
-                var subfolder = _diskProvider.GetParentFolder(author.Path).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
+                var subfolder = _diskProvider.GetParentFolder(authorPath).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
                 DeleteTrackFile(bookFile, subfolder);
             }
             else

--- a/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileDeletionService.cs
@@ -66,47 +66,54 @@ namespace NzbDrone.Core.MediaFiles
         {
             var fullPath = bookFile.Path;
 
-            var authorPath = bookFile.MediaType switch
-            {
-                "ebook" => author.EbookRootFolderPath,
-                "audiobook" => author.AudiobookRootFolderPath,
-                _ => author.Path
-            };
+            // The file's own path is the only reliable authority for which configured root holds it.
+            // Chaptarr has per-media-type roots, so the author's stored path is only ever one of them,
+            // and Organize rewrites a file's path after that author path was recorded. Media type does
+            // not prove containment either: a colocated ebook can live under the audiobook root.
+            var rootFolder = _rootFolderService.GetBestRootFolder(fullPath);
 
-            var rootFolder = _diskProvider.GetParentFolder(authorPath);
-
-            if (!_diskProvider.FolderExists(rootFolder))
+            if (rootFolder == null)
             {
-                _logger.Warn("Author's root folder ({0}) doesn't exist.", rootFolder);
-                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Author's root folder ({0}) doesn't exist.", rootFolder);
+                _logger.Warn("Book file ({0}) is not inside any configured root folder.", fullPath);
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Book file ({0}) is not inside any configured root folder.", fullPath);
             }
 
-            if (_diskProvider.GetDirectories(rootFolder).Empty())
+            if (!_diskProvider.FolderExists(rootFolder.Path))
             {
-                _logger.Warn("Author's root folder ({0}) is empty.", rootFolder);
-                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Author's root folder ({0}) is empty.", rootFolder);
+                _logger.Warn("Root folder ({0}) doesn't exist.", rootFolder.Path);
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Root folder ({0}) doesn't exist.", rootFolder.Path);
             }
 
-            if (_diskProvider.FolderExists(authorPath))
+            if (_diskProvider.GetDirectories(rootFolder.Path).Empty())
             {
-                var subfolder = _diskProvider.GetParentFolder(authorPath).GetRelativePath(_diskProvider.GetParentFolder(fullPath));
-                DeleteTrackFile(bookFile, subfolder);
+                _logger.Warn("Root folder ({0}) is empty.", rootFolder.Path);
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Root folder ({0}) is empty.", rootFolder.Path);
             }
-            else
-            {
-                // delete from db even if the author folder is missing
-                _mediaFileService.Delete(bookFile, DeleteMediaFileReason.Manual);
-            }
+
+            var fileFolder = _diskProvider.GetParentFolder(fullPath);
+
+            // A file sitting directly in the root has no subfolder; GetRelativePath treats equal paths
+            // as unrelated and would throw.
+            var subfolder = rootFolder.Path.PathEquals(fileFolder)
+                ? string.Empty
+                : rootFolder.Path.GetRelativePath(fileFolder);
+
+            DeleteTrackFile(bookFile, subfolder, rootFolder);
         }
 
         public void DeleteTrackFile(BookFile bookFile, string subfolder = "")
+        {
+            DeleteTrackFile(bookFile, subfolder, null);
+        }
+
+        private void DeleteTrackFile(BookFile bookFile, string subfolder, RootFolder rootFolder)
         {
             var fullPath = bookFile.Path;
 
             if (_diskProvider.FileExistsCanonical(fullPath))
             {
                 _logger.Info("Deleting book file: {0}", fullPath);
-                DeleteFile(bookFile, subfolder);
+                DeleteFile(bookFile, subfolder, rootFolder);
             }
 
             // Delete the track file from the database to clean it up even if the file was already deleted
@@ -115,9 +122,19 @@ namespace NzbDrone.Core.MediaFiles
             _eventAggregator.PublishEvent(new DeleteCompletedEvent());
         }
 
-        private void DeleteFile(BookFile bookFile, string subfolder = "")
+        private void DeleteFile(BookFile bookFile, string subfolder = "", RootFolder rootFolder = null)
         {
-            var rootFolder = _rootFolderService.GetBestRootFolder(bookFile.Path);
+            rootFolder ??= _rootFolderService.GetBestRootFolder(bookFile.Path);
+
+            // Outside the try on purpose: the catch below turns everything into a 500, and this is a
+            // deliberate refusal. Without a containing root there is no Calibre setting to consult, so
+            // recycling the file would be guessing at the one decision we cannot make safely.
+            if (rootFolder == null)
+            {
+                _logger.Warn("Book file ({0}) is not inside any configured root folder.", bookFile.Path);
+                throw new NzbDroneClientException(HttpStatusCode.Conflict, "Book file ({0}) is not inside any configured root folder.", bookFile.Path);
+            }
+
             var isCalibre = rootFolder.IsCalibreLibrary && rootFolder.CalibreSettings != null;
 
             try


### PR DESCRIPTION
#### Description
This change updates the logic in the `DeleteTrackFile` method to use the appropriate root path, based on the `MediaType` of the `BookItem` passed in. The current logic uses the `Path` property of the `Author` object, which doesn't necessarily match the root path of the `BookItem` you're trying to delete.

Fixes #32 

#### Database Migration
No

#### How was this tested?
I ran Chaptarr locally via docker compose, building the image from the included Dockerfile.build file. Once built and loaded, I attempted to delete a book file again, and this time, it was successful. The file was removed immediately from Chaptarr, and I verified that the file was deleted from the filesystem.

#### Note
It's been a while since I coded, and I'm not sure what other functionality this change might affect. It appears pretty strictly limited to the `DeleteTrackFile` method, which should limit its scope, but I trust the devs have a better overall picture of the codebase.

---

**A note on AI:** We know AI/agentic coding is everywhere and only getting
more popular. We won't insist that you disclose whether you used it or which
models you used, but in the same spirit, please don't take offense if your PR
is scrutinized and changes are requested.

**Review time:** The longer the PR and the more lines changed, the longer the
review will take. Small, focused PRs merge fastest. If yours is big, please be
patient.
