### PR TITLE
Fix sorting the book index by Size on Disk

### DIFF
--- a/src/Chaptarr.Core.Test/Books/BookRepositoryIndexFilterFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookRepositoryIndexFilterFixture.cs
@@ -143,6 +143,34 @@ namespace Chaptarr.Core.Test.Books
         }
 
         [Test]
+        public void paged_books_should_sort_by_size_on_disk()
+        {
+            WithRepository(sut =>
+            {
+                var descending = sut.GetBooksPaged(
+                    offset: 0,
+                    pageSize: 100,
+                    sortKey: "sizeOnDisk",
+                    sortDirection: "DESC",
+                    includeUnmonitored: true);
+
+                // Sizes: book 8 = 789 + 790, book 4 = 456, book 3 = 123, the rest have no files.
+                Assert.That(descending.Records.Select(book => book.Id),
+                    Is.EqualTo(new[] { 8, 4, 3, 7, 6, 5, 2, 1 }));
+
+                var ascending = sut.GetBooksPaged(
+                    offset: 0,
+                    pageSize: 100,
+                    sortKey: "sizeOnDisk",
+                    sortDirection: "ASC",
+                    includeUnmonitored: true);
+
+                Assert.That(ascending.Records.Select(book => book.Id),
+                    Is.EqualTo(new[] { 1, 2, 5, 6, 7, 3, 4, 8 }));
+            });
+        }
+
+        [Test]
         public void find_existing_should_return_partial_results_without_weakening_strict_get()
         {
             WithRepository(sut =>

--- a/src/Chaptarr.Core.Test/Books/BookRepositoryIndexFilterFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookRepositoryIndexFilterFixture.cs
@@ -171,6 +171,49 @@ namespace Chaptarr.Core.Test.Books
         }
 
         [Test]
+        public void paged_size_sort_should_preserve_media_type_and_downloaded_filters()
+        {
+            WithRepository(sut =>
+            {
+                var ebooks = sut.GetBooksPaged(
+                    offset: 0,
+                    pageSize: 100,
+                    sortKey: "sizeOnDisk",
+                    sortDirection: "DESC",
+                    includeUnmonitored: true,
+                    mediaType: "ebook",
+                    downloaded: null);
+
+                Assert.That(ebooks.Records.Select(book => book.Id),
+                    Is.EqualTo(new[] { 8, 4, 3, 5, 2, 1 }));
+
+                var audiobooks = sut.GetBooksPaged(
+                    offset: 0,
+                    pageSize: 100,
+                    sortKey: "sizeOnDisk",
+                    sortDirection: "DESC",
+                    includeUnmonitored: true,
+                    mediaType: "audiobook",
+                    downloaded: null);
+
+                Assert.That(audiobooks.Records.Select(book => book.Id),
+                    Is.EqualTo(new[] { 7, 6 }));
+
+                var downloadedEbooks = sut.GetBooksPaged(
+                    offset: 0,
+                    pageSize: 100,
+                    sortKey: "sizeOnDisk",
+                    sortDirection: "DESC",
+                    includeUnmonitored: true,
+                    mediaType: "ebook",
+                    downloaded: true);
+
+                Assert.That(downloadedEbooks.Records.Select(book => book.Id),
+                    Is.EqualTo(new[] { 8, 3 }));
+            });
+        }
+
+        [Test]
         public void find_existing_should_return_partial_results_without_weakening_strict_get()
         {
             WithRepository(sut =>

--- a/src/NzbDrone.Core/AuthorStats/AuthorStatisticsRepository.cs
+++ b/src/NzbDrone.Core/AuthorStats/AuthorStatisticsRepository.cs
@@ -19,15 +19,8 @@ namespace NzbDrone.Core.AuthorStats
     {
         private const string _selectTemplate = "SELECT /**select**/ FROM \"Books\" /**join**/ /**innerjoin**/ /**leftjoin**/ /**where**/ /**groupby**/ /**having**/ /**orderby**/";
 
-        private const string _fileStatisticsJoin = @"(
-            SELECT ""Editions"".""BookId"" AS ""BookId"",
-                   SUM(""BookFiles"".""Size"") AS ""SizeOnDisk"",
-                   COUNT(""BookFiles"".""Id"") AS ""BookFileCount""
-            FROM ""BookFiles""
-            CROSS JOIN ""Editions""
-            WHERE ""Editions"".""Id"" = ""BookFiles"".""EditionId""
-            GROUP BY ""Editions"".""BookId""
-        ) AS ""FileStatistics"" ON ""FileStatistics"".""BookId"" = ""Books"".""Id""";
+        private const string _fileStatisticsJoin = "(" + BookFileStatisticsSql.GroupedByBook +
+                                                   @") AS ""FileStatistics"" ON ""FileStatistics"".""BookId"" = ""Books"".""Id""";
 
         private readonly IMainDatabase _database;
 

--- a/src/NzbDrone.Core/Books/BookFileStatisticsSql.cs
+++ b/src/NzbDrone.Core/Books/BookFileStatisticsSql.cs
@@ -1,0 +1,15 @@
+namespace NzbDrone.Core.Books
+{
+    internal static class BookFileStatisticsSql
+    {
+        internal const string GroupedByBook = @"
+            SELECT ""Editions"".""BookId"" AS ""BookId"",
+                   SUM(""BookFiles"".""Size"") AS ""SizeOnDisk"",
+                   COUNT(""BookFiles"".""Id"") AS ""BookFileCount""
+            FROM ""BookFiles""
+            CROSS JOIN ""Editions""
+            WHERE ""Editions"".""Id"" = ""BookFiles"".""EditionId""
+            GROUP BY ""Editions"".""BookId""
+        ";
+    }
+}

--- a/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
@@ -1111,7 +1111,7 @@ namespace NzbDrone.Core.Books
                 ["releasedate"] = $"\"{tableName}\".\"ReleaseDate\"",
                 ["added"] = $"\"{tableName}\".\"Added\"",
                 ["id"] = $"\"{tableName}\".\"Id\"",
-                ["sizeondisk"] = $"COALESCE((SELECT SUM(bf.\"Size\") FROM \"Editions\" e INNER JOIN \"BookFiles\" bf ON bf.\"EditionId\" = e.\"Id\" WHERE e.\"BookId\" = \"{tableName}\".\"Id\"), 0)"
+                ["sizeondisk"] = "COALESCE(\"FileStatistics\".\"SizeOnDisk\", 0)"
             };
 
             var normalizedSortKey = sortKey.ToLowerInvariant();
@@ -1124,6 +1124,11 @@ namespace NzbDrone.Core.Books
                 var totalCount = conn.QuerySingle<int>(countTemplate.RawSql, countTemplate.Parameters);
                 var builder = CreatePagedBooksBuilder(includeUnmonitored, mediaType, downloaded, monitored, missing, wanted);
                 builder.Select(typeof(Book));
+
+                if (normalizedSortKey == "sizeondisk")
+                {
+                    builder.LeftJoin($@"({BookFileStatisticsSql.GroupedByBook}) AS ""FileStatistics"" ON ""FileStatistics"".""BookId"" = ""{tableName}"".""Id""");
+                }
 
                 if (normalizedSortKey == "authortitle")
                 {

--- a/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
+++ b/src/NzbDrone.Core/Books/Repositories/BookRepository.cs
@@ -1094,7 +1094,7 @@ namespace NzbDrone.Core.Books
             offset = Math.Max(0, offset);
             pageSize = Math.Clamp(pageSize, 1, 500);
 
-            var allowedSortKeys = new HashSet<string> { "cleantitle", "title", "authortitle", "releasedate", "added", "id" };
+            var allowedSortKeys = new HashSet<string> { "cleantitle", "title", "authortitle", "releasedate", "added", "id", "sizeondisk" };
             if (string.IsNullOrWhiteSpace(sortKey) || !allowedSortKeys.Contains(sortKey.ToLowerInvariant()))
             {
                 sortKey = "title";
@@ -1110,7 +1110,8 @@ namespace NzbDrone.Core.Books
                 ["authortitle"] = "LOWER(\"Authors\".\"Name\")",
                 ["releasedate"] = $"\"{tableName}\".\"ReleaseDate\"",
                 ["added"] = $"\"{tableName}\".\"Added\"",
-                ["id"] = $"\"{tableName}\".\"Id\""
+                ["id"] = $"\"{tableName}\".\"Id\"",
+                ["sizeondisk"] = $"COALESCE((SELECT SUM(bf.\"Size\") FROM \"Editions\" e INNER JOIN \"BookFiles\" bf ON bf.\"EditionId\" = e.\"Id\" WHERE e.\"BookId\" = \"{tableName}\".\"Id\"), 0)"
             };
 
             var normalizedSortKey = sortKey.ToLowerInvariant();


### PR DESCRIPTION
Sorting the book index by **Size on Disk** does nothing — the posters view loads books server-side via `/book/paged`, and `GetBooksPaged` only allows title/author/date sort keys, so `sizeOnDisk` silently falls back to title order.

This adds `sizeondisk` as an allowed sort key, ordered by the summed `BookFiles.Size` per book (zero for books without files, `Id` tiebreak for stable paging), plus a regression test in `BookRepositoryIndexFilterFixture` covering both directions.