### PR TITLE
Track multiple narrations of the same audiobook

### DIFF
--- a/frontend/src/Store/Actions/narratorActions.js
+++ b/frontend/src/Store/Actions/narratorActions.js
@@ -1,10 +1,8 @@
 import { createAction } from 'redux-actions';
-import * as commandNames from 'Commands/commandNames';
 import { createThunk, handleThunks } from 'Store/thunks';
 import createAjaxRequest from 'Utilities/createAjaxRequest';
 import translate from 'Utilities/String/translate';
 import { set } from './baseActions';
-import { executeCommand } from './commandActions';
 import createHandleActions from './Creators/createHandleActions';
 
 //
@@ -251,97 +249,33 @@ export const actionHandlers = handleThunks({
       (narrator.editionId || narrator.EditionId) :
       null;
 
-    // Check if the current book has any physical files
-    const hasFiles = currentBook.statistics?.bookFileCount > 0;
-
     if (selectedEditionId) {
-      if (hasFiles) {
-        // Book already has audio files: do NOT modify it. Create a separate wanted instance pinned to the selected edition.
-        const promise = createAjaxRequest({
-          url: `/book/${bookId}/editions/wanted`,
-          method: 'POST',
-          data: JSON.stringify({ editionId: selectedEditionId, searchForNewBook: payload.searchForNewBook === true }),
-          contentType: 'application/json'
-        }).request;
-
-        promise.done((data) => {
-          dispatch(set({
-            section,
-            isSettingPreferred: false,
-            discovery: optimisticallyMoveNarrator(getState(), bookId, narrator)
-          }));
-          if (payload.onSuccess) {
-            payload.onSuccess(data);
-          }
-        });
-
-        promise.fail((xhr) => {
-          dispatch(set({
-            section,
-            isSettingPreferred: false,
-            error: xhr
-          }));
-        });
-
-        return;
-      }
-
-      // Missing instance (no files): pin the selected edition as the monitored/manual one.
-      // This uses the existing ManualAdd mechanism so imports won't override the user's choice.
-      const editionsPromise = createAjaxRequest({
-        url: `/edition?bookId=${bookId}`,
-        method: 'GET'
+      // Track this narration alongside whatever the book already wants rather than
+      // replacing it. The server decides whether a separate row is needed and returns
+      // the existing one when this narrator is already tracked.
+      const promise = createAjaxRequest({
+        url: `/book/${bookId}/editions/wanted`,
+        method: 'POST',
+        data: JSON.stringify({
+          editionId: selectedEditionId,
+          searchForNewBook: payload.searchForNewBook === true,
+          asNewVariant: true
+        }),
+        contentType: 'application/json'
       }).request;
 
-      editionsPromise.done((editions) => {
-        const updatedEditions = (editions || []).map((e) => {
-          const isSelected = e.id === selectedEditionId;
-          return {
-            ...e,
-            monitored: isSelected,
-            manualAdd: isSelected
-          };
-        });
-
-        const promise = createAjaxRequest({
-          url: `/book/${bookId}`,
-          method: 'PUT',
-          data: JSON.stringify({
-            ...currentBook,
-            monitored: true,
-            anyEditionOk: false,
-            editions: updatedEditions
-          }),
-          contentType: 'application/json'
-        }).request;
-
-        promise.done((data) => {
-          dispatch(set({
-            section,
-            isSettingPreferred: false,
-            discovery: optimisticallyMoveNarrator(getState(), bookId, narrator)
-          }));
-          if (payload.searchForNewBook === true) {
-            dispatch(executeCommand({
-              name: commandNames.BOOK_SEARCH,
-              bookIds: [bookId]
-            }));
-          }
-          if (payload.onSuccess) {
-            payload.onSuccess(data);
-          }
-        });
-
-        promise.fail((xhr) => {
-          dispatch(set({
-            section,
-            isSettingPreferred: false,
-            error: xhr
-          }));
-        });
+      promise.done((data) => {
+        dispatch(set({
+          section,
+          isSettingPreferred: false,
+          discovery: optimisticallyMoveNarrator(getState(), bookId, narrator)
+        }));
+        if (payload.onSuccess) {
+          payload.onSuccess(data);
+        }
       });
 
-      editionsPromise.fail((xhr) => {
+      promise.fail((xhr) => {
         dispatch(set({
           section,
           isSettingPreferred: false,

--- a/src/Chaptarr.Api.V1/Books/AddWantedEditionRequest.cs
+++ b/src/Chaptarr.Api.V1/Books/AddWantedEditionRequest.cs
@@ -7,5 +7,9 @@ namespace Chaptarr.Api.V1.Books
         // Whether to start an automatic search for the newly created wanted edition.
         // Defaults to false; the UI exposes this as an opt-in toggle.
         public bool SearchForNewBook { get; set; } = false;
+
+        // Track this narration alongside the book's current selection instead of replacing it.
+        // Defaults to false so existing callers keep the previous pin-in-place behaviour.
+        public bool AsNewVariant { get; set; } = false;
     }
 }

--- a/src/Chaptarr.Api.V1/Books/BookController.cs
+++ b/src/Chaptarr.Api.V1/Books/BookController.cs
@@ -1929,7 +1929,7 @@ namespace Chaptarr.Api.V1.Books
 
 	            try
 	            {
-	                var wantedBook = _bookService.AddWantedEdition(id, request.EditionId);
+	                var wantedBook = _bookService.AddWantedEdition(id, request.EditionId, request.AsNewVariant);
 	                EnsureBookCover(wantedBook.Id, "wantedEdition");
 
 	                if (request.SearchForNewBook)

--- a/src/Chaptarr.Core.Test/Api/BookControllerSiblingDeleteInfoFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/BookControllerSiblingDeleteInfoFixture.cs
@@ -67,7 +67,7 @@ namespace Chaptarr.Core.Test.Api
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Api/CalendarFeedControllerFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/CalendarFeedControllerFixture.cs
@@ -149,7 +149,7 @@ namespace Chaptarr.Core.Test.Api
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Api/Wanted/WantedMonitoringFilterFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/Wanted/WantedMonitoringFilterFixture.cs
@@ -69,7 +69,7 @@ namespace Chaptarr.Core.Test.Api.Wanted
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/AddBookServiceAutoEditionSelectionFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AddBookServiceAutoEditionSelectionFixture.cs
@@ -196,7 +196,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceMonitoredEditionSelectionFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceMonitoredEditionSelectionFixture.cs
@@ -62,7 +62,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceProviderIdDedupFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceProviderIdDedupFixture.cs
@@ -244,7 +244,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceRootFolderInheritanceFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceRootFolderInheritanceFixture.cs
@@ -161,7 +161,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceSpecificBookMonitoringFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorLibraryServiceSpecificBookMonitoringFixture.cs
@@ -174,7 +174,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/BookServiceWantedNarratorSeriesLinksFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/BookServiceWantedNarratorSeriesLinksFixture.cs
@@ -150,7 +150,23 @@ namespace Chaptarr.Core.Test.Books
             public System.Collections.Generic.List<Edition> GetEditionsByProviderAndId(string providerPrefix, string providerId) => new System.Collections.Generic.List<Edition>();
             public List<Edition> GetAllMonitoredEditions() => throw new NotImplementedException();
             public void InsertMany(List<Edition> editions, IDbConnection connection, IDbTransaction transaction) => throw new NotImplementedException();
-            public void UpdateMany(List<Edition> editions) => throw new NotImplementedException();
+            public void UpdateMany(List<Edition> editions)
+            {
+                foreach (var edition in editions ?? new List<Edition>())
+                {
+                    if (!_editionsByBookId.TryGetValue(edition.BookId, out var list))
+                    {
+                        continue;
+                    }
+
+                    var index = list.FindIndex(e => e.Id == edition.Id);
+                    if (index >= 0)
+                    {
+                        list[index] = edition;
+                    }
+                }
+            }
+
             public void DeleteMany(List<Edition> editions) => throw new NotImplementedException();
             public List<Edition> GetEditionsForRefresh(int bookId) => throw new NotImplementedException();
             public List<Edition> GetEditionsByAuthor(int authorId) => throw new NotImplementedException();
@@ -201,7 +217,13 @@ namespace Chaptarr.Core.Test.Books
             public int Count() => throw new NotImplementedException();
             public Book Find(int id) => throw new NotImplementedException();
             public Book Insert(Book model) => throw new NotImplementedException();
-            public Book Update(Book model) => throw new NotImplementedException();
+
+            public Book Update(Book model)
+            {
+                _booksById[model.Id] = model;
+                return model;
+            }
+
             public void SetFields(Book model, params System.Linq.Expressions.Expression<Func<Book, object>>[] properties) => throw new NotImplementedException();
             public void Delete(Book model) => throw new NotImplementedException();
             public void Delete(int id) => throw new NotImplementedException();
@@ -372,6 +394,142 @@ namespace Chaptarr.Core.Test.Books
                 Assert.That(wanted.Id, Is.Not.EqualTo(otherWanted.Id));
                 Assert.That(wanted.GoodreadsWorkId, Is.EqualTo(baseBook.GoodreadsWorkId));
             });
+        }
+
+        private static (BookService Sut, Book BaseBook, Edition First, Edition Second, InMemoryEditionService Editions) BuildTwoNarratorBook(
+            bool withFiles,
+            params Book[] additionalBooks)
+        {
+            var author = new Author { Id = 1, Name = "George Orwell" };
+
+            var firstEdition = new Edition
+            {
+                Id = 101,
+                BookId = 20,
+                Title = "1984",
+                ForeignEditionId = "edition-first",
+                ReadingFormatId = 2,
+                Narrator = "Stephen Fry",
+                NarratorNames = new List<string> { "Stephen Fry" },
+                Monitored = true
+            };
+
+            var secondEdition = new Edition
+            {
+                Id = 102,
+                BookId = 20,
+                Title = "1984",
+                ForeignEditionId = "edition-second",
+                ReadingFormatId = 2,
+                Narrator = "Andrew Wincott",
+                NarratorNames = new List<string> { "Andrew Wincott" }
+            };
+
+            var baseBook = new Book
+            {
+                Id = 20,
+                AuthorId = author.Id,
+                Title = "1984",
+                TitleSlug = "1984",
+                MediaType = BookMediaType.Audiobook,
+                GoodreadsWorkId = "gr:work-1984",
+                Editions = new List<Edition> { firstEdition, secondEdition }
+            };
+
+            var editions = new InMemoryEditionService();
+            editions.Seed(baseBook.Id, firstEdition, secondEdition);
+
+            var books = new List<Book> { baseBook };
+            books.AddRange(additionalBooks ?? Array.Empty<Book>());
+
+            var mediaFiles = new StubMediaFileService();
+            if (withFiles)
+            {
+                mediaFiles.FilesByBookId[baseBook.Id] = new List<BookFile> { new BookFile { Id = 1 } };
+            }
+
+            var sut = new BookService(
+                new InMemoryBookRepository(books.ToArray()),
+                editions,
+                new StubEventAggregator(),
+                new StubAuthorService(author),
+                mediaFiles,
+                rootFolderService: null,
+                seriesBookLinkRepository: null,
+                multiCopySeriesService: new StubMultiCopySeriesService(),
+                logger: LogManager.GetCurrentClassLogger());
+
+            return (sut, baseBook, firstEdition, secondEdition, editions);
+        }
+
+        [Test]
+        public void should_create_a_separate_variant_for_a_second_narrator_when_the_book_has_no_files()
+        {
+            var (sut, baseBook, _, secondEdition, _) = BuildTwoNarratorBook(withFiles: false);
+
+            var variant = sut.AddWantedEdition(baseBook.Id, secondEdition.Id, asNewVariant: true);
+
+            Assert.That(variant.Id, Is.Not.EqualTo(baseBook.Id));
+        }
+
+        [Test]
+        public void should_pin_in_place_without_creating_a_variant_when_not_requested()
+        {
+            var (sut, baseBook, _, secondEdition, _) = BuildTwoNarratorBook(withFiles: false);
+
+            var pinned = sut.AddWantedEdition(baseBook.Id, secondEdition.Id);
+
+            Assert.That(pinned.Id, Is.EqualTo(baseBook.Id));
+        }
+
+        [Test]
+        public void should_not_duplicate_the_base_book_when_it_already_wants_that_narrator()
+        {
+            var (sut, baseBook, _, secondEdition, _) = BuildTwoNarratorBook(withFiles: false);
+
+            // The book is already pinned to this narrator by an earlier in-place selection.
+            var pinned = sut.AddWantedEdition(baseBook.Id, secondEdition.Id);
+            Assume.That(pinned.Id, Is.EqualTo(baseBook.Id));
+
+            var variant = sut.AddWantedEdition(baseBook.Id, secondEdition.Id, asNewVariant: true);
+
+            Assert.That(variant.Id, Is.EqualTo(baseBook.Id));
+        }
+
+        [Test]
+        public void should_reuse_an_existing_variant_that_already_wants_the_same_narrator()
+        {
+            var existingVariant = new Book
+            {
+                Id = 21,
+                AuthorId = 1,
+                Title = "1984",
+                TitleSlug = "1984_wanted_earlier",
+                MediaType = BookMediaType.Audiobook,
+                GoodreadsWorkId = "gr:work-1984",
+                AddOptions = new AddBookOptions { AddType = BookAddType.Manual }
+            };
+
+            var (sut, baseBook, _, secondEdition, editions) = BuildTwoNarratorBook(withFiles: false, existingVariant);
+
+            // The existing variant is pinned to a *different* edition record that happens to have
+            // the same narrator, so provider-id dedup cannot catch it -- only narrator dedup can.
+            editions.Seed(existingVariant.Id, new Edition
+            {
+                Id = 201,
+                BookId = existingVariant.Id,
+                Title = "1984",
+                ForeignEditionId = "edition-other-printing",
+                ReadingFormatId = 2,
+                Narrator = secondEdition.Narrator,
+                NarratorNames = new List<string> { secondEdition.Narrator },
+                ManualAdd = true,
+                Monitored = true
+            });
+
+            var variant = sut.AddWantedEdition(baseBook.Id, secondEdition.Id, asNewVariant: true);
+
+            Assert.That(variant.Id, Is.EqualTo(existingVariant.Id));
         }
     }
 }

--- a/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceActiveEditionSelectionFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceActiveEditionSelectionFixture.cs
@@ -60,7 +60,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceAddChildrenFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceAddChildrenFixture.cs
@@ -67,7 +67,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId, string mediaType) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored, string mediaType, bool? downloaded) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceDuplicateMatchingFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceDuplicateMatchingFixture.cs
@@ -58,7 +58,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceMonitoringFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceMonitoringFixture.cs
@@ -77,7 +77,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceUnmergeSplitFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshAuthorServiceUnmergeSplitFixture.cs
@@ -67,7 +67,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/RefreshBookServiceMergeEditionSelectionFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshBookServiceMergeEditionSelectionFixture.cs
@@ -107,7 +107,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Books/UpdateEditionSelectionOnMetadataProfileChangeServiceFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/UpdateEditionSelectionOnMetadataProfileChangeServiceFixture.cs
@@ -106,7 +106,7 @@ namespace Chaptarr.Core.Test.Books
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaCover/DeferredCoverDownloadServiceFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaCover/DeferredCoverDownloadServiceFixture.cs
@@ -94,7 +94,7 @@ namespace Chaptarr.Core.Test.MediaCover
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookFileEventHandlersFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookFileEventHandlersFixture.cs
@@ -73,7 +73,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new System.NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new System.NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new System.NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new System.NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new System.NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new System.NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new System.NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new System.NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/FormatScopedUnitCloneFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/FormatScopedUnitCloneFixture.cs
@@ -159,7 +159,7 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/HolyGrailSmokeTestFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/HolyGrailSmokeTestFixture.cs
@@ -596,7 +596,7 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/LogicalWorkGroupingFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/LogicalWorkGroupingFixture.cs
@@ -124,7 +124,7 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/MatchingProvenancePopulationFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/MatchingProvenancePopulationFixture.cs
@@ -186,7 +186,7 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/BookImport/PinnedEditionFirstCrackFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookImport/PinnedEditionFirstCrackFixture.cs
@@ -148,7 +148,7 @@ namespace Chaptarr.Core.Test.MediaFiles.BookImport
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new System.NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new System.NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new System.NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new System.NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new System.NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new System.NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new System.NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new System.NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/EbookColocateOnAudiobookImportHandlerFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/EbookColocateOnAudiobookImportHandlerFixture.cs
@@ -65,7 +65,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/MediaFiles/EbookColocationPlannerFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/EbookColocationPlannerFixture.cs
@@ -58,7 +58,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/Chaptarr.Core.Test/Profiles/Metadata/MetadataProfileServiceMediaTypeFilteringFixture.cs
+++ b/src/Chaptarr.Core.Test/Profiles/Metadata/MetadataProfileServiceMediaTypeFilteringFixture.cs
@@ -155,7 +155,7 @@ namespace Chaptarr.Core.Test.Profiles.Metadata
             public List<Book> GetAuthorBooksWithFiles(Author author) => throw new NotImplementedException();
             public List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null) => throw new NotImplementedException();
             public List<Book> GetBooksByBaseId(string baseBookId) => throw new NotImplementedException();
-            public Book AddWantedEdition(int bookId, int editionId) => throw new NotImplementedException();
+            public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false) => throw new NotImplementedException();
             public bool ShouldSearchForMediaType(Book book, string mediaType) => throw new NotImplementedException();
             public List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType) => throw new NotImplementedException();
             public BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null) => throw new NotImplementedException();

--- a/src/NzbDrone.Core/Books/Services/BookService.cs
+++ b/src/NzbDrone.Core/Books/Services/BookService.cs
@@ -67,7 +67,7 @@ namespace NzbDrone.Core.Books
         List<Book> GetAuthorBooksWithFiles(Author author);
             List<Book> GetBooksForDisplay(int? authorId = null, string mediaType = null);
             List<Book> GetBooksByBaseId(string baseBookId);
-            Book AddWantedEdition(int bookId, int editionId);
+            Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false);
             bool ShouldSearchForMediaType(Book book, string mediaType);
             List<Book> GetMonitoredBooksForAuthor(int authorId, string mediaType);
             BookBucketResource GetBookBuckets(string sortKey, string sortDirection, bool includeUnmonitored = false, string mediaType = null, bool? downloaded = null);
@@ -2091,7 +2091,7 @@ namespace NzbDrone.Core.Books
                 .ToList();
         }
 
