### PR TITLE
Fix inverted equality in memoized author/book collection selectors (#43)

### DIFF
--- a/frontend/src/Store/Selectors/createAuthorClientSideCollectionItemsSelector.js
+++ b/frontend/src/Store/Selectors/createAuthorClientSideCollectionItemsSelector.js
@@ -14,7 +14,11 @@ function createUnoptimizedSelector(uiSection) {
 }
 
 function authorListEqual(a, b) {
-  return hasDifferentItemsOrOrder(a, b);
+  // Reselect equality functions must return true when the inputs are EQUAL
+  // (reuse the cached result). hasDifferentItemsOrOrder returns true when
+  // they DIFFER, so it must be negated here or filtering/sorting reuses the
+  // stale unfiltered collection.
+  return !hasDifferentItemsOrOrder(a, b);
 }
 
 const createAuthorEqualSelector = createSelectorCreator(

--- a/frontend/src/Store/Selectors/createBookClientSideCollectionItemsSelector.js
+++ b/frontend/src/Store/Selectors/createBookClientSideCollectionItemsSelector.js
@@ -29,7 +29,11 @@ function createUnoptimizedSelector(uiSection) {
 }
 
 function bookListEqual(a, b) {
-  return hasDifferentItemsOrOrder(a, b);
+  // Reselect equality functions must return true when the inputs are EQUAL
+  // (reuse the cached result). hasDifferentItemsOrOrder returns true when
+  // they DIFFER, so it must be negated here or filtering/sorting reuses the
+  // stale unfiltered collection.
+  return !hasDifferentItemsOrOrder(a, b);
 }
 
 const createBookEqualSelector = createSelectorCreator(


### PR DESCRIPTION
Fixes #43.

@digitalgp's diagnosis is exactly right: `hasDifferentItemsOrOrder` returns `true` when two collections **differ**, but both client-side collection selectors pass it to Reselect as an **equality** function, where `true` means "inputs are equal — reuse the cached result". So a filter/sort change that produces a different list is precisely the case that reuses the stale unfiltered result (e.g. **Monitored Only** leaving unmonitored authors visible).

This negates the comparator in both selectors (`createAuthorClientSideCollectionItemsSelector`, `createBookClientSideCollectionItemsSelector`) with a comment explaining the contract so it doesn't regress.

Also swept the rest of `frontend/src` for the pattern: all other `hasDifferentItemsOrOrder` call sites are `componentDidUpdate`-style checks where `true → act` is the correct sense; these two selectors were the only inversions.
