### PR TITLE
Fix: unsatisfied-slot safety pause can live-lock and permanently over-count

### DIFF
--- a/src/Chaptarr.Core.Test/Indexers/MamUnsatisfiedSlotGuardFixture.cs
+++ b/src/Chaptarr.Core.Test/Indexers/MamUnsatisfiedSlotGuardFixture.cs
@@ -310,6 +310,71 @@ namespace Chaptarr.Core.Test.Indexers
             Assert.That(repositoryState.Rows, Is.Empty);
         }
 
+        [Test]
+        public void reservation_should_retire_after_maximum_lifetime_despite_retries()
+        {
+            var settings = FreshSettings(count: 1, limit: 50, safetyReserve: 5);
+            var repository = CreateRepository(out var repositoryState);
+            repositoryState.Rows.Add(new MamUnsatisfiedSlotReservation
+            {
+                Id = 1,
+                IndexerId = 9,
+                TorrentId = "659145",
+                ReservedUtc = DateTime.UtcNow,
+                FirstReservedUtc = DateTime.UtcNow.Add(-MamUnsatisfiedSlotGuard.MaximumReservationLifetime).AddMinutes(-5)
+            });
+
+            var indexer = CreateMamIndexer(settings, repository);
+            var guard = CreateGuard(CreateFactory((IndexerDefinition)indexer.Definition), repository);
+
+            guard.Reconcile(indexer, new MyAnonaMouseAccountStatus { SnapshotCreatedUtc = DateTime.UtcNow.AddHours(-1) });
+
+            Assert.That(repositoryState.Rows, Is.Empty);
+        }
+
+        [Test]
+        public void reservation_within_maximum_lifetime_should_survive_a_stale_snapshot()
+        {
+            var settings = FreshSettings(count: 1, limit: 50, safetyReserve: 5);
+            var repository = CreateRepository(out var repositoryState);
+            repositoryState.Rows.Add(new MamUnsatisfiedSlotReservation
+            {
+                Id = 1,
+                IndexerId = 9,
+                TorrentId = "659145",
+                ReservedUtc = DateTime.UtcNow,
+                FirstReservedUtc = DateTime.UtcNow.AddHours(-1)
+            });
+
+            var indexer = CreateMamIndexer(settings, repository);
+            var guard = CreateGuard(CreateFactory((IndexerDefinition)indexer.Definition), repository);
+
+            guard.Reconcile(indexer, new MyAnonaMouseAccountStatus { SnapshotCreatedUtc = DateTime.UtcNow.AddHours(-1) });
+
+            Assert.That(repositoryState.Rows, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public void retry_should_preserve_the_first_reserved_anchor()
+        {
+            var settings = FreshSettings(count: 0, limit: 50, safetyReserve: 5);
+            var repository = CreateRepository(out var repositoryState);
+            var originalAttempt = DateTime.UtcNow.AddHours(-1);
+            repositoryState.Rows.Add(new MamUnsatisfiedSlotReservation
+            {
+                Id = 1,
+                IndexerId = 9,
+                TorrentId = "100",
+                ReservedUtc = originalAttempt
+            });
+
+            var guard = CreateGuard(CreateFactory(Definition(settings)), repository);
+
+            Assert.That(guard.TryReserve(Release("100")).Accepted, Is.True);
+            Assert.That(repositoryState.Rows.Single().ReservedUtc, Is.GreaterThan(originalAttempt));
+            Assert.That(repositoryState.Rows.Single().FirstReservedUtc, Is.EqualTo(originalAttempt));
+        }
+
         private static MyAnonaMouseSettings FreshSettings(int count, int limit, int safetyReserve, int manualGrabBuffer = 0)
         {
             return new MyAnonaMouseSettings

--- a/src/NzbDrone.Core/Datastore/Migration/103_add_mam_reservation_first_reserved.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/103_add_mam_reservation_first_reserved.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(103)]
+    public class add_mam_reservation_first_reserved : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            if (Schema.Table("MamUnsatisfiedSlotReservations").Exists() &&
+                !Schema.Table("MamUnsatisfiedSlotReservations").Column("FirstReservedUtc").Exists())
+            {
+                Alter.Table("MamUnsatisfiedSlotReservations")
+                    .AddColumn("FirstReservedUtc").AsDateTime().Nullable();
+
+                Execute.Sql("UPDATE \"MamUnsatisfiedSlotReservations\" SET \"FirstReservedUtc\" = \"ReservedUtc\" WHERE \"FirstReservedUtc\" IS NULL");
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Indexers/MyAnonaMouse/MamUnsatisfiedSlotGuard.cs
+++ b/src/NzbDrone.Core/Indexers/MyAnonaMouse/MamUnsatisfiedSlotGuard.cs
@@ -42,6 +42,11 @@ namespace NzbDrone.Core.Indexers.MyAnonaMouse
         // MAM documents a 5-20 minute lag before snatches reach account summaries. Keep counting locally through the full window.
         private static readonly TimeSpan SummaryAccountingLag = TimeSpan.FromMinutes(20);
 
+        // A retried release refreshes its accounting window (see Evaluate), so a
+        // permanently failing grab would otherwise keep its reservation alive forever
+        // and hold the account over the limit. No reservation outlives this.
+        internal static readonly TimeSpan MaximumReservationLifetime = TimeSpan.FromHours(24);
+
         private readonly IIndexerFactory _indexerFactory;
         private readonly IMamUnsatisfiedSlotReservationRepository _repository;
         private readonly Logger _logger;
@@ -83,6 +88,26 @@ namespace NzbDrone.Core.Indexers.MyAnonaMouse
             }
 
             var reservations = GetAccountReservations(definition, settings);
+
+            var utcNow = DateTime.UtcNow;
+            foreach (var reservation in reservations.Where(r =>
+                         utcNow - (r.FirstReservedUtc ?? r.ReservedUtc) >= MaximumReservationLifetime))
+            {
+                lock (_reservationLock)
+                {
+                    var current = _repository.Find(reservation.IndexerId, reservation.TorrentId);
+                    if (current != null &&
+                        utcNow - (current.FirstReservedUtc ?? current.ReservedUtc) >= MaximumReservationLifetime)
+                    {
+                        _repository.Delete(current.Id);
+                        _logger.Info(
+                            "Retired MAM slot reservation for torrent {0} on indexer '{1}': it exceeded the maximum reservation lifetime of {2} hours without being satisfied",
+                            current.TorrentId,
+                            definition.Name,
+                            MaximumReservationLifetime.TotalHours);
+                    }
+                }
+            }
 
             // This does not infer that a torrent became satisfied. Once MAM's own snapshot covers the
             // latest attempt plus its documented accounting lag, a served torrent is in the reported
@@ -154,6 +179,7 @@ namespace NzbDrone.Core.Indexers.MyAnonaMouse
             {
                 if (reserve && !existingReservation.ConfirmedUtc.HasValue)
                 {
+                    existingReservation.FirstReservedUtc ??= existingReservation.ReservedUtc;
                     existingReservation.ReservedUtc = DateTime.UtcNow;
                     _repository.Update(existingReservation);
                 }
@@ -190,7 +216,8 @@ namespace NzbDrone.Core.Indexers.MyAnonaMouse
                 {
                     IndexerId = definition.Id,
                     TorrentId = torrentId,
-                    ReservedUtc = now
+                    ReservedUtc = now,
+                    FirstReservedUtc = now
                 });
             }
 

--- a/src/NzbDrone.Core/Indexers/MyAnonaMouse/MamUnsatisfiedSlotReservation.cs
+++ b/src/NzbDrone.Core/Indexers/MyAnonaMouse/MamUnsatisfiedSlotReservation.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Indexers.MyAnonaMouse
         public int IndexerId { get; set; }
         public string TorrentId { get; set; }
         public DateTime ReservedUtc { get; set; }
+        public DateTime? FirstReservedUtc { get; set; }
         public DateTime? ConfirmedUtc { get; set; }
     }
 }


