### PR TITLE
Fix #28: author audiobook/ebook path edits are silently dropped

### DIFF
--- a/src/Chaptarr.Api.V1/Author/AuthorController.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorController.cs
@@ -213,6 +213,8 @@ namespace Chaptarr.Api.V1.Author
             PostValidator.RuleFor(s => s.ForeignAuthorId).NotEmpty().SetValidator(authorExistsValidator);
 
 	            PutValidator.RuleFor(s => s.Path).IsValidPath();
+	            PutValidator.RuleFor(s => s.AudiobookPath).IsValidPath().When(s => s.AudiobookPath.IsNotNullOrWhiteSpace());
+	            PutValidator.RuleFor(s => s.EbookPath).IsValidPath().When(s => s.EbookPath.IsNotNullOrWhiteSpace());
 	        }
 
 	        private bool IsImportActive()

--- a/src/Chaptarr.Api.V1/Author/AuthorResource.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorResource.cs
@@ -67,6 +67,10 @@ namespace Chaptarr.Api.V1.Author
         // Readarr/Seerr compatibility (monitor mode string, e.g. "none")
         public string MonitorNewItems { get; set; }
         public string Folder { get; set; }
+        // Writable per-media author paths. The edit UI submits these; AudiobookFolder/
+        // EbookFolder below remain the read-only display values set by the controller.
+        public string AudiobookPath { get; set; }
+        public string EbookPath { get; set; }
         public string AudiobookFolder { get; set; }
         public string EbookFolder { get; set; }
         public List<string> Genres { get; set; }
@@ -131,6 +135,8 @@ namespace Chaptarr.Api.V1.Author
                 Images = displayImages.JsonClone(),
 
                 Path = model.Path,
+                AudiobookPath = model.AudiobookPath,
+                EbookPath = model.EbookPath,
                 AudiobookQualityProfileId = model.AudiobookQualityProfileId,
                 EbookQualityProfileId = model.EbookQualityProfileId,
                 MetadataProfileId = model.MetadataProfileId,
@@ -463,6 +469,8 @@ namespace Chaptarr.Api.V1.Author
 
                 //AlternateTitles
                 Path = resource.Path,
+                AudiobookPath = resource.AudiobookPath,
+                EbookPath = resource.EbookPath,
                 AudiobookQualityProfileId = audiobookQualityProfileId,
                 EbookQualityProfileId = ebookQualityProfileId,
                 MetadataProfileId = resource.MetadataProfileId,
@@ -566,6 +574,16 @@ namespace Chaptarr.Api.V1.Author
             if (resource.Path == null)
             {
                 updatedAuthor.Path = storedAuthor.Path;
+            }
+
+            if (resource.AudiobookPath == null)
+            {
+                updatedAuthor.AudiobookPath = storedAuthor.AudiobookPath;
+            }
+
+            if (resource.EbookPath == null)
+            {
+                updatedAuthor.EbookPath = storedAuthor.EbookPath;
             }
 
             if (resource.AddOptions == null)

--- a/src/Chaptarr.Core.Test/Books/AuthorResourceMapperFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorResourceMapperFixture.cs
@@ -100,6 +100,53 @@ namespace Chaptarr.Core.Test.Books
         }
 
         [Test]
+        public void should_apply_media_paths_on_put_update()
+        {
+            var existing = new NzbDrone.Core.Books.Author
+            {
+                Id = 1,
+                Name = "J.R.R. Tolkien",
+                AudiobookPath = "/audiobooks/J.R.R. Tolkien",
+                EbookPath = "/ebooks/J.R.R. Tolkien"
+            };
+
+            var resource = new AuthorResource
+            {
+                Id = 1,
+                AuthorName = "J.R.R. Tolkien",
+                AudiobookPath = "/audiobooks/J. R. R. Tolkien"
+            };
+
+            var updated = resource.ToModel(existing);
+
+            Assert.That(updated.AudiobookPath, Is.EqualTo("/audiobooks/J. R. R. Tolkien"));
+            Assert.That(updated.EbookPath, Is.EqualTo("/ebooks/J.R.R. Tolkien"), "an omitted media path must keep its stored value");
+        }
+
+        [Test]
+        public void should_not_wipe_media_paths_when_not_provided_on_put_update()
+        {
+            var existing = new NzbDrone.Core.Books.Author
+            {
+                Id = 1,
+                Name = "J.R.R. Tolkien",
+                AudiobookPath = "/audiobooks/J.R.R. Tolkien",
+                EbookPath = "/ebooks/J.R.R. Tolkien"
+            };
+
+            var resource = new AuthorResource
+            {
+                Id = 1,
+                AuthorName = "J.R.R. Tolkien"
+            };
+
+            var updated = resource.ToModel(existing);
+
+            Assert.That(updated.AudiobookPath, Is.EqualTo("/audiobooks/J.R.R. Tolkien"));
+            Assert.That(updated.EbookPath, Is.EqualTo("/ebooks/J.R.R. Tolkien"));
+        }
+
+        [Test]
         public void should_apply_per_type_metadata_profiles_on_put_update()
         {
             var existing = new NzbDrone.Core.Books.Author

--- a/src/NzbDrone.Core/Books/Model/Author.cs
+++ b/src/NzbDrone.Core/Books/Model/Author.cs
@@ -328,6 +328,11 @@ namespace NzbDrone.Core.Books
             AddOptions = other.AddOptions;
             AudiobookRootFolderPath = other.AudiobookRootFolderPath;
             EbookRootFolderPath = other.EbookRootFolderPath;
+
+            // Per-media author paths: null means the caller did not provide a value,
+            // so keep the stored one (an explicit clear arrives as an empty string).
+            AudiobookPath = other.AudiobookPath ?? AudiobookPath;
+            EbookPath = other.EbookPath ?? EbookPath;
             Monitored = other.Monitored;
             // TRI-STATE MONITORING SYSTEM - Copy only when explicitly provided (not null).
             // This prevents partial updates from wiping existing monitoring values.


### PR DESCRIPTION
Fixes #28

## The bug

Editing an author's Audiobook or Ebook path in the UI never saves — the request succeeds, nothing is logged, and the value reverts. The reporter's devtools captures show why: the frontend submits `audiobookPath`/`ebookPath`, but `AuthorResource` has no such properties (the API's only per-media path fields are the read-only `audiobookFolder`/`ebookFolder` display values), so the deserializer silently drops the incoming value. Not related to spaces in author names — no author path edit can save.

The value was actually being dropped at **two** layers:

1. `AuthorResource` → model: the fields don't exist on the resource, and `ToModel` never maps them
2. `Author.ApplyChanges` (the final merge for plain updates): copies `Path` and the root-folder paths but not `AudiobookPath`/`EbookPath`

## Fix

- Add writable `AudiobookPath`/`EbookPath` to `AuthorResource` (the read-only folder display fields are unchanged), map them in both directions
- Preserve-when-null in the facade update path, mirroring the existing `Path` handling
- Merge them in `Author.ApplyChanges` with `?? ` semantics: null means not-provided (keep stored), an explicit clear arrives as an empty string
- `PutValidator` path validation for both, only when set

## Tests

`AuthorResourceMapperFixture`, following the fixture's existing apply/not-wipe pattern:
- `should_apply_media_paths_on_put_update` — provided value lands; omitted sibling keeps its stored value
- `should_not_wipe_media_paths_when_not_provided_on_put_update`

Mapper suite 102/102; wider Books suite 567/567.