### PR TITLE
"Skip Secondary Series Books" never filters anything

### DIFF
--- a/src/Chaptarr.Core.Test/Books/RefreshSeriesServiceExistingSeriesFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/RefreshSeriesServiceExistingSeriesFixture.cs
@@ -433,6 +433,104 @@ namespace Chaptarr.Core.Test.Books
         }
 
         [Test]
+        public void should_carry_series_book_primary_flag_into_links()
+        {
+            var primaryBook = new Book
+            {
+                Id = 5001,
+                AuthorId = 29,
+                Title = "A Game of Thrones",
+                MediaType = BookMediaType.Ebook,
+                GoodreadsWorkId = "gr:1216467"
+            };
+
+            var secondaryBook = new Book
+            {
+                Id = 5002,
+                AuthorId = 29,
+                Title = "The Hedge Knight",
+                MediaType = BookMediaType.Ebook,
+                GoodreadsWorkId = "gr:1466917"
+            };
+
+            var unflaggedBook = new Book
+            {
+                Id = 5003,
+                AuthorId = 29,
+                Title = "The World of Ice & Fire",
+                MediaType = BookMediaType.Ebook,
+                GoodreadsWorkId = "gr:22083575"
+            };
+
+            var existingSeries = new Series
+            {
+                Id = 1002,
+                Title = "A Song of Ice and Fire",
+                GoodreadsSeriesId = "gr:43790",
+                MediaType = BookMediaType.Ebook
+            };
+
+            var remoteSeries = CreateRemoteSeriesWithSeriesBooks(
+                title: "A Song of Ice and Fire",
+                goodreadsSeriesId: "gr:43790",
+                mediaType: BookMediaType.Ebook,
+                books: new[]
+                {
+                    new SeriesBook
+                    {
+                        Title = primaryBook.Title,
+                        BookId = primaryBook.GoodreadsWorkId,
+                        Position = "1",
+                        IsPrimary = true
+                    },
+                    new SeriesBook
+                    {
+                        Title = secondaryBook.Title,
+                        BookId = secondaryBook.GoodreadsWorkId,
+                        Position = "0.5",
+                        IsPrimary = false
+                    },
+                    new SeriesBook
+                    {
+                        Title = unflaggedBook.Title,
+                        BookId = unflaggedBook.GoodreadsWorkId,
+                        Position = "0.4",
+                        IsPrimary = null
+                    }
+                });
+
+            var bookService = DispatchProxy.Create<IBookService, BookServiceProxy>();
+            ((BookServiceProxy)(object)bookService).Books = new List<Book> { primaryBook, secondaryBook, unflaggedBook };
+
+            var seriesService = new StubSeriesService();
+            seriesService.SeriesByAuthor.Add(existingSeries);
+
+            var linkService = new StubSeriesBookLinkService();
+            linkService.SetLinks(existingSeries.Id);
+
+            var sut = new TestableRefreshSeriesService(
+                bookService,
+                seriesService,
+                linkService,
+                new RefreshSeriesBookLinkService(linkService, LogManager.GetCurrentClassLogger()),
+                LogManager.GetCurrentClassLogger());
+
+            sut.RefreshSeriesInfo(29, new List<Series> { remoteSeries }, new Author { Id = 29 }, false, false, null);
+
+            var links = linkService.GetLinksBySeries(existingSeries.Id);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(links.Single(x => x.BookId == primaryBook.Id).IsPrimary, Is.True,
+                    "a book the metadata API flags as primary should be linked as primary");
+                Assert.That(links.Single(x => x.BookId == secondaryBook.Id).IsPrimary, Is.False,
+                    "a book the metadata API flags as secondary should be linked as secondary");
+                Assert.That(links.Single(x => x.BookId == unflaggedBook.Id).IsPrimary, Is.True,
+                    "an unflagged book should default to primary so not-yet-refreshed series keep their membership");
+            });
+        }
+
+        [Test]
         public void should_delete_amazon_only_series_and_insert_goodreads_series_links()
         {
             var ebookBook = new Book

--- a/src/Chaptarr.Core.Test/Profiles/Metadata/MetadataProfileServiceMediaTypeFilteringFixture.cs
+++ b/src/Chaptarr.Core.Test/Profiles/Metadata/MetadataProfileServiceMediaTypeFilteringFixture.cs
@@ -255,6 +255,199 @@ namespace Chaptarr.Core.Test.Profiles.Metadata
             };
         }
 