-        public Book AddWantedEdition(int bookId, int editionId)
+        public Book AddWantedEdition(int bookId, int editionId, bool asNewVariant = false)
         {
             var baseBook = GetBook(bookId);
             if (baseBook == null)
@@ -2115,9 +2115,11 @@ namespace NzbDrone.Core.Books
                 throw new InvalidOperationException($"Edition {editionId} does not belong to book {bookId}");
             }
 
-            // If this book has no files, it is already a "missing" instance; just pin the selected edition here.
+            // If this book has no files, it is already a "missing" instance; just pin the selected
+            // edition here. When the caller explicitly asks for a variant, fall through instead so a
+            // second narration can be tracked alongside the first rather than replacing it.
             var existingFiles = _mediaFileService.GetFilesByBook(baseBook.Id);
-            if (!existingFiles.Any())
+            if (!existingFiles.Any() && !asNewVariant)
             {
                 var editions = _editionService.GetEditionsByBook(baseBook.Id);
 
@@ -2198,7 +2200,8 @@ namespace NzbDrone.Core.Books
 
             // If a matching wanted instance already exists, return it (don’t create duplicates).
             var selectedEditionKey = GetEditionKey(selectedEdition);
-            if (baseBook.AuthorId > 0 && !string.IsNullOrWhiteSpace(selectedEditionKey))
+            var selectedNarratorKeys = GetEditionNarratorKeys(selectedEdition);
+            if (baseBook.AuthorId > 0 && (!string.IsNullOrWhiteSpace(selectedEditionKey) || selectedNarratorKeys.Count > 0))
             {
                 var authorBooks = _bookRepository.GetBooksByAuthorId(baseBook.AuthorId);
                 var wantedCandidates = authorBooks
@@ -2223,12 +2226,19 @@ namespace NzbDrone.Core.Books
                         }
 
                         var candidateKey = GetEditionKey(candidateManual);
-                        if (candidateKey == null)
-                        {
-                            continue;
-                        }
 
-                        if (string.Equals(candidateKey, selectedEditionKey, StringComparison.OrdinalIgnoreCase))
+                        var sameEdition = candidateKey != null &&
+                                          !string.IsNullOrWhiteSpace(selectedEditionKey) &&
+                                          string.Equals(candidateKey, selectedEditionKey, StringComparison.OrdinalIgnoreCase);
+
+                        // Different printings of the same narration are distinct edition records but
+                        // the same request, so an existing variant for this narrator already covers it.
+                        var sameNarrator = selectedNarratorKeys.Count > 0 &&
+                                           GetEditionNarratorKeys(candidateManual)
+                                               .Intersect(selectedNarratorKeys, StringComparer.OrdinalIgnoreCase)
+                                               .Any();
+
+                        if (sameEdition || sameNarrator)
                         {
                             if (!candidate.AudiobookMonitored)
                             {
@@ -2244,6 +2254,28 @@ namespace NzbDrone.Core.Books
                             return GetBook(candidate.Id);
                         }
                     }
+                }
+            }
+
+            // The base book may already be pinned to this narration from an earlier in-place
+            // selection, in which case a variant would just duplicate what is already wanted.
+            if (asNewVariant && selectedNarratorKeys.Count > 0)
+            {
+                var baseEditions = _editionService.GetEditionsByBook(baseBook.Id);
+                if (baseEditions == null || baseEditions.Count == 0)
+                {
+                    baseEditions = baseBook.Editions?.ToList() ?? new List<Edition>();
+                }
+
+                var basePinned = baseEditions.FirstOrDefault(e => e.ManualAdd)
+                                 ?? baseEditions.FirstOrDefault(e => e.Monitored);
+
+                if (basePinned != null &&
+                    GetEditionNarratorKeys(basePinned)
+                        .Intersect(selectedNarratorKeys, StringComparer.OrdinalIgnoreCase)
+                        .Any())
+                {
+                    return GetBook(baseBook.Id);
                 }
             }
 
