### PR TITLE
Fix: multi-format ebook downloads import a format the profile has disabled

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/ImportApprovedBooksEbookAlternativeFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/ImportApprovedBooksEbookAlternativeFixture.cs
@@ -69,6 +69,111 @@ namespace Chaptarr.Core.Test.MediaFiles
             Assert.That(importResults.All(r => r.Result == ImportResultType.Rejected), Is.True);
         }
 
+        [Test]
+        public void should_prefer_allowed_format_over_higher_ranked_disallowed_format()
+        {
+            var profile = new QualityProfile
+            {
+                Id = 1,
+                Name = "Ebooks",
+                ProfileType = ProfileType.Ebook,
+                Items = new List<QualityProfileQualityItem>
+                {
+                    new() { Allowed = false, Quality = Quality.PDF },
+                    new() { Allowed = false, Quality = Quality.MOBI },
+                    new() { Allowed = true, Quality = Quality.EPUB },
+                    new() { Allowed = false, Quality = Quality.AZW3 }
+                }
+            };
+
+            var author = BuildAuthor(profile);
+            var book = BuildBook(author);
+
+            var decisions = new List<ImportDecision<LocalBook>>
+            {
+                BuildDecision(book, author, Quality.AZW3, "/downloads/Best Served Cold - Joe Abercrombie.azw3"),
+                BuildDecision(book, author, Quality.EPUB, "/downloads/Best Served Cold - Joe Abercrombie.epub"),
+                BuildDecision(book, author, Quality.MOBI, "/downloads/Best Served Cold - Joe Abercrombie.mobi")
+            };
+
+            var importResults = new List<ImportResult>();
+            var subject = BuildSubject();
+
+            var retained = subject.SelectSingleEbookAlternative(decisions, author, importResults);
+
+            Assert.That(retained, Has.Count.EqualTo(1));
+            Assert.That(retained.Single().Item.Quality.Quality, Is.EqualTo(Quality.EPUB),
+                "the only profile-allowed format must win over a higher-ranked disabled format");
+            Assert.That(importResults, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void should_fall_back_to_profile_order_when_no_format_is_allowed()
+        {
+            var profile = new QualityProfile
+            {
+                Id = 1,
+                Name = "Ebooks",
+                ProfileType = ProfileType.Ebook,
+                Items = new List<QualityProfileQualityItem>
+                {
+                    new() { Allowed = false, Quality = Quality.PDF },
+                    new() { Allowed = false, Quality = Quality.MOBI },
+                    new() { Allowed = false, Quality = Quality.EPUB },
+                    new() { Allowed = false, Quality = Quality.AZW3 }
+                }
+            };
+
+            var author = BuildAuthor(profile);
+            var book = BuildBook(author);
+
+            var decisions = new List<ImportDecision<LocalBook>>
+            {
+                BuildDecision(book, author, Quality.EPUB, "/downloads/Best Served Cold - Joe Abercrombie.epub"),
+                BuildDecision(book, author, Quality.AZW3, "/downloads/Best Served Cold - Joe Abercrombie.azw3")
+            };
+
+            var importResults = new List<ImportResult>();
+            var subject = BuildSubject();
+
+            var retained = subject.SelectSingleEbookAlternative(decisions, author, importResults);
+
+            Assert.That(retained, Has.Count.EqualTo(1));
+            Assert.That(retained.Single().Item.Quality.Quality, Is.EqualTo(Quality.AZW3),
+                "with nothing allowed the existing profile-order pick should be preserved");
+        }
+
+        private static Author BuildAuthor(QualityProfile profile)
+        {
+            return new Author
+            {
+                Id = 38,
+                Name = "Joe Abercrombie",
+                EbookQualityProfileId = profile.Id,
+                EbookQualityProfile = profile
+            };
+        }
+
+        private static Book BuildBook(Author author)
+        {
+            return new Book
+            {
+                Id = 5792,
+                Title = "Best Served Cold",
+                Author = author,
+                AuthorId = author.Id,
+                MediaType = BookMediaType.Ebook
+            };
+        }
+
+        private static ImportApprovedBooks BuildSubject()
+        {
+            return new ImportApprovedBooks(
+                null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null,
+                LogManager.GetLogger("ImportApprovedBooksEbookAlternativeFixture"));
+        }
+
         private static ImportDecision<LocalBook> BuildDecision(Book book, Author author, Quality quality, string path)
         {
             return new ImportDecision<LocalBook>(new LocalBook

--- a/src/Chaptarr.Core.Test/MediaFiles/ImportApprovedBooksNotificationFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/ImportApprovedBooksNotificationFixture.cs
@@ -390,6 +390,174 @@ namespace Chaptarr.Core.Test.MediaFiles
             return (results, editionServiceProxy);
         }
 
+        private static (
+            List<ImportResult> Results,
+            StubMediaFileService MediaFiles,
+            StubMoveBookFiles Mover)
+            ImportMixedEbookPayload(bool downloadForced)
+        {
+            var qualityProfile = new QualityProfile
+            {
+                Id = 1,
+                Name = "EPUB only",
+                ProfileType = ProfileType.Ebook,
+                UpgradeAllowed = true,
+                Items = new List<QualityProfileQualityItem>
+                {
+                    new() { Allowed = false, Quality = Quality.MOBI },
+                    new() { Allowed = true, Quality = Quality.EPUB },
+                    new() { Allowed = false, Quality = Quality.AZW3 }
+                }
+            };
+
+            var author = new Author
+            {
+                Id = 38,
+                Name = "Joe Abercrombie",
+                EbookRootFolderPath = "/ebooks",
+                EbookPath = "/ebooks/Joe Abercrombie",
+                EbookQualityProfileId = qualityProfile.Id,
+                EbookQualityProfile = qualityProfile
+            };
+
+            var book = new Book
+            {
+                Id = 5792,
+                AuthorId = author.Id,
+                Author = author,
+                Title = "Best Served Cold",
+                CleanTitle = "bestservedcold",
+                MediaType = BookMediaType.Ebook,
+                AnyEditionOk = true
+            };
+
+            var edition = new Edition
+            {
+                Id = 15629,
+                BookId = book.Id,
+                Book = book,
+                Title = book.Title,
+                Monitored = true,
+                IsEbook = true
+            };
+
+            var mediaFileService = new StubMediaFileService();
+            var eventAggregator = new CapturingEventAggregator();
+            var mover = new StubMoveBookFiles
+            {
+                DestinationPath = "/ebooks/Joe Abercrombie/Best Served Cold/Best Served Cold.epub"
+            };
+
+            var bookService = DispatchProxy.Create<IBookService, BookServiceProxy>();
+            ((BookServiceProxy)(object)bookService).Book = book;
+
+            var authorService = DispatchProxy.Create<IAuthorService, AuthorServiceProxy>();
+            ((AuthorServiceProxy)(object)authorService).Author = author;
+
+            var editionService = DispatchProxy.Create<IEditionService, EditionServiceProxy>();
+            ((EditionServiceProxy)(object)editionService).Edition = edition;
+            ((EditionServiceProxy)(object)editionService).EditionsByBook = new List<Edition> { edition };
+
+            var service = new ImportApprovedBooks(
+                mediaFileService,
+                new StubMetadataTagService(),
+                new StubMediaInfoExtractor(),
+                authorService,
+                bookService,
+                editionService,
+                Proxy<IRecycleBinProvider>(),
+                Proxy<IExtraService>(),
+                mover,
+                Proxy<IHistoryService>(),
+                Proxy<NzbDrone.Core.Download.History.IDownloadHistoryService>(),
+                eventAggregator,
+                Proxy<IManageCommandQueue>(),
+                Proxy<ISeriesBookLinkService>(),
+                Proxy<ISeriesService>(),
+                Proxy<IQualityProfileService>(),
+                Proxy<IM4bConversionService>(),
+                LogManager.GetLogger("ImportApprovedBooksNotificationFixture"));
+
+            var decisions = new[]
+            {
+                (Quality: Quality.AZW3, Extension: "azw3"),
+                (Quality: Quality.EPUB, Extension: "epub"),
+                (Quality: Quality.MOBI, Extension: "mobi")
+            }
+            .Select(candidate => new ImportDecision<LocalBook>(new LocalBook
+            {
+                Path = $"/downloads/complete/Best Served Cold.{candidate.Extension}",
+                ExistingFile = false,
+                Book = book,
+                Author = author,
+                Edition = edition,
+                Quality = new QualityModel { Quality = candidate.Quality, Revision = new Revision() },
+                Part = 1,
+                PartCount = 1
+            }))
+            .ToList();
+
+            var results = service.Import(
+                decisions,
+                replaceExisting: true,
+                downloadClientItem: new DownloadClientItem
+                {
+                    DownloadId = "mixed-ebook-download",
+                    DownloadForced = downloadForced,
+                    DownloadClientInfo = new DownloadClientItemClientInfo { Name = "qBittorrent", Type = "qbittorrent" }
+                },
+                importMode: ImportMode.Move,
+                cancellationToken: CancellationToken.None);
+
+            return (results, mediaFileService, mover);
+        }
+
+        [Test]
+        public void interactive_grab_should_import_profile_allowed_ebook_from_multi_format_payload()
+        {
+            var import = ImportMixedEbookPayload(downloadForced: true);
+
+            Assert.That(import.Results, Has.Count.EqualTo(3));
+            Assert.That(import.Results.Count(result => result.Result == ImportResultType.Imported), Is.EqualTo(1));
+            Assert.That(import.Results.Count(result => result.Result == ImportResultType.Rejected), Is.EqualTo(2));
+
+            var imported = import.Results.Single(result => result.Result == ImportResultType.Imported);
+            Assert.That(imported.ImportDecision.Item.Quality.Quality, Is.EqualTo(Quality.EPUB));
+            Assert.That(import.MediaFiles.AddedFiles, Has.Count.EqualTo(1));
+            Assert.That(import.MediaFiles.AddedFiles.Single().Quality.Quality, Is.EqualTo(Quality.EPUB));
+            Assert.That(import.Mover.MoveCalls, Is.EqualTo(1));
+
+            var rejected = import.Results.Where(result => result.Result == ImportResultType.Rejected).ToList();
+            Assert.That(rejected.All(result =>
+                result.ImportDecision.Rejections.Single().Reason.Contains("Skipped duplicate ebook format")), Is.True);
+            Assert.That(rejected.All(result =>
+                !result.ImportDecision.Rejections.Single().IsQualityFilter), Is.True);
+        }
+
+        [Test]
+        public void automatic_grab_should_reject_disallowed_ebook_alternatives_before_selection()
+        {
+            var import = ImportMixedEbookPayload(downloadForced: false);
+
+            Assert.That(import.Results, Has.Count.EqualTo(3));
+            Assert.That(import.Results.Count(result => result.Result == ImportResultType.Imported), Is.EqualTo(1));
+            Assert.That(import.Results.Count(result => result.Result == ImportResultType.Rejected), Is.EqualTo(2));
+
+            var imported = import.Results.Single(result => result.Result == ImportResultType.Imported);
+            Assert.That(imported.ImportDecision.Item.Quality.Quality, Is.EqualTo(Quality.EPUB));
+            Assert.That(import.MediaFiles.AddedFiles, Has.Count.EqualTo(1));
+            Assert.That(import.MediaFiles.AddedFiles.Single().Quality.Quality, Is.EqualTo(Quality.EPUB));
+            Assert.That(import.Mover.MoveCalls, Is.EqualTo(1));
+
+            var rejected = import.Results.Where(result => result.Result == ImportResultType.Rejected).ToList();
+            Assert.That(rejected.All(result =>
+                result.ImportDecision.Rejections.Single().Type == RejectionType.Permanent), Is.True);
+            Assert.That(rejected.All(result =>
+                result.ImportDecision.Rejections.Single().IsQualityFilter), Is.True);
+            Assert.That(rejected.All(result =>
+                !result.ImportDecision.Rejections.Single().CanBypass), Is.True);
+        }
+
         [TestCase(false, true, ImportResultType.Skipped)]
         [TestCase(true, true, ImportResultType.Imported)]
         [TestCase(true, false, ImportResultType.Imported)]

--- a/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
@@ -782,7 +782,16 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 return bookDecisions;
             }
 
-            var winner = ebookCandidates.Aggregate((best, candidate) =>
+            // The profile comparer ranks purely by Items position and never reads
+            // Allowed, so a disallowed format placed above the preferred one would
+            // win this pick. Prefer allowed formats; fall back to the ranked pick
+            // only when the download contains no allowed format at all.
+            var allowedCandidates = ebookCandidates
+                .Where(candidate => IsQualityAllowedInProfile(author, candidate.Item?.Quality?.Quality))
+                .ToList();
+            var selectionPool = allowedCandidates.Any() ? allowedCandidates : ebookCandidates;
+
+            var winner = selectionPool.Aggregate((best, candidate) =>
                 CompareEbookImportCandidate(candidate, best, author) > 0 ? candidate : best);
 
             var skipped = ebookCandidates.Where(d => !ReferenceEquals(d, winner)).ToList();
@@ -818,6 +827,21 @@ namespace NzbDrone.Core.MediaFiles.BookImport
 
             return QualityMediaTypeHelper.IsEbookQuality(quality) ||
                    (quality == Qualities.Quality.Unknown && localBook.Book?.MediaType == BookMediaType.Ebook);
+        }
+
+        private static bool IsQualityAllowedInProfile(Author author, Qualities.Quality quality)
+        {
+            if (quality == null || quality == Qualities.Quality.Unknown)
+            {
+                return true;
+            }
+
+            var profile = author?.GetQualityProfileForQuality(quality);
+            var item = profile?.Items?.FirstOrDefault(i =>
+                (i.Quality != null && i.Quality.Id == quality.Id) ||
+                (i.Items?.Any(nested => nested.Quality != null && nested.Quality.Id == quality.Id) ?? false));
+
+            return item?.Allowed ?? true;
         }
 
         private static int CompareEbookImportCandidate(

--- a/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
@@ -837,11 +837,9 @@ namespace NzbDrone.Core.MediaFiles.BookImport
             }
 
             var profile = author?.GetQualityProfileForQuality(quality);
-            var item = profile?.Items?.FirstOrDefault(i =>
-                (i.Quality != null && i.Quality.Id == quality.Id) ||
-                (i.Items?.Any(nested => nested.Quality != null && nested.Quality.Id == quality.Id) ?? false));
-
-            return item?.Allowed ?? true;
+            return profile == null ||
+                   profile.Items.Any(item =>
+                       item.Allowed && item.GetQualities().Any(candidate => candidate.Id == quality.Id));
         }
 
         private static int CompareEbookImportCandidate(


### PR DESCRIPTION
## The bug (reported on Discord)

A grabbed release contains several text formats for the same book (e.g. EPUB + AZW3 + MOBI). The quality profile allows **only EPUB**, with AZW3 disabled but sitting higher in the list. On import, Chaptarr picks and imports the **AZW3** and rejects the EPUB as a duplicate format.

## Root cause

`SelectSingleEbookAlternative` reduces the download's formats to one winner using `CompareEbookImportCandidate`, which defers to `QualityModelComparer`. That comparer ranks purely by position in the profile's `Items` list — `Allowed` is never consulted anywhere in the pick (`QualityProfile.GetIndex` walks positions only). Disabled therefore means "don't grab" at search time but is invisible at import time, so a disallowed format ranked above the preferred one wins.

This also explains the known workaround (moving EPUB to the top of the list): reordering changes the comparer's ranking even though the checkboxes do nothing.

## Fix

Partition the download's candidates into profile-allowed vs disallowed before running the winner aggregation, and pick from the allowed set whenever it is non-empty. List order still breaks ties within the allowed set.

**Open question for review:** when the download contains *no* allowed format at all, this PR falls back to the existing ranked pick rather than rejecting everything — importing something seemed better than stranding the download at import-blocked. If you'd rather hard-reject in that case, happy to change it.

## Tests

Extended `ImportApprovedBooksEbookAlternativeFixture`:
- `should_prefer_allowed_format_over_higher_ranked_disallowed_format` — written first against the unpatched code, where it fails with `Expected: <EPUB> But was: <AZW3>`, reproducing the report exactly; passes with the fix
- `should_fall_back_to_profile_order_when_no_format_is_allowed` — pins the fallback behaviour
- Existing all-formats-allowed test unchanged and passing

Full MediaFiles suite: 705/705 passing.