### PR TITLE
Fix Only This Book catalog imports

### DIFF
--- a/src/Chaptarr.Core.Test/Books/AddBookServiceAutoEditionSelectionFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AddBookServiceAutoEditionSelectionFixture.cs
@@ -175,7 +175,7 @@ namespace Chaptarr.Core.Test.Books
 
             public MetadataProfile Add(MetadataProfile profile) => throw new NotImplementedException();
             public void Delete(int id) => throw new NotImplementedException();
-            public List<MetadataProfile> All() => throw new NotImplementedException();
+            public List<MetadataProfile> All() => _profiles.Values.ToList();
             public void Update(MetadataProfile profile) => throw new NotImplementedException();
             public List<Book> FilterBooks(Author input, int profileId) => throw new NotImplementedException();
         }
@@ -284,6 +284,28 @@ namespace Chaptarr.Core.Test.Books
             return (bool)method.Invoke(service, new object[] { book });
         }
 
+        private static int? InvokeResolveMetadataProfileIdForBookAdd(
+            AddBookService service,
+            BookMediaType profileMediaType,
+            BookMediaType requestedMediaType,
+            int? configuredProfileId,
+            bool isSpecificBookIntent)
+        {
+            var method = typeof(AddBookService).GetMethod("ResolveMetadataProfileIdForBookAdd", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (method == null)
+            {
+                throw new InvalidOperationException("Could not find AddBookService.ResolveMetadataProfileIdForBookAdd via reflection");
+            }
+
+            return (int?)method.Invoke(service, new object[]
+            {
+                profileMediaType,
+                requestedMediaType,
+                configuredProfileId,
+                isSpecificBookIntent
+            });
+        }
+
         private static string InvokeResolveAddHydrationLookupId(AddBookService service, Book book)
         {
             var method = typeof(AddBookService).GetMethod("ResolveAddHydrationLookupId", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -299,6 +321,66 @@ namespace Chaptarr.Core.Test.Books
         {
             var monitored = editions.Where(e => e.Monitored).ToList();
             Assert.That(monitored.Select(e => e.ForeignEditionId), Is.EqualTo(new[] { expectedForeignEditionId }));
+        }
+
+        [TestCase(BookMediaType.Audiobook)]
+        [TestCase(BookMediaType.Ebook)]
+        public void specific_book_add_should_use_none_metadata_profile_for_requested_media_type(BookMediaType mediaType)
+        {
+            var configuredProfile = new MetadataProfile { Id = 7, Name = "Default" };
+            var noneProfile = new MetadataProfile
+            {
+                Id = 11,
+                Name = MetadataProfileService.NONE_PROFILE_NAME,
+                MinPopularity = MetadataProfileService.NONE_PROFILE_MIN_POPULARITY
+            };
+            var service = BuildService(
+                new StubAuthorService(null),
+                new StubBookService(),
+                new StubEditionService(Array.Empty<Edition>()),
+                new StubMetadataProfileService(configuredProfile, noneProfile));
+
+            var resolvedProfileId = InvokeResolveMetadataProfileIdForBookAdd(
+                service,
+                mediaType,
+                mediaType,
+                configuredProfile.Id,
+                true);
+
+            Assert.That(resolvedProfileId, Is.EqualTo(noneProfile.Id));
+        }
+
+        [Test]
+        public void regular_book_add_should_preserve_configured_metadata_profiles()
+        {
+            var configuredProfile = new MetadataProfile { Id = 7, Name = "Default" };
+            var noneProfile = new MetadataProfile
+            {
+                Id = 11,
+                Name = MetadataProfileService.NONE_PROFILE_NAME,
+                MinPopularity = MetadataProfileService.NONE_PROFILE_MIN_POPULARITY
+            };
+            var service = BuildService(
+                new StubAuthorService(null),
+                new StubBookService(),
+                new StubEditionService(Array.Empty<Edition>()),
+                new StubMetadataProfileService(configuredProfile, noneProfile));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(InvokeResolveMetadataProfileIdForBookAdd(
+                    service,
+                    BookMediaType.Audiobook,
+                    BookMediaType.Audiobook,
+                    configuredProfile.Id,
+                    false), Is.EqualTo(configuredProfile.Id));
+                Assert.That(InvokeResolveMetadataProfileIdForBookAdd(
+                    service,
+                    BookMediaType.Ebook,
+                    BookMediaType.Audiobook,
+                    configuredProfile.Id,
+                    true), Is.EqualTo(configuredProfile.Id));
+            });
         }
 
         [Test]

--- a/src/NzbDrone.Core/Books/Services/AddBookService.cs
+++ b/src/NzbDrone.Core/Books/Services/AddBookService.cs
@@ -340,11 +340,19 @@ namespace NzbDrone.Core.Books
                                 CreateEbook = book.MediaType == BookMediaType.Ebook,
                                 MonitorNewItems = book.Author.Monitored,
                                 AudiobookQualityProfileId = book.Author.AudiobookQualityProfileId,
-                            EbookQualityProfileId = book.Author.EbookQualityProfileId,
-                                AudiobookMetadataProfileId = book.Author.AudiobookMetadataProfileId,
-                            EbookMetadataProfileId = book.Author.EbookMetadataProfileId,
-                            AudiobookRootFolderPath = book.Author.AudiobookRootFolderPath,
-                            EbookRootFolderPath = book.Author.EbookRootFolderPath,
+                                EbookQualityProfileId = book.Author.EbookQualityProfileId,
+                                AudiobookMetadataProfileId = ResolveMetadataProfileIdForBookAdd(
+                                    BookMediaType.Audiobook,
+                                    book.MediaType,
+                                    book.Author.AudiobookMetadataProfileId,
+                                    isSpecificBookIntent),
+                                EbookMetadataProfileId = ResolveMetadataProfileIdForBookAdd(
+                                    BookMediaType.Ebook,
+                                    book.MediaType,
+                                    book.Author.EbookMetadataProfileId,
+                                    isSpecificBookIntent),
+                                AudiobookRootFolderPath = book.Author.AudiobookRootFolderPath,
+                                EbookRootFolderPath = book.Author.EbookRootFolderPath,
                                 AudiobookTags = book.Author.AudiobookTags,
                                 EbookTags = book.Author.EbookTags,
                                 Tags = book.Author.Tags,
@@ -974,6 +982,31 @@ namespace NzbDrone.Core.Books
             }
 
             return -1;