@@ -2389,6 +2421,30 @@ namespace NzbDrone.Core.Books
             }
 
             return GetBook(wantedBook.Id);
+        }
+
+        // Narrator names arrive from several providers with inconsistent spacing and casing
+        // ("Peter   Noble"), so compare on normalised tokens rather than the raw string.
+        private static List<string> GetEditionNarratorKeys(Edition edition)
+        {
+            var names = new List<string>();
+
+            if (edition?.NarratorNames != null)
+            {
+                names.AddRange(edition.NarratorNames);
+            }
+
+            if (!string.IsNullOrWhiteSpace(edition?.Narrator))
+            {
+                names.Add(edition.Narrator);
+            }
+
+            return names
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => string.Join(" ", Services.TextNormalizer.NormalizeAndTokenize(name)))
+                .Where(key => key.Length > 0)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         private Edition SelectMonitoredEditionForInsert(IEnumerable<Edition> editions, BookMediaType mediaType)


### PR DESCRIPTION
#### Description

Some works have narrations worth keeping side by side — Jim Dale and Stephen Fry, Roy Dotrice and John Lee. Chaptarr already has most of what that needs: wanted instances carry `BaseBookId`, get a `_wanted_{editionId}` slug, de-duplicate against existing rows, and the `{Narrator}` naming token files them into separate folders. The narrator modal is already wired to `addNarratorVariant`, and it lists the narrators you *don't* yet have, which is additive by intent.

