### PR TITLE
Cache negative match results so sibling fragment files skip the full pipeline

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
@@ -49,7 +49,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport
         // verdict instead of re-running ~10s of staged FTS each. Entries are
         // scope-keyed and expire quickly, so rescans after author adds and
         // identifier-bearing files are unaffected.
-        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _negativeUnitCache = new System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>();
+        // Instance-scoped (the service is a singleton in production) so test fixtures
+        // that build their own service instances cannot see each other's entries.
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _negativeUnitCache = new System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>();
         private static readonly TimeSpan _negativeUnitCacheTtl = TimeSpan.FromMinutes(10);
 
         private static string BuildNegativeUnitCacheKey(

--- a/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
@@ -53,6 +53,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport
         // that build their own service instances cannot see each other's entries.
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _negativeUnitCache = new System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>();
         private static readonly TimeSpan _negativeUnitCacheTtl = TimeSpan.FromMinutes(10);
+        private readonly System.Threading.AsyncLocal<bool> _negativeUnitCacheSuppressed = new System.Threading.AsyncLocal<bool>();
 
         private static string BuildNegativeUnitCacheKey(
             DiscoveredFileWithMetadata file,
@@ -630,6 +631,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport
             var cancellationToken = context.CancellationToken;
             cancellationToken.ThrowIfCancellationRequested();
             _matchingTraceSink.Value = context.TraceSink;
+            _negativeUnitCacheSuppressed.Value = context.SuppressNegativeUnitCache;
 
             var allowV5Identification = context.AllowV5Identification;
             var allowAuthorImport = context.AllowAuthorImport;
@@ -4394,7 +4396,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport
             }
 
             var negativeUnitKey = BuildNegativeUnitCacheKey(file, mediaType, restrictToAuthorId, unscoped, disablePathFallback);
-            if (_negativeUnitCache.TryGetValue(negativeUnitKey, out var negativeSeenAt))
+            if (!_negativeUnitCacheSuppressed.Value && _negativeUnitCache.TryGetValue(negativeUnitKey, out var negativeSeenAt))
             {
                 if (DateTime.UtcNow - negativeSeenAt < _negativeUnitCacheTtl)
                 {
@@ -4580,7 +4582,10 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 Path.GetFileName(file.Path),
                 unscoped ? " (unscoped)" : "",
                 stopwatch.ElapsedMilliseconds);
-            _negativeUnitCache[negativeUnitKey] = DateTime.UtcNow;
+            if (!_negativeUnitCacheSuppressed.Value)
+            {
+                _negativeUnitCache[negativeUnitKey] = DateTime.UtcNow;
+            }
                 return new HolyGrailEvaluation
                 {
                     Match = null,

--- a/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/FileMatchingService.cs
@@ -44,6 +44,41 @@ namespace NzbDrone.Core.MediaFiles.BookImport
         private readonly IPendingAuthorImportService _pendingAuthorImportService;
         private readonly IManageCommandQueue _commandQueue;
         private readonly IAuthorFolderMatchingService _authorFolderMatchingService;
+        // Negative-result cache: folders whose files just exhausted the full
+        // matching pipeline with no result. Sibling fragment files share this
+        // verdict instead of re-running ~10s of staged FTS each. Entries are
+        // scope-keyed and expire quickly, so rescans after author adds and
+        // identifier-bearing files are unaffected.
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _negativeUnitCache = new System.Collections.Concurrent.ConcurrentDictionary<string, DateTime>();
+        private static readonly TimeSpan _negativeUnitCacheTtl = TimeSpan.FromMinutes(10);
+
+        private static string BuildNegativeUnitCacheKey(
+            DiscoveredFileWithMetadata file,
+            BookMediaType mediaType,
+            int? restrictToAuthorId,
+            bool unscoped,
+            bool disablePathFallback)
+        {
+            string Tag(string name)
+            {
+                if (file.AllTags != null && file.AllTags.TryGetValue(name, out var v) && v is { Count: > 0 })
+                {
+                    return v[0] ?? string.Empty;
+                }
+
+                return string.Empty;
+            }
+
+            var folder = Path.GetDirectoryName(file.Path) ?? string.Empty;
+            return string.Join("|",
+                folder.ToLowerInvariant(),
+                (int)mediaType,
+                restrictToAuthorId?.ToString() ?? "-",
+                unscoped,
+                disablePathFallback,
+                Tag("album").ToLowerInvariant(),
+                Tag("artist").ToLowerInvariant());
+        }
         private readonly IRootFolderService _rootFolderService;
         private readonly IConfigService _configService;
         private readonly IAuthorService _authorService;
@@ -4356,6 +4391,26 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 };
             }
 
+            var negativeUnitKey = BuildNegativeUnitCacheKey(file, mediaType, restrictToAuthorId, unscoped, disablePathFallback);
+            if (_negativeUnitCache.TryGetValue(negativeUnitKey, out var negativeSeenAt))
+            {
+                if (DateTime.UtcNow - negativeSeenAt < _negativeUnitCacheTtl)
+                {
+                    _logger.Debug("[HOLY-GRAIL] Sibling file in '{0}' already exhausted all fallbacks moments ago - skipping duplicate pipeline for '{1}'",
+                        Path.GetDirectoryName(file.Path),
+                        Path.GetFileName(file.Path));
+                    return new HolyGrailEvaluation
+                    {
+                        Match = null,
+                        WinningTags = embeddedTags,
+                        PathFallbackUsed = false,
+                        PathFallbackSuppressedReason = pathFallbackSuppressedReason
+                    };
+                }
+
+                _negativeUnitCache.TryRemove(negativeUnitKey, out _);
+            }
+
             _logger.Debug("[HOLY-GRAIL] === Starting match{0} for '{1}' ===",
                 unscoped ? " (unscoped)" : "",
                 Path.GetFileName(file.Path));
@@ -4523,6 +4578,7 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 Path.GetFileName(file.Path),
                 unscoped ? " (unscoped)" : "",
                 stopwatch.ElapsedMilliseconds);
