### PR TITLE
Derive series labels from series links instead of stale snapshots

### DIFF
--- a/frontend/src/Book/Details/BookDetails.js
+++ b/frontend/src/Book/Details/BookDetails.js
@@ -386,7 +386,7 @@ BookDetails.propTypes = {
   id: PropTypes.number.isRequired,
   titleSlug: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  seriesTitle: PropTypes.string.isRequired,
+  seriesTitle: PropTypes.string,
   pageCount: PropTypes.number,
   overview: PropTypes.string,
   releaseDate: PropTypes.string.isRequired,

--- a/frontend/src/Book/Details/BookDetailsHeader.js
+++ b/frontend/src/Book/Details/BookDetailsHeader.js
@@ -244,9 +244,12 @@ class BookDetailsHeader extends Component {
             </Measure>
 
             <div className={styles.details}>
-              <div>
-                {seriesTitle}
-              </div>
+              {
+                !!seriesTitle &&
+                  <div>
+                    {seriesTitle}
+                  </div>
+              }
 
               <div>
                 <AuthorNameLink
@@ -409,7 +412,7 @@ BookDetailsHeader.propTypes = {
   width: PropTypes.number.isRequired,
   titleSlug: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-  seriesTitle: PropTypes.string.isRequired,
+  seriesTitle: PropTypes.string,
   pageCount: PropTypes.number,
   overview: PropTypes.string,
   statistics: PropTypes.object.isRequired,

--- a/src/Chaptarr.Api.V1/Books/BookResource.cs
+++ b/src/Chaptarr.Api.V1/Books/BookResource.cs
@@ -151,19 +151,17 @@ namespace Chaptarr.Api.V1.Books
             var selectedEdition = SelectMonitoredEdition(model.Editions);
             var title = (selectedEdition?.Title ?? model.Title) ?? string.Empty;
 
-            // Use SeriesName and SeriesPosition from Book model until SeriesBookLink is properly populated
-            var seriesTitle = !string.IsNullOrWhiteSpace(model.SeriesName)
-                ? model.SeriesName + (!string.IsNullOrWhiteSpace(model.SeriesPosition) ? $" #{model.SeriesPosition}" : string.Empty)
-                : null;
+            var seriesTitle = BookSeriesLabel.Build(model.SeriesLinks);
 
-            // Fallback to SeriesLinks if available (for future when SeriesBookLink is populated)
-            if (string.IsNullOrWhiteSpace(seriesTitle) && model.SeriesLinks?.Any() == true)
+            // Lookup and search results are not persisted and therefore never carry links, so the
+            // denormalized pair from the metadata server is all they have. For a library book the
+            // links are the truth, including when there are none.
+            if (seriesTitle.IsNullOrWhiteSpace() && model.Id <= 0)
             {
-                var seriesLinks = model.SeriesLinks.OrderBy(x => x.SeriesPosition);
-                seriesTitle = seriesLinks.Select(x => x?.Series?.Value?.Title + (x?.Position.IsNotNullOrWhiteSpace() ?? false ? $" #{x.Position}" : string.Empty)).ConcatToString("; ");
+                seriesTitle = BookSeriesLabel.Format(model.SeriesName, model.SeriesPosition);
             }
 
-            title = StripDuplicatedSeriesSuffix(title, seriesTitle);
+            title = StripDuplicatedSeriesSuffix(title, BuildSuffixCandidates(model, seriesTitle));
 
             var authorTitle = $"{model.Author?.SortNameLastFirst} {title}";
             var hasFiles = options.Statistics != null
@@ -258,12 +256,36 @@ namespace Chaptarr.Api.V1.Books
             return resource;
         }
 
-            private static string StripDuplicatedSeriesSuffix(string title, string seriesTitle)
+            private static List<string> BuildSuffixCandidates(Book model, string seriesTitle)
+            {
+                var candidates = new List<string>();
+
+                if (seriesTitle.IsNotNullOrWhiteSpace())
+                {
+                    candidates.Add(seriesTitle);
+                }
+
+                candidates.AddRange(BookSeriesLabel.BuildAll(model.SeriesLinks));
+
+                var denormalized = BookSeriesLabel.Format(model.SeriesName, model.SeriesPosition);
+                if (denormalized.IsNotNullOrWhiteSpace())
+                {
+                    candidates.Add(denormalized);
+                }
+
+                return candidates;
+            }
+
+            private static string StripDuplicatedSeriesSuffix(string title, IEnumerable<string> seriesTitles)
             {
                 title ??= string.Empty;
                 title = title.Trim();
 
-                if (title.Length == 0 || string.IsNullOrWhiteSpace(seriesTitle))
+                var candidates = (seriesTitles ?? Enumerable.Empty<string>())
+                    .Where(x => x.IsNotNullOrWhiteSpace())
+                    .ToList();
+
+                if (title.Length == 0 || candidates.Count == 0)
                 {
                     return title;
                 }
@@ -275,7 +297,7 @@ namespace Chaptarr.Api.V1.Books
                 }
 
                 var suffix = match.Groups["suffix"].Value;
-                if (!SuffixMatchesSeriesTitle(suffix, seriesTitle))
+                if (!candidates.Any(candidate => SuffixMatchesSeriesTitle(suffix, candidate)))
                 {
                     return title;
                 }

--- a/src/Chaptarr.Api.V1/Series/SeriesBookLinkResource.cs
+++ b/src/Chaptarr.Api.V1/Series/SeriesBookLinkResource.cs
@@ -11,6 +11,7 @@ namespace Chaptarr.Api.V1.Series
         public int SeriesPosition { get; set; }
         public int SeriesId { get; set; }
         public int BookId { get; set; }
+        public bool IsPrimary { get; set; }
     }
 
     public static class SeriesBookLinkResourceMapper
@@ -23,7 +24,8 @@ namespace Chaptarr.Api.V1.Series
                 Position = model.Position,
                 SeriesPosition = model.SeriesPosition,
                 SeriesId = model.SeriesId,
-                BookId = model.BookId
+                BookId = model.BookId,
+                IsPrimary = model.IsPrimary
             };
         }
 

