### PR TITLE
Save series information into ebook files so readers group them correctly

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/EbookTagServiceDirectWriteFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/EbookTagServiceDirectWriteFixture.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using NLog;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Books.Calibre;
+using NzbDrone.Core.Configuration;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Commands;
+using NzbDrone.Core.RootFolders;
+using NUnit.Framework;
+
+namespace Chaptarr.Core.Test.MediaFiles
+{
+    /// <summary>
+    /// Covers writing series metadata straight into the book file, which is the only path
+    /// available to the majority of users who do not run a Calibre content server.
+    /// </summary>
+    [TestFixture]
+    public class EbookTagServiceDirectWriteFixture
+    {
+        private class ThrowingProxy<T> : DispatchProxy
+            where T : class
+        {
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                throw new NotImplementedException($"Unexpected call to {typeof(T).Name}.{targetMethod?.Name}");
+            }
+        }
+
+        private class ConfigServiceProxy : DispatchProxy
+        {
+            public WriteBookTagsType WriteBookTags { get; set; } = WriteBookTagsType.NewFiles;
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name switch
+                {
+                    "get_WriteBookTags" => WriteBookTags,
+                    "get_UpdateCovers" => false,
+                    "get_EmbedMetadata" => false,
+                    _ => throw new NotImplementedException($"Unexpected call to IConfigService.{targetMethod?.Name}")
+                };
+            }
+        }
+
+        private class RootFolderServiceProxy : DispatchProxy
+        {
+            public RootFolder RootFolder { get; set; }
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name == "GetBestRootFolder"
+                    ? RootFolder
+                    : throw new NotImplementedException($"Unexpected call to IRootFolderService.{targetMethod?.Name}");
+            }
+        }
+
+        private class FileMutationSafetyProxy : DispatchProxy
+        {
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name == "EnsureMutableFile"
+                    ? null
+                    : throw new NotImplementedException($"Unexpected call to IFileMutationSafetyService.{targetMethod?.Name}");
+            }
+        }
+
+        private class RecordingSeriesTagWriter : IEpubSeriesTagWriter
+        {
+            public List<(string Path, string SeriesName, double? SeriesIndex)> Calls { get; } = new();
+
+            public string ThrowForPath { get; set; }
+
+            public bool WriteSeriesTags(string epubPath, string seriesName, double? seriesIndex)
+            {
+                Calls.Add((epubPath, seriesName, seriesIndex));
+
+                if (epubPath == ThrowForPath)
+                {
+                    throw new IOException($"Simulated failure writing {epubPath}");
+                }
+
+                return true;
+            }
+        }
+
+        private class AuthorServiceProxy : DispatchProxy
+        {
+            public List<Author> Authors { get; set; } = new();
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name == "GetAuthors"
+                    ? Authors
+                    : throw new NotImplementedException($"Unexpected call to IAuthorService.{targetMethod?.Name}");
+            }
+        }
+
+        private class MediaFileServiceProxy : DispatchProxy
+        {
+            public List<BookFile> Files { get; set; } = new();
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name is "GetFilesByAuthor" or "GetFilesByBooks"
+                    ? Files
+                    : throw new NotImplementedException($"Unexpected call to IMediaFileService.{targetMethod?.Name}");
+            }
+        }
+
+        private RecordingSeriesTagWriter _writer;
+        private object _authorService;
+        private object _mediaFileService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _writer = new RecordingSeriesTagWriter();
+            _authorService = DispatchProxy.Create<IAuthorService, AuthorServiceProxy>();
+            _mediaFileService = DispatchProxy.Create<IMediaFileService, MediaFileServiceProxy>();
+        }
+
+        private EBookTagService BuildSubject(bool isCalibreLibrary, WriteBookTagsType writeBookTags = WriteBookTagsType.NewFiles)
+        {
+            var rootFolderService = DispatchProxy.Create<IRootFolderService, RootFolderServiceProxy>();
+            ((RootFolderServiceProxy)rootFolderService).RootFolder = new RootFolder
+            {
+                Path = "/books",
+                IsCalibreLibrary = isCalibreLibrary
+            };
+
+            var configService = DispatchProxy.Create<IConfigService, ConfigServiceProxy>();
+            ((ConfigServiceProxy)configService).WriteBookTags = writeBookTags;
+
+            return new EBookTagService(
+                (IAuthorService)_authorService,
+                (IMediaFileService)_mediaFileService,
+                rootFolderService,
+                configService,
+                DispatchProxy.Create<ICalibreProxy, ThrowingProxy<ICalibreProxy>>(),
+                DispatchProxy.Create<IFileMutationSafetyService, FileMutationSafetyProxy>(),
+                _writer,
+                LogManager.GetLogger("test"));
+        }
+
+        private static BookFile GivenBookFile(string seriesName, string seriesPosition, string path = "/books/example.epub")
+        {
+            return new BookFile
+            {
+                Path = path,
+                Edition = new Edition
+                {
+                    Title = "An Example Book",
+                    Book = new Book
+                    {
+                        SeriesName = seriesName,
+                        SeriesPosition = seriesPosition
+                    }
+                }
+            };
+        }
+
+        [Test]
+        public void should_write_series_tags_directly_when_root_folder_is_not_a_calibre_library()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            // The Calibre proxy throws on any call, so reaching Calibre would fail this test.
+            sut.WriteTags(GivenBookFile("Example Series", "3"), newDownload: true);
+
+            Assert.That(_writer.Calls, Has.Count.EqualTo(1));
+            Assert.That(_writer.Calls[0].Path, Is.EqualTo("/books/example.epub"));
+            Assert.That(_writer.Calls[0].SeriesName, Is.EqualTo("Example Series"));
+            Assert.That(_writer.Calls[0].SeriesIndex, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void should_pass_no_index_when_series_position_is_not_numeric()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            sut.WriteTags(GivenBookFile("Example Series", "2 - Heavy Metal"), newDownload: true);
+
+            Assert.That(_writer.Calls, Has.Count.EqualTo(1));
+            Assert.That(_writer.Calls[0].SeriesName, Is.EqualTo("Example Series"));
+            Assert.That(_writer.Calls[0].SeriesIndex, Is.Null);
+        }
+
+        [Test]
+        public void should_parse_fractional_series_position()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            sut.WriteTags(GivenBookFile("Example Series", "11.5"), newDownload: true);
+
+            Assert.That(_writer.Calls[0].SeriesIndex, Is.EqualTo(11.5));
+        }
+
+        [Test]
+        public void should_not_write_anything_when_book_has_no_series()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            sut.WriteTags(GivenBookFile(null, null), newDownload: true);
+
+            Assert.That(_writer.Calls, Is.Empty);
+        }
+
+        [Test]
+        public void should_not_write_series_tags_for_formats_with_no_writer()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            sut.WriteTags(GivenBookFile("Example Series", "3", "/books/example.pdf"), newDownload: true);
+
+            Assert.That(_writer.Calls, Is.Empty);
+        }
+
+        [Test]
+        public void should_not_write_directly_when_config_limits_tagging_to_new_files()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            sut.WriteTags(GivenBookFile("Example Series", "3"), newDownload: false);
+
+            Assert.That(_writer.Calls, Is.Empty);
+        }
+
+        [Test]
+        public void should_retag_epubs_without_a_calibre_id_when_backfilling_an_author()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            ((AuthorServiceProxy)_authorService).Authors = new List<Author> { new Author { Id = 1, Name = "An Example Author" } };
+            ((MediaFileServiceProxy)_mediaFileService).Files = new List<BookFile> { GivenBookFile("Example Series", "3") };
+
+            sut.RetagAuthor(new RetagAuthorCommand { AuthorIds = new List<int> { 1 } });
+
+            Assert.That(_writer.Calls, Has.Count.EqualTo(1));
+            Assert.That(_writer.Calls[0].SeriesName, Is.EqualTo("Example Series"));
+        }
+
+        [Test]
+        public void should_keep_backfilling_the_rest_of_an_author_when_one_file_cannot_be_written()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false);
+
+            _writer.ThrowForPath = "/books/broken.epub";
+
+            ((AuthorServiceProxy)_authorService).Authors = new List<Author> { new Author { Id = 1, Name = "An Example Author" } };
+            ((MediaFileServiceProxy)_mediaFileService).Files = new List<BookFile>
+            {
+                GivenBookFile("Example Series", "1", "/books/broken.epub"),
+                GivenBookFile("Example Series", "2", "/books/intact.epub")
+            };
+
+            Assert.DoesNotThrow(() => sut.RetagAuthor(new RetagAuthorCommand { AuthorIds = new List<int> { 1 } }));
+
+            // One unreadable book must not strand the rest of the library untagged.
+            Assert.That(_writer.Calls.Select(x => x.Path),
+                Is.EqualTo(new[] { "/books/broken.epub", "/books/intact.epub" }));
+        }
+
+        [Test]
+        public void should_sync_epubs_without_a_calibre_id()
+        {
+            var sut = BuildSubject(isCalibreLibrary: false, writeBookTags: WriteBookTagsType.Sync);
+
+            var edition = new Edition
+            {
+                Id = 1,
+                BookId = 1,
+                Title = "An Example Book",
+                Book = new Book { SeriesName = "Example Series", SeriesPosition = "3" },
+                BookFiles = new List<BookFile> { GivenBookFile("Example Series", "3") }
+            };
+
+            sut.SyncTags(new List<Edition> { edition });
+
+            Assert.That(_writer.Calls, Has.Count.EqualTo(1));
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/MediaFiles/EpubSeriesTagWriterFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/EpubSeriesTagWriterFixture.cs
@@ -1,0 +1,277 @@
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
+using NLog;
+using NzbDrone.Core.MediaFiles;
+using NUnit.Framework;
+
+namespace Chaptarr.Core.Test.MediaFiles
+{
+    [TestFixture]
+    public class EpubSeriesTagWriterFixture
+    {
+        private static readonly XNamespace OpfNs = "http://www.idpf.org/2007/opf";
+
+        private string _workingFolder;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _workingFolder = Path.Combine(Path.GetTempPath(), "chaptarr-epub-tests", Path.GetRandomFileName());
+            Directory.CreateDirectory(_workingFolder);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_workingFolder != null && Directory.Exists(_workingFolder))
+            {
+                Directory.Delete(_workingFolder, true);
+            }
+        }
+
+        private EpubSeriesTagWriter Subject => new EpubSeriesTagWriter(LogManager.GetLogger("test"));
+
+        [Test]
+        public void should_write_series_name_and_index_when_epub_has_none()
+        {
+            var path = GivenEpub();
+
+            var changed = Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            Assert.That(changed, Is.True);
+            Assert.That(GetMeta(path, "calibre:series"), Is.EqualTo("Example Series"));
+            Assert.That(GetMeta(path, "calibre:series_index"), Is.EqualTo("3"));
+        }
+
+        [Test]
+        public void should_report_unchanged_when_series_tags_already_match()
+        {
+            var path = GivenEpub(existingSeries: "Example Series", existingSeriesIndex: "3");
+            var before = File.ReadAllBytes(path);
+
+            var changed = Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            Assert.That(changed, Is.False);
+            Assert.That(File.ReadAllBytes(path), Is.EqualTo(before), "the file should not be rewritten when nothing changes");
+        }
+
+        [Test]
+        public void should_update_existing_series_tags_when_they_differ()
+        {
+            var path = GivenEpub(existingSeries: "Stale Series", existingSeriesIndex: "9");
+
+            var changed = Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            Assert.That(changed, Is.True);
+            Assert.That(GetMeta(path, "calibre:series"), Is.EqualTo("Example Series"));
+            Assert.That(GetMeta(path, "calibre:series_index"), Is.EqualTo("3"));
+        }
+
+        [Test]
+        public void should_write_tags_that_the_bundled_epub_reader_can_read_back()
+        {
+            var path = GivenEpub();
+
+            Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            using var book = VersOne.Epub.EpubReader.OpenBook(path);
+            var metaItems = book.Schema.Package.Metadata.MetaItems;
+
+            Assert.That(metaItems.Any(x => x.Name == "calibre:series" && x.Content == "Example Series"), Is.True);
+            Assert.That(metaItems.Any(x => x.Name == "calibre:series_index" && x.Content == "3"), Is.True);
+        }
+
+        [Test]
+        public void should_keep_mimetype_first_and_uncompressed()
+        {
+            var path = GivenEpub();
+
+            Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            using var archive = ZipFile.OpenRead(path);
+            var first = archive.Entries.First();
+
+            Assert.That(first.FullName, Is.EqualTo("mimetype"));
+            Assert.That(first.CompressedLength, Is.EqualTo(first.Length), "mimetype must be stored uncompressed");
+        }
+
+        [Test]
+        public void should_write_fractional_series_index_using_invariant_decimal_separator()
+        {
+            var path = GivenEpub();
+            var originalCulture = CultureInfo.CurrentCulture;
+
+            try
+            {
+                // A culture whose decimal separator is a comma would otherwise emit "11,5",
+                // which readers cannot parse as a series position.
+                CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+                Subject.WriteSeriesTags(path, "Example Series", 11.5);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = originalCulture;
+            }
+
+            Assert.That(GetMeta(path, "calibre:series_index"), Is.EqualTo("11.5"));
+        }
+
+        [Test]
+        public void should_write_series_name_and_omit_index_when_position_is_unknown()
+        {
+            var path = GivenEpub();
+
+            var changed = Subject.WriteSeriesTags(path, "Example Series", null);
+
+            // Grouping is what readers key off; an unparseable position should cost the book
+            // its ordering, not its series.
+            Assert.That(changed, Is.True);
+            Assert.That(GetMeta(path, "calibre:series"), Is.EqualTo("Example Series"));
+            Assert.That(GetMeta(path, "calibre:series_index"), Is.Null);
+        }
+
+        [Test]
+        public void should_remove_stale_index_when_position_becomes_unknown()
+        {
+            var path = GivenEpub(existingSeries: "Example Series", existingSeriesIndex: "9");
+
+            Subject.WriteSeriesTags(path, "Example Series", null);
+
+            Assert.That(GetMeta(path, "calibre:series_index"), Is.Null);
+        }
+
+        [Test]
+        public void should_not_reprefix_elements_it_did_not_need_to_touch()
+        {
+            var path = GivenEpub();
+
+            Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            // An OPF package commonly binds a prefix to the same namespace URI it already uses
+            // by default. Re-prefixing every element on the way out is namespace-equivalent but
+            // rewrites far more of the reader's book than asked, and trips naive OPF parsers.
+            var opf = GetOpfText(path);
+
+            Assert.That(opf, Does.Contain("<metadata"));
+            Assert.That(opf, Does.Not.Contain("<opf:metadata"));
+            Assert.That(opf, Does.Contain("<meta name=\"calibre:series\""));
+            Assert.That(opf, Does.Not.Contain("<opf:meta "));
+        }
+
+        [Test]
+        public void should_indent_added_metadata_to_match_the_surrounding_document()
+        {
+            var path = GivenEpub();
+
+            Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            var opf = GetOpfText(path);
+
+            Assert.That(opf, Does.Contain("\n    <meta name=\"calibre:series\""));
+            Assert.That(opf, Does.Contain("\n    <meta name=\"calibre:series_index\""));
+            Assert.That(opf, Does.Contain("\n  </metadata>"));
+        }
+
+        [Test]
+        public void should_leave_unrelated_metadata_untouched()
+        {
+            var path = GivenEpub();
+
+            Subject.WriteSeriesTags(path, "Example Series", 3);
+
+            var opf = GetOpfText(path);
+
+            Assert.That(opf, Does.Contain("<dc:creator opf:role=\"aut\">An Example Author</dc:creator>"));
+            Assert.That(opf, Does.Contain("<dc:title>An Example Book</dc:title>"));
+        }
+
+        // Builds a minimal, structurally valid EPUB 2 containing only text authored for this
+        // test. The mimetype entry is written first and uncompressed, as the EPUB spec requires.
+        private string GivenEpub(string existingSeries = null, string existingSeriesIndex = null)
+        {
+            var path = Path.Combine(_workingFolder, "book.epub");
+
+            var metaItems = new StringBuilder();
+            if (existingSeries != null)
+            {
+                metaItems.Append($"<meta name=\"calibre:series\" content=\"{existingSeries}\"/>");
+            }
+
+            if (existingSeriesIndex != null)
+            {
+                metaItems.Append($"<meta name=\"calibre:series_index\" content=\"{existingSeriesIndex}\"/>");
+            }
+
+            var opf = $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://www.idpf.org/2007/opf"" unique-identifier=""bookid"" version=""2.0"">
+  <metadata xmlns:dc=""http://purl.org/dc/elements/1.1/"" xmlns:opf=""http://www.idpf.org/2007/opf"">
+    <dc:title>An Example Book</dc:title>
+    <dc:creator opf:role=""aut"">An Example Author</dc:creator>
+    <dc:identifier id=""bookid"">urn:uuid:00000000-0000-0000-0000-000000000001</dc:identifier>
+    <dc:language>en</dc:language>{metaItems}
+  </metadata>
+  <manifest>
+    <item id=""chapter1"" href=""chapter1.xhtml"" media-type=""application/xhtml+xml""/>
+  </manifest>
+  <spine>
+    <itemref idref=""chapter1""/>
+  </spine>
+</package>";
+
+            var container = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<container version=""1.0"" xmlns=""urn:oasis:names:tc:opendocument:xmlns:container"">
+  <rootfiles>
+    <rootfile full-path=""OEBPS/content.opf"" media-type=""application/oebps-package+xml""/>
+  </rootfiles>
+</container>";
+
+            var chapter = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<html xmlns=""http://www.w3.org/1999/xhtml""><head><title>Chapter One</title></head>
+<body><p>This placeholder chapter exists only so the archive is a well-formed book.</p></body></html>";
+
+            using (var stream = new FileStream(path, FileMode.Create))
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Create))
+            {
+                WriteEntry(archive, "mimetype", "application/epub+zip", CompressionLevel.NoCompression);
+                WriteEntry(archive, "META-INF/container.xml", container, CompressionLevel.Optimal);
+                WriteEntry(archive, "OEBPS/content.opf", opf, CompressionLevel.Optimal);
+                WriteEntry(archive, "OEBPS/chapter1.xhtml", chapter, CompressionLevel.Optimal);
+            }
+
+            return path;
+        }
+
+        private static void WriteEntry(ZipArchive archive, string name, string content, CompressionLevel level)
+        {
+            using var entryStream = archive.CreateEntry(name, level).Open();
+            var bytes = Encoding.UTF8.GetBytes(content);
+            entryStream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static string GetOpfText(string epubPath)
+        {
+            using var archive = ZipFile.OpenRead(epubPath);
+            using var opfStream = archive.GetEntry("OEBPS/content.opf").Open();
+            using var reader = new StreamReader(opfStream);
+
+            return reader.ReadToEnd();
+        }
+
+        private static string GetMeta(string epubPath, string name)
+        {
+            using var archive = ZipFile.OpenRead(epubPath);
+            using var opfStream = archive.GetEntry("OEBPS/content.opf").Open();
+
+            return XDocument.Load(opfStream)
+                .Descendants(OpfNs + "meta")
+                .Where(x => (string)x.Attribute("name") == name)
+                .Select(x => (string)x.Attribute("content"))
+                .FirstOrDefault();
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/MediaFiles/MetadataTagServiceEbookDispatchFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/MetadataTagServiceEbookDispatchFixture.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Reflection;
+using NLog;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.MediaFiles.Commands;
+using NUnit.Framework;
+
+namespace Chaptarr.Core.Test.MediaFiles
+{
+    /// <summary>
+    /// Ebook tag writing used to be reachable only for files that carried a Calibre id, which
+    /// meant the writeBookTags setting did nothing at all unless the user ran a Calibre content
+    /// server. These cover which files now reach the ebook tag service.
+    /// </summary>
+    [TestFixture]
+    public class MetadataTagServiceEbookDispatchFixture
+    {
+        private class ThrowingProxy<T> : DispatchProxy
+            where T : class
+        {
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                throw new NotImplementedException($"Unexpected call to {typeof(T).Name}.{targetMethod?.Name}");
+            }
+        }
+
+        private sealed class RecordingEBookTagService : IEBookTagService
+        {
+            public List<BookFile> WrittenFiles { get; } = new();
+
+            public void WriteTags(BookFile trackfile, bool newDownload, bool force = false) => WrittenFiles.Add(trackfile);
+
+            public Dictionary<string, List<string>> ReadAllTags(IFileInfo file) => throw new NotImplementedException();
+            public void SyncTags(List<Edition> books) => throw new NotImplementedException();
+            public List<RetagBookFilePreview> GetRetagPreviewsByAuthor(int authorId) => throw new NotImplementedException();
+            public List<RetagBookFilePreview> GetRetagPreviewsByBook(int bookId) => throw new NotImplementedException();
+            public void RetagFiles(RetagFilesCommand message) => throw new NotImplementedException();
+            public void RetagAuthor(RetagAuthorCommand message) => throw new NotImplementedException();
+        }
+
+        private RecordingEBookTagService _ebookTagService;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _ebookTagService = new RecordingEBookTagService();
+        }
+
+        private MetadataTagService BuildSubject()
+        {
+            return new MetadataTagService(
+                DispatchProxy.Create<IAudioTagService, ThrowingProxy<IAudioTagService>>(),
+                _ebookTagService,
+                LogManager.GetLogger("test"));
+        }
+
+        [Test]
+        public void should_write_tags_for_an_epub_that_has_no_calibre_id()
+        {
+            BuildSubject().WriteTags(new BookFile { Path = "/books/example.epub", CalibreId = 0 }, newDownload: true);
+
+            Assert.That(_ebookTagService.WrittenFiles, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void should_still_write_tags_for_a_calibre_managed_file_of_any_format()
+        {
+            BuildSubject().WriteTags(new BookFile { Path = "/books/example.pdf", CalibreId = 7 }, newDownload: true);
+
+            Assert.That(_ebookTagService.WrittenFiles, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void should_not_write_tags_for_a_format_with_no_writer_and_no_calibre_id()
+        {
+            BuildSubject().WriteTags(new BookFile { Path = "/books/example.pdf", CalibreId = 0 }, newDownload: true);
+
+            Assert.That(_ebookTagService.WrittenFiles, Is.Empty);
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/MediaFiles/TagSyncHydrationFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/TagSyncHydrationFixture.cs
@@ -67,9 +67,11 @@ namespace Chaptarr.Core.Test.MediaFiles
             ((TagConfigServiceProxy)config).WriteBookTags = WriteBookTagsType.Sync;
 
             var mediaFileService = DispatchProxy.Create<IMediaFileService, MediaFileServiceProxy>();
+            // Deliberately a format Chaptarr cannot write tags into, so this stays a test about
+            // hydrating missing book files rather than about the tag writing that follows it.
             ((MediaFileServiceProxy)mediaFileService).FilesByBooks = new List<BookFile>
             {
-                new BookFile { EditionId = 42, CalibreId = 0, Path = "/books/test.epub" }
+                new BookFile { EditionId = 42, CalibreId = 0, Path = "/books/test.pdf" }
             };
 
             var sut = new EBookTagService(
@@ -79,6 +81,7 @@ namespace Chaptarr.Core.Test.MediaFiles
                 config,
                 DispatchProxy.Create<ICalibreProxy, ThrowingProxy<ICalibreProxy>>(),
                 DispatchProxy.Create<IFileMutationSafetyService, ThrowingProxy<IFileMutationSafetyService>>(),
+                DispatchProxy.Create<IEpubSeriesTagWriter, ThrowingProxy<IEpubSeriesTagWriter>>(),
                 LogManager.GetLogger("test"));
 
             var edition = new Edition { Id = 42, BookId = 7 };

--- a/src/NzbDrone.Core/MediaFiles/EbookTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/EbookTagService.cs
@@ -41,6 +41,7 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IRootFolderService _rootFolderService;
         private readonly IConfigService _configService;
         private readonly ICalibreProxy _calibre;
+        private readonly IEpubSeriesTagWriter _epubSeriesTagWriter;
         private readonly Logger _logger;
         private readonly IFileMutationSafetyService _fileMutationSafetyService;
 
@@ -50,6 +51,7 @@ namespace NzbDrone.Core.MediaFiles
             IConfigService configService,
             ICalibreProxy calibre,
             IFileMutationSafetyService fileMutationSafetyService,
+            IEpubSeriesTagWriter epubSeriesTagWriter,
             Logger logger)
         {
             _authorService = authorService;
@@ -57,6 +59,7 @@ namespace NzbDrone.Core.MediaFiles
             _rootFolderService = rootFolderService;
             _configService = configService;
             _calibre = calibre;
+            _epubSeriesTagWriter = epubSeriesTagWriter;
             _logger = logger;
             _fileMutationSafetyService = fileMutationSafetyService;
         }
@@ -125,13 +128,13 @@ namespace NzbDrone.Core.MediaFiles
 
                 _logger.Debug($"Syncing ebook tags for {edition}");
 
-                foreach (var file in bookFiles.Where(x => x.CalibreId != 0))
+                foreach (var file in bookFiles.Where(CanWriteTags))
                 {
                     // populate tracks (which should also have release/book/author set) because
                     // not all of the updates will have been committed to the database yet
                     file.Edition = edition;
 
-                    WriteTagsInternal(file, _configService.UpdateCovers, _configService.EmbedMetadata);
+                    TryWriteTagsInternal(file, _configService.UpdateCovers, _configService.EmbedMetadata);
                 }
             }
         }
@@ -183,9 +186,9 @@ namespace NzbDrone.Core.MediaFiles
 
             _logger.ProgressInfo("Re-tagging {0} ebook files for {1}", files.Count, author.Name);
 
-            foreach (var file in files.Where(x => x.CalibreId != 0))
+            foreach (var file in files.Where(CanWriteTags))
             {
-                WriteTagsInternal(file, message.UpdateCovers, message.EmbedMetadata);
+                TryWriteTagsInternal(file, message.UpdateCovers, message.EmbedMetadata);
             }
 
             _logger.ProgressInfo("Selected ebook files re-tagged for {0}", author.Name);
@@ -202,22 +205,40 @@ namespace NzbDrone.Core.MediaFiles
 
                 _logger.ProgressInfo("Re-tagging all ebook files for author: {0}", author.Name);
 
-                foreach (var file in files.Where(x => x.CalibreId != 0))
+                foreach (var file in files.Where(CanWriteTags))
                 {
-                    WriteTagsInternal(file, message.UpdateCovers, message.EmbedMetadata);
+                    TryWriteTagsInternal(file, message.UpdateCovers, message.EmbedMetadata);
                 }
 
                 _logger.ProgressInfo("All ebook files re-tagged for {0}", author.Name);
             }
         }
 
+        /// <summary>
+        /// Bulk re-tagging walks a whole author or library, so one unreadable book must not
+        /// strand every file after it. Mirrors how the import path treats tag writing as
+        /// optional post-processing.
+        /// </summary>
+        private void TryWriteTagsInternal(BookFile file, bool updateCover, bool embedMetadata)
+        {
+            try
+            {
+                WriteTagsInternal(file, updateCover, embedMetadata);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Failed writing tags for {0}, continuing with the remaining files", file?.Path);
+            }
+        }
+
+        // A file is taggable if Calibre owns it, or if we can write into the book file ourselves.
+        private static bool CanWriteTags(BookFile file)
+        {
+            return file.CalibreId != 0 || MediaFileExtensions.CanWriteEbookSeriesTags(Path.GetExtension(file.Path));
+        }
+
         private void WriteTagsInternal(BookFile file, bool updateCover, bool embedMetadata)
         {
-            if (file.CalibreId == 0)
-            {
-                _logger.Trace($"No calibre id for {file.Path}, skipping writing tags");
-            }
-
             _fileMutationSafetyService.EnsureMutableFile(file.Path);
 
             var rootFolder = _rootFolderService.GetBestRootFolder(file.Path);
@@ -227,7 +248,101 @@ namespace NzbDrone.Core.MediaFiles
                 throw new Exception($"File '{file.Path}' is not in a root folder.");
             }
 
+            if (!rootFolder.IsCalibreLibrary)
+            {
+                WriteSeriesTagsDirectly(file);
+                return;
+            }
+
+            if (file.CalibreId == 0)
+            {
+                _logger.Trace($"No calibre id for {file.Path}, skipping writing tags");
+                return;
+            }
+
             _calibre.SetFields(file, rootFolder.CalibreSettings, updateCover, embedMetadata);
+        }
+
+        /// <summary>
+        /// Writes series metadata into the book file itself. Chaptarr already knows the series
+        /// and position for every book, but outside a Calibre library it previously had no way
+        /// to record them where a reader would look.
+        /// </summary>
+        private void WriteSeriesTagsDirectly(BookFile file)
+        {
+            if (!MediaFileExtensions.CanWriteEbookSeriesTags(Path.GetExtension(file.Path)))
+            {
+                _logger.Trace("No series tag writer for {0}, skipping", file.Path);
+                return;
+            }
+
+            var book = file.Edition?.Book;
+
+            if (book == null)
+            {
+                return;
+            }
+
+            var seriesName = GetSeriesName(book);
+
+            if (seriesName.IsNullOrWhiteSpace())
+            {
+                _logger.Trace("No series known for {0}, skipping series tags", file.Path);
+                return;
+            }
+
+            var position = GetSeriesPosition(book);
+            double? seriesIndex = null;
+
+            if (position.IsNotNullOrWhiteSpace())
+            {
+                if (double.TryParse(position, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    seriesIndex = parsed;
+                }
+                else
+                {
+                    // Positions like "2 - Heavy Metal" are common in imported metadata. A reader
+                    // needs a plain number, so record the series without a position rather than
+                    // writing something it cannot use.
+                    _logger.Debug("Series position '{0}' for {1} is not numeric, writing series without a position", position, file.Path);
+                }
+            }
+
+            if (_epubSeriesTagWriter.WriteSeriesTags(file.Path, seriesName, seriesIndex))
+            {
+                _logger.Debug("Wrote series tags to {0}: {1} #{2}", file.Path, seriesName, seriesIndex?.ToString(CultureInfo.InvariantCulture) ?? "-");
+            }
+        }
+
+        // The denormalised columns on Book are the values Chaptarr itself displays and keeps in
+        // step with the metadata provider. The relational series links are only consulted when
+        // those are empty.
+        private static string GetSeriesName(Book book)
+        {
+            if (book.SeriesName.IsNotNullOrWhiteSpace())
+            {
+                return book.SeriesName;
+            }
+
+            return GetPrimarySeriesLink(book)?.Series?.Value?.Title;
+        }
+
+        private static string GetSeriesPosition(Book book)
+        {
+            if (book.SeriesName.IsNotNullOrWhiteSpace())
+            {
+                return book.SeriesPosition;
+            }
+
+            return GetPrimarySeriesLink(book)?.Position;
+        }
+
+        private static SeriesBookLink GetPrimarySeriesLink(Book book)
+        {
+            return book.SeriesLinks?
+                .OrderBy(x => x.SeriesPosition)
+                .FirstOrDefault(x => x.Series?.Value?.Title.IsNotNullOrWhiteSpace() == true);
         }
 
         private IEnumerable<RetagBookFilePreview> GetPreviews(List<BookFile> files)

--- a/src/NzbDrone.Core/MediaFiles/EpubSeriesTagWriter.cs
+++ b/src/NzbDrone.Core/MediaFiles/EpubSeriesTagWriter.cs
@@ -1,0 +1,269 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using NLog;
+
+namespace NzbDrone.Core.MediaFiles
+{
+    public interface IEpubSeriesTagWriter
+    {
+        bool WriteSeriesTags(string epubPath, string seriesName, double? seriesIndex);
+    }
+
+    /// <summary>
+    /// Writes Calibre-style series metadata directly into an epub's OPF package document.
+    ///
+    /// Chaptarr's other tag writer talks to a Calibre content server, which most users do not
+    /// run. Readers such as Kavita group books into series purely from the calibre:series and
+    /// calibre:series_index meta elements, so without this the series Chaptarr already knows
+    /// never reaches the reader.
+    /// </summary>
+    public class EpubSeriesTagWriter : IEpubSeriesTagWriter
+    {
+        private const string SeriesMetaName = "calibre:series";
+        private const string SeriesIndexMetaName = "calibre:series_index";
+        private const string MimetypeEntryName = "mimetype";
+
+        private static readonly XNamespace ContainerNs = "urn:oasis:names:tc:opendocument:xmlns:container";
+
+        private readonly Logger _logger;
+
+        public EpubSeriesTagWriter(Logger logger)
+        {
+            _logger = logger;
+        }
+
+        public bool WriteSeriesTags(string epubPath, string seriesName, double? seriesIndex)
+        {
+            string opfPath;
+            XmlDocument opf;
+
+            using (var archive = ZipFile.OpenRead(epubPath))
+            {
+                opfPath = GetOpfPath(archive);
+
+                if (opfPath == null)
+                {
+                    _logger.Debug("No OPF package document found in {0}, not writing series tags", epubPath);
+                    return false;
+                }
+
+                using var opfStream = archive.GetEntry(opfPath).Open();
+
+                // PreserveWhitespace keeps the reader's own formatting, and XmlDocument writes
+                // every node back with the prefix it was read with. XDocument re-derives
+                // prefixes, which silently rewrites <metadata> as <opf:metadata> whenever the
+                // package binds a prefix to the namespace it already uses by default.
+                opf = new XmlDocument { PreserveWhitespace = true };
+                opf.Load(opfStream);
+            }
+
+            if (!ApplySeriesTags(opf, seriesName, seriesIndex))
+            {
+                return false;
+            }
+
+            RewriteArchive(epubPath, opfPath, opf);
+
+            return true;
+        }
+
+        private static string GetOpfPath(ZipArchive archive)
+        {
+            var containerEntry = archive.GetEntry("META-INF/container.xml");
+
+            if (containerEntry == null)
+            {
+                return null;
+            }
+
+            using var containerStream = containerEntry.Open();
+
+            return XDocument.Load(containerStream)
+                .Descendants(ContainerNs + "rootfile")
+                .Select(x => (string)x.Attribute("full-path"))
+                .FirstOrDefault(x => !string.IsNullOrWhiteSpace(x));
+        }
+
+        private static bool ApplySeriesTags(XmlDocument opf, string seriesName, double? seriesIndex)
+        {
+            var package = opf.DocumentElement;
+
+            if (package == null)
+            {
+                return false;
+            }
+
+            var metadata = package.ChildNodes.OfType<XmlElement>()
+                .FirstOrDefault(x => x.LocalName == "metadata" && x.NamespaceURI == package.NamespaceURI);
+
+            if (metadata == null)
+            {
+                return false;
+            }
+
+            var changed = UpsertMeta(metadata, SeriesMetaName, seriesName);
+
+            // Calibre stores the index as a plain decimal number; anything else makes readers
+            // fall back to treating the book as unpositioned.
+            var index = seriesIndex?.ToString("0.##", CultureInfo.InvariantCulture);
+
+            return UpsertMeta(metadata, SeriesIndexMetaName, index) || changed;
+        }
+
+        private static bool UpsertMeta(XmlElement metadata, string name, string content)
+        {
+            var existing = metadata.ChildNodes.OfType<XmlElement>()
+                .FirstOrDefault(x => x.LocalName == "meta" &&
+                                     x.NamespaceURI == metadata.NamespaceURI &&
+                                     x.GetAttribute("name") == name);
+
+            // A null value means "we have nothing trustworthy to say about this field", so any
+            // stale value is cleared rather than left to contradict the rest of the metadata.
+            if (content == null)
+            {
+                if (existing == null)
+                {
+                    return false;
+                }
+
+                RemoveWithLeadingWhitespace(metadata, existing);
+                return true;
+            }
+
+            if (existing != null)
+            {
+                if (existing.GetAttribute("content") == content)
+                {
+                    return false;
+                }
+
+                existing.SetAttribute("content", content);
+                return true;
+            }
+
+            AppendMeta(metadata, name, content);
+            return true;
+        }
+
+        /// <summary>
+        /// Adds a meta element carrying the same prefix as the metadata element around it, so the
+        /// addition is indistinguishable in style from what the book already contained.
+        /// </summary>
+        private static void AppendMeta(XmlElement metadata, string name, string content)
+        {
+            var element = metadata.OwnerDocument.CreateElement(metadata.Prefix, "meta", metadata.NamespaceURI);
+            element.SetAttribute("name", name);
+            element.SetAttribute("content", content);
+
+            var lastElement = metadata.ChildNodes.OfType<XmlElement>().LastOrDefault();
+
+            if (lastElement == null)
+            {
+                metadata.AppendChild(element);
+                return;
+            }
+
+            // Sit directly after the last entry, borrowing its indentation, so the whitespace
+            // that already closes the element is left exactly as the reader wrote it.
+            metadata.InsertAfter(element, lastElement);
+
+            if (IsWhitespace(lastElement.PreviousSibling))
+            {
+                metadata.InsertBefore(metadata.OwnerDocument.CreateWhitespace(lastElement.PreviousSibling.Value), element);
+            }
+        }
+
+        // With PreserveWhitespace on, whitespace-only nodes are XmlWhitespace rather than
+        // XmlText, and the two are siblings in the type hierarchy rather than one deriving
+        // from the other.
+        private static bool IsWhitespace(XmlNode node)
+        {
+            return node is XmlCharacterData data && string.IsNullOrWhiteSpace(data.Value);
+        }
+
+        private static void RemoveWithLeadingWhitespace(XmlElement metadata, XmlElement element)
+        {
+            if (IsWhitespace(element.PreviousSibling))
+            {
+                metadata.RemoveChild(element.PreviousSibling);
+            }
+
+            metadata.RemoveChild(element);
+        }
+
+        /// <summary>
+        /// Rewrites the archive to a sibling temporary file and moves it into place, so a failure
+        /// part-way through can never leave the user with a truncated book.
+        /// </summary>
+        private void RewriteArchive(string epubPath, string opfPath, XmlDocument opf)
+        {
+            var tempPath = epubPath + ".chaptarr-tmp";
+
+            try
+            {
+                using (var source = ZipFile.OpenRead(epubPath))
+                using (var destStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write))
+                using (var dest = new ZipArchive(destStream, ZipArchiveMode.Create))
+                {
+                    foreach (var entry in OrderEntries(source))
+                    {
+                        // The spec requires mimetype to be the first entry and stored uncompressed.
+                        var level = entry.FullName == MimetypeEntryName
+                            ? CompressionLevel.NoCompression
+                            : CompressionLevel.Optimal;
+
+                        var destEntry = dest.CreateEntry(entry.FullName, level);
+                        destEntry.LastWriteTime = entry.LastWriteTime;
+
+                        using var destEntryStream = destEntry.Open();
+
+                        if (entry.FullName == opfPath)
+                        {
+                            // No BOM and no re-indenting: the only intended difference between
+                            // the old package document and the new one is the series metadata.
+                            var settings = new XmlWriterSettings
+                            {
+                                Encoding = new UTF8Encoding(false),
+                                Indent = false,
+                                CloseOutput = false
+                            };
+
+                            using var xmlWriter = XmlWriter.Create(destEntryStream, settings);
+                            opf.Save(xmlWriter);
+                        }
+                        else
+                        {
+                            using var sourceEntryStream = entry.Open();
+                            sourceEntryStream.CopyTo(destEntryStream);
+                        }
+                    }
+                }
+
+                File.Move(tempPath, epubPath, true);
+            }
+            catch
+            {
+                if (File.Exists(tempPath))
+                {
+                    File.Delete(tempPath);
+                }
+
+                throw;
+            }
+        }
+
+        private static IEnumerable<ZipArchiveEntry> OrderEntries(ZipArchive archive)
+        {
+            return archive.Entries
+                .OrderByDescending(x => x.FullName == MimetypeEntryName)
+                .ToList();
+        }
+    }
+}

--- a/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
+++ b/src/NzbDrone.Core/MediaFiles/MediaFileExtensions.cs
@@ -17,6 +17,11 @@ namespace NzbDrone.Core.MediaFiles
         private static readonly HashSet<string> _allExtensionSet;
         private static readonly HashSet<string> _singleFileBookContainerSet;
 
+        // Formats Chaptarr can write series metadata into without help from Calibre. Both are
+        // OPF-in-a-zip; the Mobi-derived formats and PDF have no writer.
+        private static readonly HashSet<string> _seriesTagWritableExtensionSet =
+            new HashSet<string>(new[] { ".epub", ".kepub" }, StringComparer.OrdinalIgnoreCase);
+
         static MediaFileExtensions()
         {
             _textExtensions = new Dictionary<string, Quality>(StringComparer.OrdinalIgnoreCase)
@@ -95,6 +100,11 @@ namespace NzbDrone.Core.MediaFiles
         public static bool CanWriteAudioTags(string extension)
         {
             return AudioExtensions.Contains(extension) && !IsMatroskaAudioExtension(extension);
+        }
+
+        public static bool CanWriteEbookSeriesTags(string extension)
+        {
+            return extension != null && _seriesTagWritableExtensionSet.Contains(extension);
         }
 
         public static bool IsSingleFileBookContainer(string extension)

--- a/src/NzbDrone.Core/MediaFiles/MetadataTagService.cs
+++ b/src/NzbDrone.Core/MediaFiles/MetadataTagService.cs
@@ -417,7 +417,7 @@ namespace NzbDrone.Core.MediaFiles
             {
                 _audioTagService.WriteTags(bookFile, newDownload, force);
             }
-            else if (bookFile.CalibreId > 0)
+            else if (bookFile.CalibreId > 0 || MediaFileExtensions.CanWriteEbookSeriesTags(extension))
             {
                 _eBookTagService.WriteTags(bookFile, newDownload, force);
             }


### PR DESCRIPTION
#### Description

**The problem.** If you read your Chaptarr library in something like Kavita, books that belong to a series often show up as unrelated standalone titles instead of being grouped together. A reader works out which series a book belongs to by looking *inside* the ebook file. Chaptarr knows perfectly well what series a book is in and where it falls in the order — it just never writes any of that into the file, so the reader never sees it. Today the only ebooks that group correctly are the ones whose original packager happened to fill the field in already; Chaptarr itself contributes nothing either way.

**Why it happens.** Chaptarr already has a setting for this, Write Book Tags, and a whole ebook tag-writing subsystem behind it. But that writer only ever runs for books that have been registered with a Calibre content server, because it's gated on an id that only Calibre hands out. If you don't run Calibre — which is most people — the setting silently does nothing at all. It isn't broken so much as unreachable.

**What this does.** Makes that existing setting actually work without Calibre, by writing the series name and position directly into the epub. Anyone already using Calibre keeps the current behaviour, unchanged.

So this is less a new feature than making an existing setting, and an existing subsystem, do something for the majority of users.

<details>
<summary>Technical detail</summary>

Ebook tag writing is reachable only for files that carry a `BookFiles.CalibreId`, and that column is populated exclusively by `cdb/add-book/`. `MetadataTagService.WriteTags` gates the ebook branch on `bookFile.CalibreId > 0`, and `SyncTags` / `RetagFiles` / `RetagAuthor` each filter on `CalibreId != 0`. With no Calibre server there is no id, so nothing downstream ever runs. (`EBookTagService.WriteTagsInternal` also logs "No calibre id … skipping writing tags" without actually returning, so the message is misleading; that's fixed here too.)

The specific fields that matter are `calibre:series` and `calibre:series_index` in the epub's OPF package document — Kavita decides series membership *solely* from those. `ReadAllEpubTags` already parses both on the way in, so only the write side was missing.

This adds an OPF writer for `.epub` / `.kepub`, plus routing to it when a file's root folder is not a Calibre library (`RootFolder.IsCalibreLibrary`). Calibre libraries keep their existing `CalibreProxy.SetFields` path untouched.

</details>

Deliberate choices worth flagging for review:

- **No new setting.** It honours the existing `writeBookTags` enum. The default is `NewFiles`, so an existing library is never touched until the user either downloads a new book or explicitly asks for a re-tag. There is no scheduled task that triggers re-tagging.
- **This does change behaviour on defaults**, in that a newly imported epub now gets modified where previously it silently didn't. That seemed right given the setting is named "Write Book Tags" and already defaults to "for new files" — but it's the judgement call most worth challenging here.
- **Never edits in place.** The archive is rewritten to a temporary file and moved into place, so an interrupted write can't truncate a book. `mimetype` stays first and stored.
- **Idempotent.** An epub whose tags already match is left byte for byte alone.
- **Non-numeric positions.** Real `SeriesPosition` values include things like `2 - Heavy Metal`. Those record the series *without* a position rather than writing a value readers can't parse — the book still groups correctly, it just loses its ordering. Fractional positions like `11.5` are kept, and the index always uses an invariant decimal separator.
- **Series source.** Uses the denormalised `Book.SeriesName` / `Book.SeriesPosition`, falling back to the relational series links only when those are empty. Happy to switch to the links if you'd rather be consistent with `SetFields`.
- **`XmlDocument`, not `XDocument`.** `XDocument` re-derives namespace prefixes on save. An OPF package commonly binds a prefix to the same namespace URI it already uses by default, and in that case a round trip rewrote `<metadata>` as `<opf:metadata>` and every `<meta>` as `<opf:meta>`. Namespace-equivalent, but it rewrites much more of the user's book than intended and risks tripping prefix-sensitive OPF parsers. `XmlDocument` with `PreserveWhitespace` writes each node back with the prefix it was read with and emits no BOM.
- **Bulk re-tagging no longer aborts** on the first unwritable file, matching how `ImportApprovedBooks.TryWriteTags` already treats tag writing as optional post-processing.

**Known gap, deliberately not addressed:** retag *previews* still go through Calibre only, so for a non-Calibre library the preview lists no changes while the re-tag itself now does work. Closing that needs a non-Calibre "read the current tags back and diff them" implementation, which felt like it belonged in its own PR rather than doubling the size of this one. Happy to fold it in if you'd prefer.

#### Database Migration

NO. No schema changes and no new columns — this reads `Books.SeriesName` / `Books.SeriesPosition` and `RootFolders.IsCalibreLibrary`, all of which already exist.

#### How was this tested?

**Unit tests** — 23 new tests, all written before the code and watched failing first. `develop` (537eb64): 2834 → this branch: 2857 (+23), 0 failing.

Run against this repo's own CI commands rather than just locally convenient ones, all clean:

| step | result |
| --- | --- |
| Guard — merge-conflict markers, `package.json` parse | clean |
| `version_guard.py sync` | OK 0.9.929 |
| `version_guard.py monotonic --compare-ref origin/develop` | OK 0.9.929 |
| `version_guard.py commit-hygiene --compare-ref origin/develop` | OK for `origin/develop..HEAD` |
| `dotnet build src/Chaptarr.NoTests.sln --configuration Release` | 0 warnings, 0 errors |
| `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj --configuration Release` | 2857 passed, 0 failed |
| `dotnet publish src/NzbDrone.Console/Chaptarr.Console.csproj -c Release` | exit 0 |

No frontend files are touched (8 files changed, all `.cs`), so the yarn steps that live outside `build.yml` aren't applicable here.

- `EpubSeriesTagWriterFixture` — writes when absent, updates when stale, reports unchanged and leaves the file byte-identical when tags already match, omits and clears the index when the position is unknown, keeps `mimetype` first and stored, invariant decimal separator under a comma-decimal culture, doesn't re-prefix elements it didn't need to touch, leaves unrelated `dc:` metadata alone, and a round trip proving the bundled `VersOne.Epub` reader can read back what was written.
- `EbookTagServiceDirectWriteFixture` — routing by `IsCalibreLibrary` (with a Calibre proxy that throws on any call, so reaching Calibre fails the test), non-numeric and fractional position handling, no series and unsupported-format cases, config gating, backfill via `RetagAuthor`, sync, and continuing past a file that throws.
- `MetadataTagServiceEbookDispatchFixture` — an epub with no Calibre id now dispatches; a Calibre-managed file of any format still dispatches; an unsupported format with no Calibre id still doesn't.

Test epubs are generated by the fixture from text written for the purpose; nothing is committed as a binary.

**End to end**, Docker on Linux: this branch's `Chaptarr.Core.dll` bind-mounted over the published `chaptarr/chaptarr:0.9.929` image (the assembly version matches, so no full image rebuild), against an empty config and a scratch library, with three generated epubs and a non-Calibre root folder. Ran `RetagAuthor` from the API and checksummed before and after:

| epub | series data in Chaptarr | result |
| --- | --- | --- |
| no existing tags | `An Example Series` / `3` | both meta elements written |
| no existing tags | `An Example Series` / `2 - Heavy Metal` | series written, index correctly omitted |
| already correctly tagged | matching values | **byte identical — not rewritten** |

The resulting OPF keeps its original prefixes, indentation and unrelated metadata, with `mimetype` still first and stored. This also confirms the new interface resolves through DryIoc's auto-registration at runtime, which the unit tests can't prove.

#### Screenshots (UI changes only)

None — no UI changes.