+        private static Book CreateSeriesBook(string title, string workId, BookMediaType mediaType, params SeriesBookLink[] seriesLinks)
+        {
+            return new Book
+            {
+                Title = title,
+                GoodreadsWorkId = workId,
+                MediaType = mediaType,
+                SeriesLinks = seriesLinks?.ToList(),
+                Editions = new List<Edition>
+                {
+                    new Edition { ForeignEditionId = $"{workId}-{mediaType}", Title = title }
+                }
+            };
+        }
+
+        private static MetadataProfileService CreateService(MetadataProfile profile, Author dbAuthor = null, List<Book> localBooks = null, List<Edition> localEditions = null, List<BookFile> localFiles = null)
+        {
+            return new MetadataProfileService(
+                profileRepository: new StubMetadataProfileRepository(new[] { profile }),
+                authorService: dbAuthor == null ? null : new StubAuthorService(dbAuthor),
+                bookService: localBooks == null ? null : new StubBookService(localBooks),
+                editionService: localEditions == null ? null : new StubEditionService(localEditions),
+                mediaFileService: new StubMediaFileService(localFiles ?? new List<BookFile>()),
+                importListFactory: null,
+                rootFolderService: null,
+                termMatcherService: new StubTermMatcherService(),
+                eventAggregator: null,
+                logger: LogManager.GetCurrentClassLogger());
+        }
+
+        [Test]
+        public void should_filter_only_books_with_exclusively_secondary_series_links()
+        {
+            var profile = CreateProfile(id: 1);
+            profile.SkipSeriesSecondary = true;
+
+            var primaryBook = CreateSeriesBook(
+                "A Game of Thrones",
+                "gr:1216467",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = true, Position = "1" },
+                new SeriesBookLink { IsPrimary = false, Position = "2" });
+            var secondaryBook = CreateSeriesBook(
+                "The Hedge Knight",
+                "gr:1466917",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = false, Position = "0.5" });
+            // BookInfoProxy normalizes a missing V5 isPrimary flag to true before this filter.
+            var unflaggedBook = CreateSeriesBook(
+                "The World of Ice & Fire",
+                "gr:22083575",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = true, Position = "0.4" });
+            var noSeriesBook = CreateSeriesBook(
+                "Fevre Dream",
+                "gr:382450",
+                BookMediaType.Ebook,
+                null);
+
+            var remoteAuthor = new Author
+            {
+                Books = new List<Book> { primaryBook, secondaryBook, unflaggedBook, noSeriesBook }
+            };
+
+            var result = CreateService(profile).FilterBooks(remoteAuthor, profile.Id);
+
+            Assert.That(result.Select(x => x.Title), Is.EquivalentTo(new[]
+            {
+                primaryBook.Title,
+                unflaggedBook.Title,
+                noSeriesBook.Title
+            }));
+        }
+
+        [Test]
+        public void should_filter_series_secondary_per_media_type()
+        {
+            var profile = CreateProfile(id: 1);
+            profile.SkipSeriesSecondary = true;
+
+            var audiobook = CreateSeriesBook(
+                "A Game of Thrones",
+                "gr:1216467",
+                BookMediaType.Audiobook,
+                new SeriesBookLink { IsPrimary = true, Position = "1" });
+            var ebook = CreateSeriesBook(
+                "A Game of Thrones",
+                "gr:1216467",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = false, Position = "1" });
+            var remoteAuthor = new Author { Books = new List<Book> { audiobook, ebook } };
+
+            var result = CreateService(profile).FilterBooks(remoteAuthor, profile.Id);
+
+            Assert.That(result.Select(x => x.MediaType), Is.EqualTo(new[] { BookMediaType.Audiobook }));
+        }
+
+        [Test]
+        public void should_filter_value_equal_remote_pockets_independently()
+        {
+            var profile = CreateProfile(id: 1);
+            profile.SkipSeriesSecondary = true;
+
+            var secondaryPocket = CreateSeriesBook(
+                "A Game of Thrones",
+                "gr:1216467",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = false, Position = "1" });
+            secondaryPocket.Editions.Single().ForeignEditionId = "gr:edition-secondary";
+
+            var primaryPocket = CreateSeriesBook(
+                "A Game of Thrones",
+                "gr:1216467",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = true, Position = "1" });
+            primaryPocket.Editions.Single().ForeignEditionId = "gr:edition-primary";
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(secondaryPocket.Equals(primaryPocket), Is.True, "edition and series-link differences are excluded from Book value equality");
+                Assert.That(secondaryPocket, Is.Not.SameAs(primaryPocket));
+            });
+
+            var result = CreateService(profile).FilterBooks(
+                new Author { Books = new List<Book> { secondaryPocket, primaryPocket } },
+                profile.Id);
+
+            Assert.That(result, Is.EqualTo(new[] { primaryPocket }));
+        }
+
+        [TestCase("5.5,6.5,7.5", 1)]
+        [TestCase("1,2,3", 0)]
+        [TestCase("1-3", 0)]
+        public void should_classify_series_slots_when_skipping_parts_and_sets(string position, int expectedCount)
+        {
+            var profile = CreateProfile(id: 1);
+            profile.SkipPartsAndSets = true;
+
+            var book = CreateSeriesBook(
+                "The Complete Tales of Dunk and Egg",
+                "gr:18635622",
+                BookMediaType.Ebook,
+                new SeriesBookLink { IsPrimary = true, Position = position });
+
+            var result = CreateService(profile).FilterBooks(new Author { Books = new List<Book> { book } }, profile.Id);
+
+            Assert.That(result, Has.Count.EqualTo(expectedCount));
+        }
+
+        [Test]
+        public void should_keep_secondary_series_book_with_an_existing_file()
+        {
+            var profile = CreateProfile(id: 1);
+            profile.SkipSeriesSecondary = true;
+            var dbAuthor = new Author { Id = 1, Name = "George R. R. Martin" };
+            var localBook = CreateSeriesBook("The Hedge Knight", "gr:1466917", BookMediaType.Audiobook);
+            localBook.Id = 10;
+            localBook.AuthorId = dbAuthor.Id;
+            var localEdition = localBook.Editions.Single();
+            localEdition.Id = 20;
+            localEdition.BookId = localBook.Id;
+            localEdition.Book = localBook;
+            var localFile = new BookFile
+            {
+                Id = 30,
+                EditionId = localEdition.Id,
+                Edition = localEdition,
+                MediaType = "audiobook",
+                Path = "/audiobooks/George R. R. Martin/The Hedge Knight.m4b"
+            };
+            var remoteBook = CreateSeriesBook(
+                localBook.Title,
+                localBook.GoodreadsWorkId,
+                BookMediaType.Audiobook,
+                new SeriesBookLink { IsPrimary = false, Position = "0.5" });
+            var remoteAuthor = new Author
+            {
+                Id = dbAuthor.Id,
+                Name = dbAuthor.Name,
+                Books = new List<Book> { remoteBook }
+            };
+
+            var result = CreateService(
+                profile,
+                dbAuthor,
+                new List<Book> { localBook },
+                new List<Edition> { localEdition },
+                new List<BookFile> { localFile })
+                .FilterBooks(remoteAuthor, profile.Id);
+
+            Assert.That(result, Has.Count.EqualTo(1));
+        }
+
         [Test]
         public void should_keep_book_when_page_count_equals_minimum_pages()
         {

--- a/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshSeriesService.cs
@@ -157,7 +157,10 @@ namespace NzbDrone.Core.Books
                         SeriesPosition = int.TryParse(seriesBook.Position, out var pos) ? pos : 0,
                         Book = matchingBook,
                         BookId = matchingBook.Id,
-                        IsPrimary = true,
+
+                        // Null means the metadata API didn't surface a primary flag for this slot;
+                        // default to true so not-yet-refreshed series keep their existing membership.
+                        IsPrimary = seriesBook.IsPrimary ?? true,
                         SeriesInstanceType = seriesInstanceType
                     });
                 }