### PR DESCRIPTION
## The bug (user-reported)

The safety pause counts `the tracker's reported unsatisfied count + local in-flight reservations`. Reservations are retired by `Reconcile` once the provider's summary snapshot postdates the reservation's accounting window (`ReservedUtc` + 20 min). But retrying an unconfirmed reservation deliberately refreshes `ReservedUtc` (per `retry_should_refresh_an_unconfirmed_reservations_accounting_window`) — so a release that keeps failing and re-grabbing slides its window forward forever and its reservation becomes **immortal**:

1. N releases fail/retry repeatedly → their reservations never retire
2. The account reads permanently N over → the safety pause rejects everything else
3. Which keeps the same N releases retrying → the loop sustains itself

Restarts and the account-status refresh task don't help because the reservation rows persist in the database and the slide resumes. Symptom: the reported unsatisfied number sits exactly N above the tracker's own count, indefinitely.

## Fix

Keep the window-refresh behaviour (the existing test still passes untouched) but add an immutable anchor and a hard ceiling:

- Migration 103 adds nullable `FirstReservedUtc`, backfilled from `ReservedUtc`
- Inserts stamp it; retries preserve it (`??=` before the slide)
- `Reconcile` unconditionally retires any reservation older than 24h from its first attempt, with an Info log naming the torrent

A reservation that genuinely satisfies still retires via the existing snapshot rule long before the ceiling; the ceiling only catches the pathological retry loop.

## Tests

- `reservation_should_retire_after_maximum_lifetime_despite_retries` — just-retried row (snapshot rule can never cover it) with a first attempt beyond the ceiling → retired
- `reservation_within_maximum_lifetime_should_survive_a_stale_snapshot` — young reservation is untouched
- `retry_should_preserve_the_first_reserved_anchor` — the slide keeps refreshing `ReservedUtc` but the anchor holds (also backfills legacy rows on first retry)
- Existing indexer suite intact: 88/88 passing

Note: no fails-first repro test for this one — the fix adds a schema column, so a pre-fix repro wouldn't compile. The live-lock derivation above plus the invariant tests are the evidence.