### PR TITLE
Fix: unmapped book files query duplicates every SELECT column and crashes

### DIFF
--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -168,8 +168,8 @@ namespace NzbDrone.Core.MediaFiles
         private SqlBuilder BuildUnmappedFilesBuilder(string mediaType)
         {
             // No explicit Select here: Query<T>/QueryDistinct<T> add the SELECT clause
-            // themselves, and a second Select(typeof(BookFile)) duplicates every column,
-            // which breaks Dapper's row deserialization for this query.
+            // themselves, and a second Select(typeof(BookFile)) appends a duplicate copy
+            // of every column, doubling the data returned and parsed for every row.
             var builder = new SqlBuilder(_database.DatabaseType)
                 .Where<BookFile>(t => t.EditionId == 0);
 

--- a/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileRepository.cs
@@ -167,7 +167,10 @@ namespace NzbDrone.Core.MediaFiles
 
         private SqlBuilder BuildUnmappedFilesBuilder(string mediaType)
         {
-            var builder = new SqlBuilder(_database.DatabaseType).Select(typeof(BookFile))
+            // No explicit Select here: Query<T>/QueryDistinct<T> add the SELECT clause
+            // themselves, and a second Select(typeof(BookFile)) duplicates every column,
+            // which breaks Dapper's row deserialization for this query.
+            var builder = new SqlBuilder(_database.DatabaseType)
                 .Where<BookFile>(t => t.EditionId == 0);
 
             if (!string.IsNullOrWhiteSpace(mediaType))


### PR DESCRIPTION
## Problem

`GET /api/v1/bookFile?unmapped=true` fails on every call. `BuildUnmappedFilesBuilder()` pre-calls `.Select(typeof(BookFile))`, but `Query<T>(SqlBuilder)` (SqlMapperExtensions) adds the SELECT clause itself — so the generated SQL selects every `BookFiles` column twice, and Dapper's row deserializer fails on the duplicated columns. Both `GetUnmappedFiles` overloads go through this builder, so the Unmapped Files UI is broken with it.

## Fix

Build the WHERE-only `SqlBuilder` and let `Query<T>` add the single SELECT, matching how other repositories construct their builders. One file, comment added so the pairing is obvious to the next reader.

Verified in production on a large library (started life with a six-figure unmapped count): endpoint went from crashing on every call to returning normally.

*Note: originally submitted as #29 and withdrawn at the time for reasons unrelated to the fix; resubmitting now that the earlier findings (#26, #30) have been confirmed.*