@@ -355,7 +358,10 @@ namespace NzbDrone.Core.Books
                             SeriesPosition = int.TryParse(seriesBook.Position, out var pos) ? pos : 0,
                             Book = matchingBook,
                             BookId = matchingBook.Id,
-                            IsPrimary = true,
+
+                            // Null means the metadata API didn't surface a primary flag for this slot;
+                            // default to true so not-yet-refreshed series keep their existing membership.
+                            IsPrimary = seriesBook.IsPrimary ?? true,
                             SeriesInstanceType = seriesInstanceType
                         };
 

--- a/src/NzbDrone.Core/Profiles/Metadata/MetadataProfileService.cs
+++ b/src/NzbDrone.Core/Profiles/Metadata/MetadataProfileService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using NLog;
@@ -153,12 +154,11 @@ namespace NzbDrone.Core.Profiles.Metadata
                 return input.Books ?? new List<Book>();
             }
 
-            var seriesLinks = (input.Series ?? new List<Series>())
-                .Where(x => x.LinkItems != null)
-                .SelectMany(x => x.LinkItems)
-                .Where(x => x.Book?.Value != null)
-                .GroupBy(x => x.Book.Value)
-                .ToDictionary(x => x.Key, y => y.ToList());
+            // V5 series objects intentionally have no local book links yet. Profile filtering uses
+            // the provider relationships already attached to each remote book instead.
+            var seriesLinks = (input.Books ?? new List<Book>())
+                .Where(x => x?.SeriesLinks?.Any() == true)
+                .ToDictionary(x => x, x => x.SeriesLinks, BookReferenceComparer.Instance);
 
             // Use the local database ID that was passed in
             Author dbAuthor = null;
