### PR TITLE
Fix: one case-duplicate path collapses the entire unmapped page to per-file units

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/BookImportUnitGroupingFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/BookImportUnitGroupingFixture.cs
@@ -29,6 +29,32 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
         }
 
         [Test]
+        public void case_only_duplicate_paths_should_not_break_unit_grouping()
+        {
+            // A folder renamed only by casing (case-insensitive mounts, sync tools)
+            // can leave the same file catalogued twice with paths that differ only
+            // by case. Grouping must degrade to keeping one of them, not throw and
+            // collapse the entire unmapped page to per-file units.
+            var folder = @"C:\library\Author\Vision in Silver".AsOsAgnostic();
+            var duplicateCasing = @"C:\library\Author\Vision In Silver".AsOsAgnostic();
+            var files = new[]
+            {
+                CreateFile(1, $@"{folder}{Sep}Vision in Silver.m4b", "audiobook",
+                    ("ARTIST", "Author"),
+                    ("TITLE", "Vision in Silver")),
+                CreateFile(2, $@"{duplicateCasing}{Sep}Vision in Silver.m4b", "audiobook",
+                    ("ARTIST", "Author"),
+                    ("TITLE", "Vision in Silver"))
+            };
+
+            IReadOnlyList<BookImportUnit> units = null;
+
+            Assert.DoesNotThrow(() => units = BookImportUnitGroupingService.BuildUnmappedUnits(files, _ => @"C:\library".AsOsAgnostic()));
+            Assert.That(units, Is.Not.Empty);
+            Assert.That(units.SelectMany(unit => unit.Files).Any(file => file.Id == 1 || file.Id == 2), Is.True);
+        }
+
+        [Test]
         public void homogeneous_audio_tracks_should_share_one_unit()
         {
             var folder = @"C:\library\Michael Connelly\Schwarzes Echo".AsOsAgnostic();

--- a/src/NzbDrone.Core/MediaFiles/BookImport/Services/BookImportUnitGroupingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/Services/BookImportUnitGroupingService.cs
@@ -200,7 +200,12 @@ namespace NzbDrone.Core.MediaFiles.BookImport.Services
                     })
                     .ToList();
                 var identitySubgroups = BuildIdentitySubgroups(discovered, excludedIdentityValues);
-                var byPath = poolFiles.ToDictionary(file => file.Path, StringComparer.OrdinalIgnoreCase);
+                // Case-only duplicate paths (e.g. a folder renamed only by casing on a
+                // case-insensitive mount) would make ToDictionary throw and degrade the
+                // whole page to per-file units. Keep the first file per case-folded path.
+                var byPath = poolFiles
+                    .GroupBy(file => file.Path, StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
                 foreach (var subgroup in identitySubgroups)
                 {


### PR DESCRIPTION
## The bug

If a library contains two catalogued files whose paths differ **only by casing** (easily produced by sync tools or case-insensitive mounts renaming a folder's case, which leaves both spellings behind), `BookImportUnitGroupingService.BuildUnmappedUnits` throws:

```
System.ArgumentException: An item with the same key has already been added. Key: <path>
```

because `poolFiles.ToDictionary(file => file.Path, StringComparer.OrdinalIgnoreCase)` requires case-insensitively-unique paths. The controller's safety net then degrades the **entire** unmapped page to per-file units — grouping, group selection, and the group counts all silently break for every file, not just the offending pair (observed live: the header pill showing a book-group count within a few dozen of the raw file count on a large library, with folder grouping gone).

## Fix

Build the lookup with `GroupBy(..., OrdinalIgnoreCase)` keeping the first file per case-folded path, so a handful of degenerate rows can't take down grouping for everyone. The duplicate file itself simply falls back to its own per-file unit, which is the existing behaviour for anything outside a built unit.

## Tests

- `case_only_duplicate_paths_should_not_break_unit_grouping` — written first against unpatched develop, where it fails with the exact `ArgumentException` above; passes with the fix
- Full MediaFiles + grouping suite: 704/704 passing
- Production soak: running on my instance against the real pathological data (five case-duplicate folder pairs); grouping restored and no degradation warnings since