But you can only ever want one narration at a time.

`AddWantedEdition` creates a separate row **only when the book already has files on disk**. With no files it pins the chosen edition in place, so picking a second narrator overwrites the first. That means a variant can only be created for a book you already partly own — you cannot say "I want both of these" from a clean library, which is the normal starting point.

Observed on a book with 116 audiobook editions, selecting three narrators in turn:

| Step | before | after |
| --- | --- | --- |
| start | 1 row — Simon Prebble | 1 row — Simon Prebble |
| want Andrew Wincott | 1 row — **Wincott replaces Prebble** | 2 rows — Prebble + Wincott |
| want Stephen Fry | 1 row — **Fry replaces Wincott** | 3 rows — Prebble + Wincott + Fry |
| want Wincott again, via a different edition record | 1 row — Wincott | 3 rows — reuses the existing Wincott row |

Before, every selection returns the same `bookId` and the previous choice is gone. After, the three narrations coexist and the repeat request de-duplicates.

**What changed**

`AddWantedEdition` takes an `asNewVariant` flag, exposed on the API as `AsNewVariant`. When set, the no-files branch is skipped so the narration is tracked alongside the current selection rather than replacing it. **It defaults to `false`, so every existing caller keeps the current behaviour** — there is a test pinning that.

De-duplication now also matches on **narrator**, not only on edition provider ids. Two printings of the same narration are distinct edition records but the same user request, so asking for a narrator already tracked returns the existing row instead of creating a near-duplicate. The base book is checked the same way, so no variant is created for a narration it is already pinned to. Names are compared on normalised tokens, because providers return inconsistent spacing — there are real records like `"Peter   Noble"` and `"Frank  Muller"`.