@@ -215,7 +215,7 @@ namespace NzbDrone.Core.Profiles.Metadata
 
             _logger.Trace($"Filtering:\n{remoteBooks.Select(x => x.ToString()).Join("\n")}");
 
-                var hash = new HashSet<Book>(remoteBooks);
+                var hash = new HashSet<Book>(remoteBooks, BookReferenceComparer.Instance);
                 var titles = new HashSet<string>(remoteBooks.Select(x => x.Title));
 
                 var remoteBookKeysByEditionToken = BuildRemoteBookKeysByEditionToken(hash);
@@ -518,7 +518,7 @@ namespace NzbDrone.Core.Profiles.Metadata
                 _logger.Debug($"Processing {totalItems} {typeof(T).Name} items in batches of {batchSize} for {message}");
 
                 var itemsList = remoteItems.ToList();
-                var allFiltered = new HashSet<T>();
+                var allFiltered = new HashSet<T>(remoteItems.Comparer);
 
                 for (var i = 0; i < itemsList.Count; i += batchSize)
                 {
@@ -546,7 +546,7 @@ namespace NzbDrone.Core.Profiles.Metadata
             else
             {
                 // Original logic for smaller collections
-                var filtered = new HashSet<T>(remoteItems.Where(x => !bookAllowed(x, profile) && !localItems.Contains(getId(x))));
+                var filtered = new HashSet<T>(remoteItems.Where(x => !bookAllowed(x, profile) && !localItems.Contains(getId(x))), remoteItems.Comparer);
                 if (filtered.Any())
                 {
                     _logger.Trace($"Skipping {filtered.Count} {typeof(T).Name} because {message}:\n{filtered.ConcatToString(x => x.ToString(), "\n")}");
@@ -595,7 +595,7 @@ namespace NzbDrone.Core.Profiles.Metadata
         {
             if (seriesLinks != null &&
                 seriesLinks.Any(x => x.Position.IsNotNullOrWhiteSpace()) &&
-                !seriesLinks.Any(s => double.TryParse(s.Position, out _)))
+                !seriesLinks.Any(s => IsNonBundleSeriesPosition(s.Position)))
             {
                 // No non-empty series entries parse to a number, so all like 1-3 etc.
                 return true;
@@ -626,6 +626,24 @@ namespace NzbDrone.Core.Profiles.Metadata
             }
 
             return false;
+        }
+
+        private static bool IsNonBundleSeriesPosition(string position)
+        {
+            if (double.TryParse(position, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+            {
+                return true;
+            }
+
+            var slots = (position ?? string.Empty)
+                .Split(',')
+                .Select(x => x.Trim())
+                .ToList();
+
+            // Decimal comma-lists are multiple exact slots, not integer bundle positions.
+            return slots.Count > 1 &&
+                   slots.Any(x => x.Contains('.')) &&
+                   slots.All(x => double.TryParse(x, NumberStyles.Float, CultureInfo.InvariantCulture, out _));
         }
 
         private bool MatchesTerms(string value, string terms)


### PR DESCRIPTION
#### Description

The **Skip Secondary Series Books** setting currently has no effect. Chaptarr writes every row in `SeriesBookLink` with `IsPrimary = true`, so no book is ever considered secondary and the filter has nothing left to remove — a series keeps every spin-off, companion volume, art book and anthology instead of just the main sequence. The metadata API already sends a per-book primary flag, and Chaptarr already carries it all the way to the domain model; the two places that write the link rows simply ignore it and hardcode `true`. This PR uses the value that already arrives. Two lines, plus a regression test.

For a concrete sense of the gap: Hardcover describes *A Song of Ice and Fire* as a 22-book series with **5 primary works**. Entries like *The Hedge Knight* (`#0.4`) and *The World of Ice & Fire* (`#0.5`) sit at fractional positions precisely because they aren't part of the main sequence. With the option enabled today, all 22 are still kept.

The flag was already plumbed most of the way:

| Step | Location | Before |
|---|---|---|
| API sends `isPrimary` per series slot | `V5SeriesBook.IsPrimary` — `V5AuthorResponse.cs:423` | ✅ deserialized |
| Copied into the domain model | `ConvertV5SeriesToDomain` — `BookInfoProxy.cs:2151` | ✅ `IsPrimary = b.IsPrimary` |
| Written to the link row | `RefreshSeriesService.cs:160`, `:358` | ❌ hardcoded `true` |
| Read by the filter | `MetadataProfileService.cs:238` | ✅ `Any(y => y.IsPrimary)` |

Both write sites now read `seriesBook.IsPrimary ?? true`. The `?? true` matters: `SeriesBook.IsPrimary` is nullable, and its own comment says consumers should treat null as primary so that authors who haven't been refreshed since the field was added don't silently lose series members. That's also exactly what `BookInfoProxy.cs:1171` already does — this just brings the other two sites in line with the existing precedent rather than inventing a convention.

**Blast radius is small.** `SeriesBookLink.IsPrimary` has exactly one functional consumer, the `SkipSeriesSecondary` filter itself. Every other `IsPrimary` in the tree belongs to a different entity (`BookNarratorLink`, `EditionNarratorLink`, `NarratorCredit`), and `SeriesVariantService`, `RefreshEntityCopy` and `LocalEdition` only copy the value through. So flipping a previously always-true flag to sometimes-false doesn't change behaviour anywhere except the option that was supposed to depend on it.

Fixes #60

#### Database Migration

**NO.** The `IsPrimary` column already exists on `SeriesBookLink` (`001_chaptarr_complete_schema.cs:435`, default `true`). Only the value written into it changes. Existing rows are corrected on the next author refresh; nothing needs backfilling, and unflagged books keep their current primary status by design.

#### How was this tested?

Built and tested on Linux, .NET 10, from source — not through Docker. Ran the same steps `build.yml` uses, including the guards that run before compilation:

- `git grep` conflict-marker check + `package.json` JSON parse — clean.
- `python3 build-tools/version_guard.py sync` — `Version sync OK for working tree: 0.9.929`.
- `python3 build-tools/version_guard.py monotonic --compare-ref origin/develop` — `Version monotonic OK: 0.9.929`.
- `python3 build-tools/version_guard.py commit-hygiene --compare-ref origin/develop` — `OK for range origin/develop..HEAD`.
- `dotnet build src/Chaptarr.NoTests.sln --configuration Release` — succeeded, **0 warnings, 0 errors** (so `TreatWarningsAsErrors` / `EnforceCodeStyleInBuild` are satisfied).
- `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj --configuration Release` — **2834 on `develop` → 2835 on this branch**, 0 failed. The one added test is the delta.
- Added `should_carry_series_book_primary_flag_into_links` to `RefreshSeriesServiceExistingSeriesFixture`, covering all three states through the path that actually persists links: `isPrimary = true` → linked primary, `isPrimary = false` → linked secondary, `isPrimary = null` → linked primary (the back-compat case).
- Confirmed the test genuinely covers the bug by reverting the fix and re-running it: it fails with `a book the metadata API flags as secondary should be linked as secondary / Expected: False / But was: True`, then passes again with the fix restored.

I have not exercised this end-to-end against a live library — the change is two lines with a single consumer, so the unit tests seemed a better proof than a manual refresh. Happy to run a real-instance check if you'd like one before merging.

#### Screenshots (UI changes only)

n/a — no UI changes.

---

Two adjacent things I deliberately left out of this PR, mentioned in #60 in case they're worth their own tickets: `WorkCount` and `PrimaryWorkCount` are assigned the same value at `BookInfoProxy.cs:4661-4662` and `SeriesLookupController.cs:222-223`, so the `({count} Primary)` label can never differ from the total; and `Series.TotalBooks` / `Series.PrimaryBooks` are written by some converters but not others, leaving them zero on rows that took the other path. Neither affects filtering, and the first looks like it may be deliberate for search previews, so I didn't want to guess at intent inside a bugfix.
