### PR TITLE
Fix author progress for future releases

### DIFF
--- a/frontend/src/Author/Index/ProgressBar/AuthorIndexProgressBar.js
+++ b/frontend/src/Author/Index/ProgressBar/AuthorIndexProgressBar.js
@@ -18,8 +18,8 @@ function AuthorIndexProgressBar(props) {
     detailedProgressBar
   } = props;
 
-  // Calculate progress as: % of monitored books that have files
-  // bookCount = monitored books, availableBookCount = monitored books with files
+  // Future releases are excluded from both counts by the author statistics query.
+  // bookCount = released monitored books, availableBookCount = released monitored books with files.
   const progress = bookCount > 0 ? (availableBookCount / bookCount) * 100 : 100;
   const text = `${availableBookCount} / ${bookCount}`;
 

--- a/frontend/src/Author/Index/Table/AuthorIndexRow.js
+++ b/frontend/src/Author/Index/Table/AuthorIndexRow.js
@@ -289,7 +289,7 @@ class AuthorIndexRow extends Component {
             }
 
             if (name === 'bookProgress') {
-              const progress = totalBookCount ? (bookCount / totalBookCount) * 100 : 100;
+              const progress = bookCount ? (availableBookCount / bookCount) * 100 : 100;
 
               return (
                 <VirtualTableRowCell
@@ -300,7 +300,7 @@ class AuthorIndexRow extends Component {
                     progress={progress}
                     kind={getProgressBarKind(status, monitored, progress)}
                     showText={true}
-                    text={`${bookCount} / ${totalBookCount}`}
+                    text={`${availableBookCount} / ${bookCount}`}
                     title={translate('AuthorProgressBarText', { bookCount, availableBookCount, bookFileCount, totalBookCount })}
                     width={125}
                   />

--- a/src/Chaptarr.Core.Test/AuthorStats/AuthorStatisticsRepositoryFixture.cs
+++ b/src/Chaptarr.Core.Test/AuthorStats/AuthorStatisticsRepositoryFixture.cs
@@ -78,6 +78,54 @@ namespace Chaptarr.Core.Test.AuthorStats
         }
 
         [Test]
+        public void should_exclude_monitored_future_releases_from_progress_for_both_media_types()
+        {
+            WithRepository((repository, connectionString) =>
+            {
+                using (var connection = new SqliteConnection(connectionString))
+                {
+                    connection.Open();
+                    connection.Execute(@"
+INSERT INTO ""Books"" (""Id"", ""AuthorId"", ""MediaType"", ""AudiobookMonitored"", ""EbookMonitored"", ""ReleaseDate"") VALUES
+    (30, 3, 1, 0, 1, @released),
+    (31, 3, 0, 1, 0, @released),
+    (32, 3, 1, 0, 1, @future),
+    (33, 3, 0, 1, 0, @future);
+INSERT INTO ""Editions"" (""Id"", ""BookId"", ""Monitored"") VALUES
+    (300, 30, 1),
+    (310, 31, 1);
+INSERT INTO ""BookFiles"" (""Id"", ""EditionId"", ""Size"") VALUES
+    (3000, 300, 10),
+    (3100, 310, 20);",
+                        new
+                        {
+                            released = DateTime.UtcNow.AddDays(-1),
+                            future = DateTime.UtcNow.AddDays(1)
+                        });
+                }
+
+                var allStats = repository.AuthorStatistics(3);
+                var ebookStats = repository.AuthorStatistics(3, "ebook");
+                var audiobookStats = repository.AuthorStatistics(3, "audiobook");
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(allStats.Sum(stat => stat.BookCount), Is.EqualTo(2));
+                    Assert.That(allStats.Sum(stat => stat.AvailableBookCount), Is.EqualTo(2));
+                    Assert.That(allStats.Sum(stat => stat.TotalBookCount), Is.EqualTo(4));
+
+                    Assert.That(ebookStats.Sum(stat => stat.BookCount), Is.EqualTo(1));
+                    Assert.That(ebookStats.Sum(stat => stat.AvailableBookCount), Is.EqualTo(1));
+                    Assert.That(ebookStats.Sum(stat => stat.TotalBookCount), Is.EqualTo(2));
+
+                    Assert.That(audiobookStats.Sum(stat => stat.BookCount), Is.EqualTo(1));
+                    Assert.That(audiobookStats.Sum(stat => stat.AvailableBookCount), Is.EqualTo(1));
+                    Assert.That(audiobookStats.Sum(stat => stat.TotalBookCount), Is.EqualTo(2));
+                });
+            });
+        }
+
+        [Test]
         public void aggregate_should_count_file_bearing_books_once()
         {
             WithRepository((repository, _) =>
@@ -133,7 +181,8 @@ CREATE TABLE ""Books"" (
     ""AuthorId"" INTEGER NOT NULL,
     ""MediaType"" INTEGER NOT NULL,
     ""AudiobookMonitored"" INTEGER NOT NULL,
-    ""EbookMonitored"" INTEGER NOT NULL
+    ""EbookMonitored"" INTEGER NOT NULL,
+    ""ReleaseDate"" TEXT NULL
 );
 CREATE TABLE ""Editions"" (
     ""Id"" INTEGER PRIMARY KEY,
@@ -146,7 +195,7 @@ CREATE TABLE ""BookFiles"" (
     ""Size"" INTEGER NOT NULL
 );
 
-INSERT INTO ""Authors"" (""Id"") VALUES (1), (2);
+INSERT INTO ""Authors"" (""Id"") VALUES (1), (2), (3);
 INSERT INTO ""Books"" (""Id"", ""AuthorId"", ""MediaType"", ""AudiobookMonitored"", ""EbookMonitored"") VALUES
     (10, 1, 0, 1, 0),
     (11, 1, 1, 0, 1),

--- a/src/Chaptarr.Core.Test/AuthorStats/AuthorStatisticsSqlParityFixture.cs
+++ b/src/Chaptarr.Core.Test/AuthorStats/AuthorStatisticsSqlParityFixture.cs
@@ -31,6 +31,8 @@ namespace Chaptarr.Core.Test.AuthorStats
                 StringAssert.Contains("CROSS JOIN \"Editions\"", authorSql);
                 StringAssert.Contains("GROUP BY \"Editions\".\"BookId\"", authorSql);
                 StringAssert.Contains(booleanComparison, authorSql);
+                StringAssert.Contains(@"""Books"".""ReleaseDate"" <= @currentDate", authorSql);
+                StringAssert.Contains(@"""Books"".""ReleaseDate"" IS NULL", authorSql);
                 StringAssert.DoesNotContain("MIN(\"BookFiles\"", authorSql);
 
                 StringAssert.Contains("FROM \"Books\"", aggregateSql);

--- a/src/NzbDrone.Core/AuthorStats/AuthorStatisticsRepository.cs
+++ b/src/NzbDrone.Core/AuthorStats/AuthorStatisticsRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Dapper;
@@ -133,6 +134,7 @@ namespace NzbDrone.Core.AuthorStats
         private static SqlBuilder Builder(DatabaseType databaseType)
         {
             var trueIndicator = databaseType == DatabaseType.PostgreSQL ? "true" : "1";
+            const string bookIsAvailable = @"(""Books"".""ReleaseDate"" <= @currentDate OR ""Books"".""ReleaseDate"" IS NULL)";
 
             return new SqlBuilder(databaseType)
                 .Select($@"""Authors"".""Id"" AS ""AuthorId"",
@@ -144,18 +146,19 @@ namespace NzbDrone.Core.AuthorStats
                              ELSE 0
                          END AS ""TotalBookCount"",
                          CASE
-                             WHEN ""Books"".""MediaType"" = 0 AND ""Books"".""AudiobookMonitored"" = {trueIndicator} AND COALESCE(""FileStatistics"".""BookFileCount"", 0) > 0 THEN 1
-                             WHEN ""Books"".""MediaType"" = 1 AND ""Books"".""EbookMonitored"" = {trueIndicator} AND COALESCE(""FileStatistics"".""BookFileCount"", 0) > 0 THEN 1
+                             WHEN ""Books"".""MediaType"" = 0 AND ""Books"".""AudiobookMonitored"" = {trueIndicator} AND {bookIsAvailable} AND COALESCE(""FileStatistics"".""BookFileCount"", 0) > 0 THEN 1
+                             WHEN ""Books"".""MediaType"" = 1 AND ""Books"".""EbookMonitored"" = {trueIndicator} AND {bookIsAvailable} AND COALESCE(""FileStatistics"".""BookFileCount"", 0) > 0 THEN 1
                              ELSE 0
                          END AS ""AvailableBookCount"",
                          CASE
-                             WHEN ""Books"".""MediaType"" = 0 AND ""Books"".""AudiobookMonitored"" = {trueIndicator} THEN 1
-                             WHEN ""Books"".""MediaType"" = 1 AND ""Books"".""EbookMonitored"" = {trueIndicator} THEN 1
+                             WHEN ""Books"".""MediaType"" = 0 AND ""Books"".""AudiobookMonitored"" = {trueIndicator} AND {bookIsAvailable} THEN 1
+                             WHEN ""Books"".""MediaType"" = 1 AND ""Books"".""EbookMonitored"" = {trueIndicator} AND {bookIsAvailable} THEN 1
                              ELSE 0
                          END AS ""BookCount"",
                          COALESCE(""FileStatistics"".""BookFileCount"", 0) AS ""BookFileCount""")
                 .Join<Book, Author>((book, author) => book.AuthorId == author.Id)
-                .LeftJoin(_fileStatisticsJoin);
+                .LeftJoin(_fileStatisticsJoin)
+                .AddParameters(new { currentDate = DateTime.UtcNow });
         }
 
         private static SqlBuilder AggregateBuilder(DatabaseType databaseType)


### PR DESCRIPTION
#### Description

Author progress currently counts monitored future releases as missing. This keeps an author poster red even when every released monitored title has a file.

This change:

- excludes books with a future `ReleaseDate` from both the available and required progress counts, while retaining `NULL` dates for the existing fallback behavior;
- applies the same logic to audiobook and ebook statistics;
- aligns the author table progress calculation with the poster and overview calculation; and
- adds repository and SQL parity coverage for both media types.

The issue was reported from an Unraid Docker installation. The fix is intentionally limited to progress statistics and does not change monitoring or future-release visibility.

Fixes #51

#### Database Migration

NO.

#### Breaking Changes

None.

#### How was this tested?

Local Windows test environment, based on the latest `develop` commit (`2587323`):

- Targeted author statistics tests: 7 passed, including released/future audiobook and ebook cases.
- `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj`: 2,770 passed, 2 skipped, and 2 unrelated existing failures remained (`should_stage_matched_provider_chapters_when_source_duration_matches` and the locale-sensitive decimal assertion in `should_use_scaled_duration_tolerance_for_output_validation`).
- TypeScript typecheck: passed.
- Translation key check: passed (1,576 files scanned).
- Production Webpack build: passed.
- Full frontend lint reports 1,478 existing repository-wide findings on unchanged code. Linting the two touched UI files reports only the pre-existing unused `titleSlug` variable in `AuthorIndexRow.js`; this patch adds no new lint finding.

The repository test explicitly verifies the expected `2 / 2` released-title progress while the two monitored future titles remain included in the total catalog count (`4`).

#### Screenshots (UI changes only)

No visual styling is changed. For the Unraid reproduction shown in #51, the red `2 / 3` author progress becomes green `2 / 2`; the future release remains visible and marked as a future release.