--- a/src/Chaptarr.Api.V1/Series/SeriesResource.cs
+++ b/src/Chaptarr.Api.V1/Series/SeriesResource.cs
@@ -16,6 +16,8 @@ namespace Chaptarr.Api.V1.Series
         public string Description { get; set; }
         public int WorkCount { get; set; }
         public int PrimaryWorkCount { get; set; }
+        public string SeriesType { get; set; }
+        public int? ParentSeriesId { get; set; }
         public string MediaType { get; set; }
         public string Narrator { get; set; }
         public List<SeriesBookLinkResource> Links { get; set; }
@@ -88,6 +90,8 @@ namespace Chaptarr.Api.V1.Series
                 Description = model.Description,
                 WorkCount = model.WorkCount,
                 PrimaryWorkCount = model.PrimaryWorkCount,
+                SeriesType = model.SeriesType,
+                ParentSeriesId = model.ParentSeriesId,
                 MediaType = model.MediaType == BookMediaType.Audiobook ? "audiobook" : "ebook",
                 Narrator = model.Narrator,
                 Links = model.LinkItems?.ToResource() ?? new List<SeriesBookLinkResource>(),

--- a/src/Chaptarr.Core.Test/Books/BookResourceSeriesTitleFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookResourceSeriesTitleFixture.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using Chaptarr.Api.V1.Books;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+
+namespace Chaptarr.Core.Test.Books
+{
+    [TestFixture]
+    public class BookResourceSeriesTitleFixture
+    {
+        private static SeriesBookLink Link(int seriesId, string title, string position, bool isPrimary = true, int workCount = 0)
+        {
+            return new SeriesBookLink
+            {
+                SeriesId = seriesId,
+                Position = position,
+                SeriesPosition = int.TryParse(position, out var parsed) ? parsed : 0,
+                IsPrimary = isPrimary,
+                Series = new Series
+                {
+                    Id = seriesId,
+                    Title = title,
+                    PrimaryWorkCount = workCount
+                }
+            };
+        }
+
+        private static Book StoredBook(int id, string title, params SeriesBookLink[] links)
+        {
+            return new Book
+            {
+                Id = id,
+                Title = title,
+                MediaType = BookMediaType.Audiobook,
+                AnyEditionOk = true,
+                SeriesLinks = new List<SeriesBookLink>(links ?? new SeriesBookLink[0]),
+                Editions = new List<Edition>
+                {
+                    new Edition
+                    {
+                        Id = id,
+                        Title = title,
+                        Format = "audiobook",
+                        ReadingFormatId = 2,
+                        Monitored = true
+                    }
+                }
+            };
+        }
+
+        [Test]
+        public void should_use_series_links_instead_of_the_stale_denormalized_pair()
+        {
+            var book = StoredBook(1, "Dust of Dreams", Link(3447, "Malazan Book of the Fallen", "9", workCount: 10));
+            book.SeriesName = "La caduta di Malazan";
+            book.SeriesPosition = "28";
+
+            var resource = book.ToResource();
+
+            Assert.That(resource.SeriesTitle, Is.EqualTo("Malazan Book of the Fallen #9"));
+        }
+
+        [Test]
+        public void should_not_report_a_series_for_a_stored_book_without_links()
+        {
+            var book = StoredBook(2, "Wuthering Heights");
+            book.SeriesName = "Jardín Secreto";
+            book.SeriesPosition = "1";
+
+            var resource = book.ToResource();
+
+            Assert.That(resource.SeriesTitle, Is.Null);
+        }
+
+        [Test]
+        public void should_fall_back_to_the_denormalized_pair_for_lookup_results()
+        {
+            var book = StoredBook(0, "The Final Empire");
+            book.SeriesName = "Mistborn";
+            book.SeriesPosition = "1";
+
+            var resource = book.ToResource();
+
+            Assert.That(resource.SeriesTitle, Is.EqualTo("Mistborn #1"));
+        }
+
+        [Test]
+        public void should_not_emit_the_same_label_for_books_in_a_shared_umbrella_series()
+        {
+            var cosmere = new Series { Id = 99, Title = "The Cosmere Universe", PrimaryWorkCount = 40 };
+
+            var wayOfKings = StoredBook(3, "The Way of Kings",
+                Link(1, "The Stormlight Archive", "1", workCount: 5),
+                new SeriesBookLink { SeriesId = 99, Position = "6", SeriesPosition = 6, IsPrimary = true, Series = cosmere });
+
+            var whiteSand = StoredBook(4, "White Sand",
+                Link(2, "White Sand", "1", workCount: 3),
+                new SeriesBookLink { SeriesId = 99, Position = "11", SeriesPosition = 11, IsPrimary = true, Series = cosmere });
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(wayOfKings.ToResource().SeriesTitle, Is.EqualTo("The Stormlight Archive #1"));
+                Assert.That(whiteSand.ToResource().SeriesTitle, Is.EqualTo("White Sand #1"));
+            });
+        }
+
+        [Test]
+        public void should_strip_a_localized_series_suffix_even_when_the_label_is_canonical()
+        {
+            var book = StoredBook(6, "Das Spiel der Götter (Das Spiel der Götter, #1)",
+                Link(3447, "Malazan Book of the Fallen", "1", workCount: 10));
+            book.SeriesName = "Das Spiel der Götter";
+            book.SeriesPosition = "1";
+
+            var resource = book.ToResource();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.Title, Is.EqualTo("Das Spiel der Götter"));
+                Assert.That(resource.SeriesTitle, Is.EqualTo("Malazan Book of the Fallen #1"));
+            });
+        }
+
+        [Test]
+        public void should_strip_a_suffix_matching_a_series_the_book_is_in_but_is_not_labelled_with()
+        {
+            var book = StoredBook(7, "The Way of Kings (The Cosmere Universe, #6)",
+                Link(1, "The Stormlight Archive", "1", workCount: 5),
+                Link(99, "The Cosmere Universe", "6", workCount: 40));
+
+            var resource = book.ToResource();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.Title, Is.EqualTo("The Way of Kings"));
+                Assert.That(resource.SeriesTitle, Is.EqualTo("The Stormlight Archive #1"));
+            });
+        }
+
+        [Test]
+        public void should_still_strip_a_duplicated_series_suffix_from_the_title()
+        {
+            var book = StoredBook(5, "Guards! Guards! (Discworld, #8)", Link(1, "Discworld", "8", workCount: 41));
+
+            var resource = book.ToResource();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(resource.Title, Is.EqualTo("Guards! Guards!"));
+                Assert.That(resource.SeriesTitle, Is.EqualTo("Discworld #8"));
+            });
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/Books/BookSeriesLabelFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookSeriesLabelFixture.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+
+namespace Chaptarr.Core.Test.Books
+{
+    [TestFixture]
+    public class BookSeriesLabelFixture
+    {
+        private static SeriesBookLink Link(int seriesId, string title, string position, bool isPrimary = true, int workCount = 0)
+        {
+            return new SeriesBookLink
+            {
+                SeriesId = seriesId,
+                Position = position,
+                SeriesPosition = int.TryParse(position, out var parsed) ? parsed : 0,
+                IsPrimary = isPrimary,
+                Series = new Series
+                {
+                    Id = seriesId,
+                    Title = title,
+                    PrimaryWorkCount = workCount
+                }
+            };
+        }
+
+        [Test]
+        public void should_take_title_and_position_from_the_same_link()
+        {
+            var links = new List<SeriesBookLink>
+            {
+                Link(2, "The Cosmere Universe", "6", workCount: 40),
+                Link(1, "The Stormlight Archive", "1", workCount: 5)
+            };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("The Stormlight Archive #1"));
+        }
+
+        [Test]
+        public void should_prefer_the_narrower_series_over_the_umbrella()
+        {
+            var links = new List<SeriesBookLink>
+            {
+                Link(2, "The Cosmere Universe", "16", workCount: 40),
+                Link(1, "Mistborn, Era 2: Wax & Wayne", "4", workCount: 4)
+            };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("Mistborn, Era 2: Wax & Wayne #4"));
+        }
+
+        [Test]
+        public void should_prefer_primary_slot_over_a_narrower_companion_series()
+        {
+            var links = new List<SeriesBookLink>
+            {
+                Link(2, "Companion Novellas", "1", isPrimary: false, workCount: 2),
+                Link(1, "Malazan Book of the Fallen", "9", isPrimary: true, workCount: 10)
+            };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("Malazan Book of the Fallen #9"));
+        }
+
+        [Test]
+        public void should_prefer_a_link_that_carries_a_position()
+        {
+            var links = new List<SeriesBookLink>
+            {
+                Link(1, "Unnumbered Collection", null, workCount: 3),
+                Link(2, "Red Rising Saga", "2", workCount: 6)
+            };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("Red Rising Saga #2"));
+        }
+
+        [Test]
+        public void should_omit_the_position_when_the_link_has_none()
+        {
+            var links = new List<SeriesBookLink> { Link(1, "Discworld", null) };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("Discworld"));
+        }
+
+        [Test]
+        public void should_ignore_links_whose_series_has_no_title()
+        {
+            var links = new List<SeriesBookLink>
+            {
+                new SeriesBookLink { SeriesId = 1, Position = "1", IsPrimary = true },
+                Link(2, "  ", "2"),
+                Link(3, "Dresden Files", "3")
+            };
+
+            Assert.That(BookSeriesLabel.Build(links), Is.EqualTo("Dresden Files #3"));
+        }
+
+        [Test]
+        public void should_return_null_when_there_are_no_links()
+        {
+            Assert.That(BookSeriesLabel.Build(null), Is.Null);
+            Assert.That(BookSeriesLabel.Build(new List<SeriesBookLink>()), Is.Null);
+        }
+
+        [Test]
+        public void should_pick_the_same_link_regardless_of_input_order()
+        {
+            var first = Link(7, "Same Size Series A", "1", workCount: 4);
+            var second = Link(9, "Same Size Series B", "1", workCount: 4);
+
+            var forward = BookSeriesLabel.Build(new List<SeriesBookLink> { first, second });
+            var reversed = BookSeriesLabel.Build(new List<SeriesBookLink> { second, first });
+
+            Assert.That(forward, Is.EqualTo(reversed));
+        }
+
+        [Test]
+        public void format_should_join_title_and_position()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(BookSeriesLabel.Format("Discworld", "8"), Is.EqualTo("Discworld #8"));
+                Assert.That(BookSeriesLabel.Format("Discworld", null), Is.EqualTo("Discworld"));
+                Assert.That(BookSeriesLabel.Format("Discworld", "  "), Is.EqualTo("Discworld"));
+                Assert.That(BookSeriesLabel.Format(null, "8"), Is.Null);
+                Assert.That(BookSeriesLabel.Format("   ", "8"), Is.Null);
+            });
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/Books/BookServiceResyncDenormalizedSeriesFieldsFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookServiceResyncDenormalizedSeriesFieldsFixture.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Linq.Expressions;
+using NLog;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Datastore;
+using NzbDrone.Core.Qualities;
+
+namespace Chaptarr.Core.Test.Books
+{
+    [TestFixture]
+    public class BookServiceResyncDenormalizedSeriesFieldsFixture
+    {
+        private const int AuthorId = 7;
+
+        [Test]
+        public void should_rewrite_stale_series_fields_from_the_links()
+        {
+            var book = new Book
+            {
+                Id = 1,
+                AuthorId = AuthorId,
+                Title = "Dust of Dreams",
+                SeriesName = "La caduta di Malazan",
+                SeriesPosition = "28"
+            };
+
+            var links = new List<SeriesBookLink>
+            {
+                Link(book.Id, 3447, "Malazan Book of the Fallen", "9")
+            };
+
+            var repo = new StubBookRepository(book);
+            var sut = BuildService(repo, new StubSeriesBookLinkRepository(links));
+
+            var repaired = sut.ResyncDenormalizedSeriesFields(AuthorId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(repaired, Is.EqualTo(1));
+                Assert.That(book.SeriesName, Is.EqualTo("Malazan Book of the Fallen"));
+                Assert.That(book.SeriesPosition, Is.EqualTo("9"));
+                Assert.That(repo.UpdatedBookIds, Is.EquivalentTo(new[] { book.Id }));
+            });
+        }
+
+        [Test]
+        public void should_leave_books_without_links_untouched()
+        {
+            var book = new Book
+            {
+                Id = 2,
+                AuthorId = AuthorId,
+                Title = "Wuthering Heights",
+                SeriesName = "Jardín Secreto",
+                SeriesPosition = "1"
+            };
+
+            var repo = new StubBookRepository(book);
+            var sut = BuildService(repo, new StubSeriesBookLinkRepository(new List<SeriesBookLink>()));
+
+            var repaired = sut.ResyncDenormalizedSeriesFields(AuthorId);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(repaired, Is.Zero);
+                Assert.That(book.SeriesName, Is.EqualTo("Jardín Secreto"));
+                Assert.That(repo.UpdatedBookIds, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_not_write_when_the_stored_pair_already_matches()
+        {
+            var book = new Book
+            {
+                Id = 3,
+                AuthorId = AuthorId,
+                Title = "Gardens of the Moon",
+                SeriesName = "Malazan Book of the Fallen",
+                SeriesPosition = "1"
+            };
+
+            var links = new List<SeriesBookLink>
+            {
+                Link(book.Id, 3447, "Malazan Book of the Fallen", "1")
+            };
+
+            var repo = new StubBookRepository(book);
+            var sut = BuildService(repo, new StubSeriesBookLinkRepository(links));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sut.ResyncDenormalizedSeriesFields(AuthorId), Is.Zero);
+                Assert.That(repo.UpdatedBookIds, Is.Empty);
+            });
+        }
+
+        private static SeriesBookLink Link(int bookId, int seriesId, string title, string position)
+        {
+            return new SeriesBookLink
+            {
+                BookId = bookId,
+                SeriesId = seriesId,
+                Position = position,
+                SeriesPosition = int.TryParse(position, out var parsed) ? parsed : 0,
+                IsPrimary = true,
+                Series = new Series { Id = seriesId, Title = title, PrimaryWorkCount = 10 }
+            };
+        }
+
+        private static BookService BuildService(StubBookRepository bookRepository, StubSeriesBookLinkRepository linkRepository)
+        {
+            return new BookService(
+                bookRepository,
+                editionService: null,
+                eventAggregator: null,
+                authorService: null,
+                mediaFileService: null,
+                rootFolderService: null,
+                seriesBookLinkRepository: linkRepository,
+                multiCopySeriesService: null,
+                logger: LogManager.GetCurrentClassLogger());
+        }
+
+        private sealed class StubBookRepository : IBookRepository
+        {
+            private readonly List<Book> _books;
+
+            public StubBookRepository(params Book[] books)
+            {
+                _books = (books ?? Array.Empty<Book>()).Where(b => b != null).ToList();
+            }
+
+            public List<int> UpdatedBookIds { get; } = new List<int>();
+
+            public List<Book> GetBooksByAuthorId(int authorId) => _books.Where(b => b.AuthorId == authorId).ToList();
+
+            public void SetFields(IList<Book> models, params Expression<Func<Book, object>>[] properties)
+            {
+                UpdatedBookIds.AddRange(models.Select(b => b.Id));
+            }
+
+            public List<Book> GetBooks(int authorId) => GetBooksByAuthorId(authorId);
+
+            public IEnumerable<Book> All() => throw new NotImplementedException();
+            public int Count() => throw new NotImplementedException();
+            public Book Find(int id) => throw new NotImplementedException();
+            public Book Get(int id) => throw new NotImplementedException();
+            public IEnumerable<Book> Get(IEnumerable<int> ids) => throw new NotImplementedException();
+            public Book Insert(Book model) => throw new NotImplementedException();
+            public Book Update(Book model) => throw new NotImplementedException();
+            public Book Upsert(Book model) => throw new NotImplementedException();
+            public void SetFields(Book model, params Expression<Func<Book, object>>[] properties) => throw new NotImplementedException();
+            public void Delete(Book model) => throw new NotImplementedException();
+            public void Delete(int id) => throw new NotImplementedException();
+            public void InsertMany(IList<Book> model) => throw new NotImplementedException();
+            public void InsertMany(IList<Book> model, IDbConnection connection, IDbTransaction transaction) => throw new NotImplementedException();
+            public void UpdateMany(IList<Book> model) => throw new NotImplementedException();
+            public void DeleteMany(List<Book> model) => throw new NotImplementedException();
+            public void DeleteMany(IEnumerable<int> ids) => throw new NotImplementedException();
+            public void Purge(bool vacuum = false) => throw new NotImplementedException();
+            public bool HasItems() => throw new NotImplementedException();
+            public Book Single() => throw new NotImplementedException();
+            public Book SingleOrDefault() => throw new NotImplementedException();
+            public PagingSpec<Book> GetPaged(PagingSpec<Book> pagingSpec) => throw new NotImplementedException();
+            public List<Book> GetLastBooks(IEnumerable<int> authorIds) => throw new NotImplementedException();
+            public List<Book> GetNextBooks(IEnumerable<int> authorIds) => throw new NotImplementedException();
+            public List<Book> GetBooksForRefresh(int authorId, IEnumerable<string> providerIds) => throw new NotImplementedException();
+            public List<Book> GetBooksByFileIds(IEnumerable<int> fileIds) => throw new NotImplementedException();
+            public Book FindByTitle(int authorId, string title) => throw new NotImplementedException();
+            public Book FindByIsbn(string isbn) => throw new NotImplementedException();
+            public Book FindByAsin(string asin) => throw new NotImplementedException();
+            public Book FindByProviderIds(string hardcoverBookId = null, string goodreadsBookId = null, string openLibraryWorkId = null) => throw new NotImplementedException();
+            public Book FindByProviderIdAndMediaType(string provider, string providerId, BookMediaType mediaType) => throw new NotImplementedException();
+            public List<Book> FindAllByProviderIdAndMediaType(string provider, string providerId, BookMediaType mediaType) => throw new NotImplementedException();
+            public Book FindBySlug(string titleSlug) => throw new NotImplementedException();
+            public PagingSpec<Book> BooksWithoutFiles(PagingSpec<Book> pagingSpec) => throw new NotImplementedException();
+            public PagingSpec<Book> BooksWhereCutoffUnmet(PagingSpec<Book> pagingSpec, List<QualitiesBelowCutoff> qualitiesBelowCutoff) => throw new NotImplementedException();
+            public List<Book> BooksBetweenDates(DateTime startDate, DateTime endDate, bool includeUnmonitored) => throw new NotImplementedException();
+            public List<Book> AuthorBooksBetweenDates(Author author, DateTime startDate, DateTime endDate, bool includeUnmonitored) => throw new NotImplementedException();
+            public void SetMonitoredFlat(Book book, bool monitored) => throw new NotImplementedException();
+            public void SetMonitored(IEnumerable<int> ids, bool monitored) => throw new NotImplementedException();
+            public void SetMonitoredForMediaType(IEnumerable<int> ids, string mediaType, bool monitored) => throw new NotImplementedException();
+            public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
+            public List<Book> GetBooksBySeries(int seriesId) => throw new NotImplementedException();
+            public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
+            public void SetMonitoringForAuthorBooks(int authorId, string mediaType, bool monitored) => throw new NotImplementedException();
+            public void UpdateMonitoringByAuthorAndMediaType(int authorId, BookMediaType mediaType, bool monitored, IEnumerable<int> exceptBookIds = null) => throw new NotImplementedException();
+            public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();
+            public PagedBookResource GetBooksPaged(int offset, int pageSize, string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();
+        }
+
+        private sealed class StubSeriesBookLinkRepository : ISeriesBookLinkRepository
+        {
+            private readonly List<SeriesBookLink> _links;
+
+            public StubSeriesBookLinkRepository(List<SeriesBookLink> links)
+            {
+                _links = links ?? new List<SeriesBookLink>();
+            }
+
+            public List<SeriesBookLink> GetLinksByBook(List<int> bookIds)
+            {
+                var ids = bookIds?.ToHashSet() ?? new HashSet<int>();
+                return _links.Where(l => ids.Contains(l.BookId)).ToList();
+            }
+
+            public HashSet<int> GetClaimedBookIdsForSeriesIdentity(BookMediaType mediaType, string goodreadsSeriesId) => new HashSet<int>();
+
+            public IEnumerable<SeriesBookLink> All() => throw new NotImplementedException();
+            public int Count() => throw new NotImplementedException();
+            public SeriesBookLink Find(int id) => throw new NotImplementedException();
+            public SeriesBookLink Get(int id) => throw new NotImplementedException();
+            public IEnumerable<SeriesBookLink> Get(IEnumerable<int> ids) => throw new NotImplementedException();
+            public SeriesBookLink Insert(SeriesBookLink model) => throw new NotImplementedException();
+            public SeriesBookLink Update(SeriesBookLink model) => throw new NotImplementedException();
+            public SeriesBookLink Upsert(SeriesBookLink model) => throw new NotImplementedException();
+            public void SetFields(SeriesBookLink model, params Expression<Func<SeriesBookLink, object>>[] properties) => throw new NotImplementedException();
+            public void SetFields(IList<SeriesBookLink> models, params Expression<Func<SeriesBookLink, object>>[] properties) => throw new NotImplementedException();
+            public void Delete(SeriesBookLink model) => throw new NotImplementedException();
+            public void Delete(int id) => throw new NotImplementedException();
+            public void InsertMany(IList<SeriesBookLink> model) => throw new NotImplementedException();
+            public void InsertMany(IList<SeriesBookLink> model, IDbConnection connection, IDbTransaction transaction) => throw new NotImplementedException();
+            public void UpdateMany(IList<SeriesBookLink> model) => throw new NotImplementedException();
+            public void DeleteMany(List<SeriesBookLink> model) => throw new NotImplementedException();
+            public void DeleteMany(IEnumerable<int> ids) => throw new NotImplementedException();
+            public void Purge(bool vacuum = false) => throw new NotImplementedException();
+            public bool HasItems() => throw new NotImplementedException();
+            public SeriesBookLink Single() => throw new NotImplementedException();
+            public SeriesBookLink SingleOrDefault() => throw new NotImplementedException();
+            public PagingSpec<SeriesBookLink> GetPaged(PagingSpec<SeriesBookLink> pagingSpec) => throw new NotImplementedException();
+            public List<SeriesBookLink> GetLinksBySeries(int seriesId) => throw new NotImplementedException();
+            public List<SeriesBookLink> GetLinksBySeriesAndAuthor(int seriesId, string foreignAuthorId) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/BookSeriesLabel.cs
+++ b/src/NzbDrone.Core/Books/BookSeriesLabel.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Common.Extensions;
+
+namespace NzbDrone.Core.Books
+{
+    /// <summary>
+    /// Picks the single <see cref="SeriesBookLink"/> that represents a book for display, and formats
+    /// the "Title #Position" label from it.
+    ///
+    /// The links are the authoritative series membership: they are reconciled on every refresh and
+    /// carry the position that belongs to that specific series. The denormalized
+    /// <see cref="Book.SeriesName"/>/<see cref="Book.SeriesPosition"/> pair is stamped once when the
+    /// book is added and can drift (wrong translation, wrong number, or a title from one series with
+    /// the number from another), so it is only a last-resort fallback for books with no links.
+    ///
+    /// Because both halves of the label always come from the same link, a book can never be labelled
+    /// with one series' title and a different series' number.
+    /// </summary>
+    public static class BookSeriesLabel
+    {
+        /// <summary>
+        /// Chooses the link that best represents the book:
+        /// primary slots first, then links that actually carry a position, then the most specific
+        /// series (an umbrella like "The Cosmere Universe" loses to "The Stormlight Archive"),
+        /// with stable tie-breakers so the same book always resolves to the same series.
+        /// </summary>
+        public static SeriesBookLink SelectDisplayLink(IEnumerable<SeriesBookLink> links)
+        {
+            if (links == null)
+            {
+                return null;
+            }
+
+            return links
+                .Where(link => link != null && ResolveSeriesTitle(link).IsNotNullOrWhiteSpace())
+                .OrderByDescending(link => link.IsPrimary)
+                .ThenByDescending(link => link.Position.IsNotNullOrWhiteSpace())
+                .ThenBy(link => GetSeriesSize(link))
+                .ThenBy(link => link.SeriesPosition <= 0 ? int.MaxValue : link.SeriesPosition)
+                .ThenBy(link => ResolveSeriesTitle(link), StringComparer.OrdinalIgnoreCase)
+                .ThenBy(link => link.SeriesId)
+                .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Builds the display label ("Malazan Book of the Fallen #9") for the book's series links,
+        /// or null when none of them resolve to a titled series.
+        /// </summary>
+        public static string Build(IEnumerable<SeriesBookLink> links)
+        {
+            var link = SelectDisplayLink(links);
+
+            return link == null
+                ? null
+                : Format(ResolveSeriesTitle(link), link.Position);
+        }
+
+        /// <summary>
+        /// Every label this book could legitimately be shown under, one per link. Used where a match
+        /// against any of the book's series is wanted rather than the single display label.
+        /// </summary>
+        public static IEnumerable<string> BuildAll(IEnumerable<SeriesBookLink> links)
+        {
+            if (links == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            return links
+                .Where(link => link != null)
+                .Select(link => Format(ResolveSeriesTitle(link), link.Position))
+                .Where(label => label != null)
+                .ToList();
+        }
+
+        /// <summary>
+        /// Formats a series title and position into the display label used across the app.
+        /// </summary>
+        public static string Format(string seriesTitle, string position)
+        {
+            if (seriesTitle.IsNullOrWhiteSpace())
+            {
+                return null;
+            }
+
+            return position.IsNullOrWhiteSpace()
+                ? seriesTitle.Trim()
+                : $"{seriesTitle.Trim()} #{position.Trim()}";
+        }
+
+        private static string ResolveSeriesTitle(SeriesBookLink link)
+        {
+            return link?.Series?.Value?.Title;
+        }
+
+        /// <summary>
+        /// How many books the series holds, used to prefer the narrower series. Series that don't
+        /// report a size sort last so a known-size series always wins over an unknown one.
+        /// </summary>
+        private static int GetSeriesSize(SeriesBookLink link)
+        {
+            var series = link?.Series?.Value;
+            if (series == null)
+            {
+                return int.MaxValue;
+            }
+
+            foreach (var count in new[] { series.PrimaryWorkCount, series.PrimaryBooks, series.WorkCount, series.TotalBooks })
+            {
+                if (count > 0)
+                {
+                    return count;
+                }
+            }
+
+            return int.MaxValue;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/Services/BookService.cs
+++ b/src/NzbDrone.Core/Books/Services/BookService.cs
@@ -30,6 +30,8 @@ namespace NzbDrone.Core.Books
         List<Book> GetLastBooksByAuthorId(IEnumerable<int> authorIds);
         List<Book> GetBooksByAuthorId(int authorId);
         List<Book> GetBooksForRefresh(int authorId, List<string> foreignIds);
+
+        int ResyncDenormalizedSeriesFields(int authorId) => 0;
         List<Book> GetBooksByFileIds(IEnumerable<int> fileIds);
         Book AddBook(Book newBook, bool doRefresh = true);
         Book FindBySlug(string titleSlug);
@@ -995,6 +997,52 @@ namespace NzbDrone.Core.Books
         public List<Book> GetBooksForRefresh(int authorId, List<string> foreignIds)
         {
             return _bookRepository.GetBooksForRefresh(authorId, foreignIds);
+        }
+
+        public int ResyncDenormalizedSeriesFields(int authorId)
+        {
+            var books = GetBooksByAuthorId(authorId);
+            var repaired = new List<Book>();
+
+            foreach (var book in books.Where(b => b != null && b.Id > 0))
+            {
+                var link = BookSeriesLabel.SelectDisplayLink(book.SeriesLinks);
+                if (link == null)
+                {
+                    // No links can mean "not in a series" or "series not linked yet". Leave the stored
+                    // pair alone either way: the API reads the links, and blanking it here would throw
+                    // away the only series context file naming has for unlinked books.
+                    continue;
+                }
+
+                var seriesName = link.Series?.Value?.Title?.Trim();
+                var seriesPosition = link.Position?.Trim();
+
+                if (seriesPosition.IsNullOrWhiteSpace())
+                {
+                    seriesPosition = null;
+                }
+
+                if (book.SeriesName == seriesName && book.SeriesPosition == seriesPosition)
+                {
+                    continue;
+                }
+
+                _logger.Debug("[SERIES] Repairing denormalized series for book {0} '{1}': '{2} #{3}' -> '{4} #{5}'",
+                    book.Id, book.Title, book.SeriesName, book.SeriesPosition, seriesName, seriesPosition);
+
+                book.SeriesName = seriesName;
+                book.SeriesPosition = seriesPosition;
+                repaired.Add(book);
+            }
+
+            if (repaired.Any())
+            {
+                _bookRepository.SetFields(repaired, b => b.SeriesName, b => b.SeriesPosition);
+                _logger.Debug("[SERIES] Repaired denormalized series fields on {0} book(s) for authorId {1}", repaired.Count, authorId);
+            }
+
+            return repaired.Count;
         }
 
         public List<Book> GetBooksByFileIds(IEnumerable<int> fileIds)

--- a/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
@@ -157,7 +157,9 @@ namespace NzbDrone.Core.Books
                         SeriesPosition = int.TryParse(seriesBook.Position, out var pos) ? pos : 0,
                         Book = matchingBook,
                         BookId = matchingBook.Id,
-                        IsPrimary = true,
+
+                        // Null means upstream didn't report the slot (pre-2026-06-02 rows); assume primary.
+                        IsPrimary = seriesBook.IsPrimary ?? true,
                         SeriesInstanceType = seriesInstanceType
                     });
                 }
@@ -355,7 +357,9 @@ namespace NzbDrone.Core.Books
                             SeriesPosition = int.TryParse(seriesBook.Position, out var pos) ? pos : 0,
                             Book = matchingBook,
                             BookId = matchingBook.Id,
-                            IsPrimary = true,
+
+                            // Null means upstream didn't report the slot (pre-2026-06-02 rows); assume primary.
+                            IsPrimary = seriesBook.IsPrimary ?? true,
                             SeriesInstanceType = seriesInstanceType
                         };
 
@@ -595,6 +599,15 @@ namespace NzbDrone.Core.Books
             foreach (var item in all)
             {
                 updated |= RefreshEntityInfo(item, providerBackedRemoteSeries, remoteData, forceBookRefresh, forceUpdateFileTags, lastUpdate);
+            }
+
+            try
+            {
+                _bookService.ResyncDenormalizedSeriesFields(authorId);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "[SERIES] Failed to repair denormalized series fields for authorId {0}", authorId);
             }
 
             return updated;

--- a/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
+++ b/src/NzbDrone.Core/Organizer/FileNameBuilder.cs
@@ -430,7 +430,7 @@ namespace NzbDrone.Core.Organizer
 
             // Fall back to SeriesLinks if present (not always loaded during renaming).
             var seriesLinks = edition.Book?.SeriesLinks;
-            var primarySeries = seriesLinks?.OrderBy(x => x.SeriesPosition).FirstOrDefault();
+            var primarySeries = BookSeriesLabel.SelectDisplayLink(seriesLinks);
 
             if (seriesName.IsNullOrWhiteSpace())
             {


### PR DESCRIPTION
#### Description
Fixes #34.

Series labels come from `Book.SeriesName`/`SeriesPosition`, stamped once at add time and never re-derived — so books show a series in the wrong language, a number borrowed from another series (`The Way of Kings` → `The Cosmere Universe #1`, where the `1` is Stormlight's), or a series on a book that isn't in one. Building Ruddarr for iOS made it worse: a book turns up under several alias series from different sources, and the label can't be matched back to one — `gr:135117` is `The Cosmere Universe` in the scalar and `The Cosmere` in the links.

`SeriesBookLink` is reconciled on every refresh, so it becomes authoritative. `BookSeriesLabel` picks one link and formats `Title #Position` from it, so both halves always come from the same series; the API, `FileNameBuilder` and a refresh-time repair all use it. Also exposes `seriesType`/`parentSeriesId` so clients get the hierarchy instead of inferring it.

#### Database Migration
NO. No schema change, but a refresh rewrites existing `Books.SeriesName`/`SeriesPosition` from the links — that's what repairs already-added books. Books without links are untouched.

#### How was this tested?
New fixtures in `Chaptarr.Core.Test/Books`: `BookSeriesLabelFixture`, `BookResourceSeriesTitleFixture`, `BookServiceResyncDenormalizedSeriesFieldsFixture`.