The narrator modal now routes both cases through the endpoint. It previously reimplemented edition pinning client-side (`GET /edition` then `PUT /book`) for books with no files, which bypassed all of the above; deleting that branch removes the duplicated logic and is why the frontend diff is mostly red.

**On the file count**

30 files sounds worse than it is: **25 are one-line signature updates to `IBookService` test doubles.** The real change is 3 source files plus tests.

**Deliberately not included:** `Books.WantedNarratorId` is never assigned anywhere in the codebase — only nulled by housekeeping and migrations — so variants remain keyed on the edition. Connecting the `Narrators` table to this flow looks like your call on the narrator entity's lifecycle rather than something to decide inside a bugfix-shaped change, so I left it alone. Happy to follow up if you want it.

This is independent of #56 and can merge in either order. They complement each other: #56 makes releases actually *match* the pinned narrator, this makes more than one narration trackable at once.

#### Database Migration

NO.

#### How was this tested?

**Unit tests** — 4 added to `BookServiceWantedNarratorSeriesLinksFixture`, each written first and observed failing for the right reason before implementing:

- `should_create_a_separate_variant_for_a_second_narrator_when_the_book_has_no_files`
- `should_pin_in_place_without_creating_a_variant_when_not_requested` — backward-compatibility guard
- `should_not_duplicate_the_base_book_when_it_already_wants_that_narrator`
- `should_reuse_an_existing_variant_that_already_wants_the_same_narrator`