+        }
+
+        private int? ResolveMetadataProfileIdForBookAdd(
+            BookMediaType profileMediaType,
+            BookMediaType requestedMediaType,
+            int? configuredProfileId,
+            bool isSpecificBookIntent)
+        {
+            if (!isSpecificBookIntent || profileMediaType != requestedMediaType)
+            {
+                return configuredProfileId;
+            }
+
+            var noneProfile = _metadataProfileService.All()
+                .FirstOrDefault(profile => profile.Name == MetadataProfileService.NONE_PROFILE_NAME);
+
+            if (noneProfile == null)
+            {
+                _logger.Warn("Built-in metadata profile '{0}' is unavailable; specific-book add will use configured profile id {1}",
+                    MetadataProfileService.NONE_PROFILE_NAME,
+                    configuredProfileId);
+                return configuredProfileId;
+            }
+
+            return noneProfile.Id;
         }
 
         private bool ShouldHydrateAddPayload(Book book)


### PR DESCRIPTION
## Summary

- restore the original `Only This Book` catalog behavior for newly added authors
- use Chaptarr's built-in `None` metadata profile only for the requested media type during a specific-book add
- preserve configured metadata profiles for regular adds and the non-requested media type
- keep the selected title through the existing manual-add path so later author refreshes do not repopulate unrelated catalog rows

## Root cause

`SpecificBook` correctly limited monitoring, but the new-author path still passed the configured metadata profile into `AuthorLibraryService`. That profile admitted the author's full eligible catalog, leaving unrelated titles persisted as unmonitored rows.

Readarr's original implementation paired `Only This Book` with its built-in `None` metadata profile. Chaptarr retained the monitoring mode during its dual-media rewrite but lost that catalog constraint.

## Tests

- regression proof with the old behavior restored temporarily:
  - audiobook case failed: expected profile `11` (`None`), got configured profile `7`
  - eBook case failed: expected profile `11` (`None`), got configured profile `7`
- focused fixture: `38/38` passed
- full core suite: `2742/2742` passed
- Docker production build: `yarn typecheck` and `yarn build` passed as part of `Dockerfile.build`

Repository-wide `yarn lint` remains red on the existing frontend baseline (`1459` errors across untouched files); this PR changes only C# files and `git diff --check` passes.

## Scope

This applies only when a new author is created from an explicit `SpecificBook` add. Existing authors, normal author adds, import-list behavior, and the non-requested media type retain their configured metadata profiles.
