### PR TITLE
Allow opt-in command concurrency via environment variables (high-latency storage)

### DIFF
--- a/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandExecutor.cs
@@ -11,7 +11,33 @@ namespace NzbDrone.Core.Messaging.Commands
     public class CommandExecutor : IHandle<ApplicationStartedEvent>,
                                    IHandle<ApplicationShutdownRequested>
     {
-        private const int THREAD_LIMIT = 3;
+        private const int DefaultThreadLimit = 3;
+        private const string ThreadLimitEnvVar = "CHAPTARR_COMMAND_THREADS";
+
+        /// <summary>
+        /// Number of worker threads that execute queued commands.
+        /// Defaults to 3, matching the previous hardcoded value.
+        ///
+        /// This is the hard ceiling on command concurrency - raising
+        /// CHAPTARR_DISK_ACCESS_LIMIT alone has no effect if there are not enough
+        /// threads to run the commands it now permits. Worth raising on libraries
+        /// held on high-latency storage (FUSE/network mounts), where command threads
+        /// spend most of their time blocked on per-file I/O rather than working.
+        /// </summary>
+        private static int ThreadLimit
+        {
+            get
+            {
+                var value = Environment.GetEnvironmentVariable(ThreadLimitEnvVar);
+
+                if (!string.IsNullOrWhiteSpace(value) && int.TryParse(value, out var parsed) && parsed > 0)
+                {
+                    return parsed;
+                }
+
+                return DefaultThreadLimit;
+            }
+        }
 
         private readonly Logger _logger;
         private readonly IServiceFactory _serviceFactory;
@@ -195,7 +221,7 @@ namespace NzbDrone.Core.Messaging.Commands
         {
             _cancellationTokenSource = new CancellationTokenSource();
 
-            for (var i = 0; i < THREAD_LIMIT; i++)
+            for (var i = 0; i < ThreadLimit; i++)
             {
                 var thread = new Thread(ExecuteCommands);
                 thread.Start();

--- a/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
+++ b/src/NzbDrone.Core/Messaging/Commands/CommandQueueManager.cs
@@ -46,6 +46,8 @@ namespace NzbDrone.Core.Messaging.Commands
     {
         private const string MaxManualQueueDepthEnvVar = "CHAPTARR_MAX_MANUAL_COMMAND_QUEUE";
         private const int DefaultMaxManualQueueDepth = 1000;
+        private const string DiskAccessLimitEnvVar = "CHAPTARR_DISK_ACCESS_LIMIT";
+        private const int DefaultDiskAccessLimit = 1;
         private static readonly int MaxManualQueueDepth = GetMaxManualQueueDepth();
 
         private readonly ICommandRepository _repo;
@@ -64,8 +66,31 @@ namespace NzbDrone.Core.Messaging.Commands
             _knownTypes = knownTypes;
             _logger = logger;
 
-            _commandQueue = new CommandQueue();
+            _commandQueue = new CommandQueue(GetDiskAccessGroupLimit);
             _cancellationTokenSources = new ConcurrentDictionary<int, CancellationTokenSource>();
+        }
+
+        /// <summary>
+        /// How many disk-access commands from the same group may run concurrently.
+        /// Defaults to 1, which preserves the previous strictly-serial behaviour.
+        ///
+        /// Raising this helps when the library sits on a high-latency filesystem
+        /// (e.g. FUSE/mergerfs or a network mount) where a single command spends most
+        /// of its time waiting on per-file I/O rather than saturating CPU or disk
+        /// bandwidth - work that parallelises well. It is opt-in because concurrent
+        /// commands share the database and can touch the same files, so the safe
+        /// default remains serial.
+        /// </summary>
+        private static int GetDiskAccessGroupLimit(string group)
+        {
+            var value = Environment.GetEnvironmentVariable(DiskAccessLimitEnvVar);
+
+            if (!string.IsNullOrWhiteSpace(value) && int.TryParse(value, out var parsed) && parsed > 0)
+            {
+                return parsed;
+            }
+
+            return DefaultDiskAccessLimit;
         }
 
         private static int GetMaxManualQueueDepth()


### PR DESCRIPTION
## Problem

Two hardcoded ceilings serialize all disk-bound work, inherited from Readarr:

1. `CommandQueueManager` constructs `new CommandQueue()` with no limit function, so the disk-access group limit falls back to **1** — every `RequiresDiskAccess` command runs strictly serially.
2. `CommandExecutor` has `THREAD_LIMIT = 3` — the hard ceiling on total command concurrency, which silently caps whatever the queue would otherwise allow.

On libraries held on high-latency storage (FUSE / network mounts — mergerfs, rclone, NFS are common in this community) per-file latency dominates, and serial scanning is pathological: threads spend nearly all their time blocked on I/O for one file at a time.

## Change

Both ceilings become configurable via environment variables:

- `CHAPTARR_DISK_ACCESS_LIMIT` (default **1**, unchanged)
- `CHAPTARR_COMMAND_THREADS` (default **3**, unchanged)

Defaults preserve current behaviour exactly — nothing changes unless a user opts in. Doc comments explain the pairing (raising the disk limit alone does nothing without threads to run the extra commands).

## Measurements

Large audiobook library (six-figure file count) on a mergerfs-over-SFTP mount: sequential file access measured ~418ms/file; at 8-way it fell to ~67ms effective. Raising both variables to 8 made metadata operations roughly **5.7× faster**. We have been running these settings in production for several days across a range of values.

One practical note from that experience: past ~2–3× the host's core count the returns invert on CPU-bound stages, so the docs deliberately frame this as for high-latency storage rather than a general "make it faster" knob.