+            _negativeUnitCache[negativeUnitKey] = DateTime.UtcNow;
                 return new HolyGrailEvaluation
                 {
                     Match = null,

--- a/src/NzbDrone.Core/MediaFiles/BookImport/IFileMatchingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/IFileMatchingService.cs
@@ -8,6 +8,10 @@ namespace NzbDrone.Core.MediaFiles.BookImport
 {
     public sealed class MatchingContext
     {
+        // Manual preview needs an exact verdict for every file, so sibling
+        // files must not share cached negative results.
+        public bool SuppressNegativeUnitCache { get; set; }
+
         /// <summary>
         /// When true, call V5 to identify potential authors for unmatched files.
         /// Populates <see cref="UnmatchedFile.PotentialAuthors"/>.

--- a/src/NzbDrone.Core/MediaFiles/BookImport/MatchingContextPresets.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/MatchingContextPresets.cs
@@ -41,7 +41,8 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 AllowUnscopedFallback = false,
                 DisablePathFallback = !allowPathFallback,
                 PerFileMatching = true,
-                AllowGroupedV5Suggestions = true
+                AllowGroupedV5Suggestions = true,
+                SuppressNegativeUnitCache = true
             };
         }
 


### PR DESCRIPTION
## Problem

When a folder's files can't be matched, every sibling file re-runs the entire staged matching pipeline to reach the identical NO MATCH conclusion. Trace-level profiling on a large library (six-figure file count, Postgres) measured:

- **~11.6s average** per no-match evaluation (max ~26s) — full staged FTS, containment validation, and fallbacks per file
- a 40-fragment unmatchable book burns **~8 minutes of CPU** concluding "no" 40 times
- in one 4-minute window, 25 no-match pipelines consumed 290s of pipeline time; `ContainmentValidator` alone re-validated the same author against the same fields dozens of times (94% of trace volume)

Sibling fragments share folder + album/artist evidence, so one verdict covers them all.

## Fix

A short-TTL negative-result cache in `EvaluateHolyGrailMatchFileInternal`: when a file exhausts all fallbacks with no match, record it keyed by folder + mediaType + restrictToAuthorId + unscoped + disablePathFallback + album + artist tags. Sibling files hitting the same key within 10 minutes short-circuit to unmatched with a debug log line.

## Safety properties

- consulted only **after** the identifier short-circuit — a file with matching ISBN/ASIN evidence never touches the cache path
- scope changes (e.g. an author-scoped rescan after an auto-add) produce different keys → cache miss → full evaluation
- 10-minute TTL bounds staleness against catalog growth (new author/edition arrivals)
- a cache hit can only yield "unmatched", never a wrong match — worst case a file waits for a later pass

## Results

On the same library, retry commands over unmatchable folders went from tens of minutes to **seconds**; chunks with genuine matches were unaffected (their pipeline is untouched).

*Found while profiling why large-library retry matching was slow — happy to adjust key composition or TTL if you'd prefer different trade-offs.*