The third caught a real duplicate-creation bug in my first implementation. Two unimplemented members on the fixture's in-memory doubles (`InMemoryBookRepository.Update`, `InMemoryEditionService.UpdateMany`) were filled in, since these paths now exercise them.

```
dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj --configuration Release
develop (537eb64): 2834 passed, 0 failed
this branch:       2838 passed, 0 failed   (+4, the tests above)
```

Debug and Release both clean; `dotnet build src/Chaptarr.NoTests.sln -c Release` reports 0 warnings, 0 errors. The `build.yml` guard steps pass too — conflict markers, `package.json` parse, and `version_guard.py` in `sync`, `monotonic` and `commit-hygiene` modes. Frontend `yarn typecheck` passes and `eslint` is clean on the changed file (worth stating explicitly, since `build.yml` runs no yarn steps).

**End-to-end**, on Linux with .NET 10. Two containers from `chaptarr/chaptarr:0.9.929`, identical config databases, differing only by the patched assemblies, driven through `POST /book/{id}/editions/wanted`. That produced the table above — before, one row that keeps getting overwritten; after:

```
book 1:   slug='1984'            narrator='Simon Prebble'
book 647: slug='1984_wanted_7'   narrator='Andrew Wincott'
book 648: slug='1984_wanted_24'  narrator='Stephen Fry'
```

and the repeat request for Wincott through a different edition record returned `647` rather than creating a fourth row.

#### Screenshots (UI changes only)

No visual changes — the narrator modal looks and behaves the same; only the request it issues changed.
