### PR TITLE
Fix #49: author merge trips the unique provider-id indexes while the source still owns them

### DIFF
--- a/src/Chaptarr.Core.Test/Books/AuthorMergeUniqueProviderIdFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorMergeUniqueProviderIdFixture.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using Dapper;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Books.Services;
+
+namespace Chaptarr.Core.Test.Books
+{
+    [TestFixture]
+    public class AuthorMergeUniqueProviderIdFixture
+    {
+        private string _databasePath;
+        private string _connectionString;
+
+        [SetUp]
+        public void Setup()
+        {
+            _databasePath = Path.Combine(TestContext.CurrentContext.WorkDirectory, $"author_merge_unique_{Guid.NewGuid():N}.db");
+            _connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = _databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate
+            }.ToString();
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+            connection.Execute(@"
+                CREATE TABLE ""Authors"" (
+                    ""Id"" INTEGER PRIMARY KEY,
+                    ""HardcoverAuthorId"" TEXT NULL,
+                    ""GoodreadsAuthorId"" TEXT NULL,
+                    ""AudnexusAuthorId"" TEXT NULL,
+                    ""OpenLibraryAuthorId"" TEXT NULL,
+                    ""GoogleBooksAuthorId"" TEXT NULL
+                );
+                CREATE UNIQUE INDEX ""UX_Authors_HardcoverAuthorId"" ON ""Authors"" (""HardcoverAuthorId"");
+                CREATE UNIQUE INDEX ""UX_Authors_GoodreadsAuthorId"" ON ""Authors"" (""GoodreadsAuthorId"");
+                CREATE UNIQUE INDEX ""UX_Authors_AudnexusAuthorId"" ON ""Authors"" (""AudnexusAuthorId"");
+                CREATE UNIQUE INDEX ""UX_Authors_OpenLibraryAuthorId"" ON ""Authors"" (""OpenLibraryAuthorId"");
+                CREATE UNIQUE INDEX ""UX_Authors_GoogleBooksAuthorId"" ON ""Authors"" (""GoogleBooksAuthorId"");
+
+                INSERT INTO ""Authors"" (""Id"", ""AudnexusAuthorId"") VALUES (416, 'az:B000APO0PQ');
+                INSERT INTO ""Authors"" (""Id"") VALUES (1577);
+            ");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(_databasePath))
+            {
+                File.Delete(_databasePath);
+            }
+        }
+
+        [Test]
+        public void saving_the_survivor_while_the_source_still_owns_the_id_reproduces_issue_49()
+        {
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+
+            var ex = Assert.Throws<SqliteException>(() => connection.Execute(
+                @"UPDATE ""Authors"" SET ""AudnexusAuthorId"" = 'az:B000APO0PQ' WHERE ""Id"" = 1577;"));
+
+            Assert.That(ex.Message, Does.Contain("UNIQUE constraint failed: Authors.AudnexusAuthorId"));
+        }
+
+        [Test]
+        public void handoff_should_transfer_all_unique_provider_ids_without_violating_the_indexes()
+        {
+            var target = new Author
+            {
+                Id = 1577,
+                AudnexusAuthorId = "az:B000APO0PQ",
+                GoodreadsAuthorId = "gr:12345"
+            };
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+            using (var transaction = connection.BeginTransaction())
+            {
+                RefreshAuthorService.ReleaseAndTransferUniqueProviderIds(connection, transaction, sourceId: 416, target);
+                connection.Execute(@"DELETE FROM ""Authors"" WHERE ""Id"" = 416;", transaction: transaction);
+                transaction.Commit();
+            }
+
+            var survivor = connection.QuerySingle(@"SELECT ""AudnexusAuthorId"", ""GoodreadsAuthorId"" FROM ""Authors"" WHERE ""Id"" = 1577;");
+            Assert.That((string)survivor.AudnexusAuthorId, Is.EqualTo("az:B000APO0PQ"));
+            Assert.That((string)survivor.GoodreadsAuthorId, Is.EqualTo("gr:12345"));
+            Assert.That(connection.ExecuteScalar<long>(@"SELECT COUNT(*) FROM ""Authors"" WHERE ""Id"" = 416;"), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void rollback_should_leave_the_source_untouched()
+        {
+            var target = new Author { Id = 1577, AudnexusAuthorId = "az:B000APO0PQ" };
+
+            using var connection = new SqliteConnection(_connectionString);
+            connection.Open();
+            using (var transaction = connection.BeginTransaction())
+            {
+                RefreshAuthorService.ReleaseAndTransferUniqueProviderIds(connection, transaction, sourceId: 416, target);
+                transaction.Rollback();
+            }
+
+            var source = connection.QuerySingle(@"SELECT ""AudnexusAuthorId"" FROM ""Authors"" WHERE ""Id"" = 416;");
+            Assert.That((string)source.AudnexusAuthorId, Is.EqualTo("az:B000APO0PQ"));
+            Assert.That(connection.ExecuteScalar<string>(@"SELECT ""AudnexusAuthorId"" FROM ""Authors"" WHERE ""Id"" = 1577;"), Is.Null);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Books/Services/RefreshAuthorService.cs
+++ b/src/NzbDrone.Core/Books/Services/RefreshAuthorService.cs
@@ -3069,13 +3069,47 @@ namespace NzbDrone.Core.Books
 
         private bool TryMergeAuthorsWithoutDataLoss(Author source, Author target, string canonicalId, out string reason)
         {
+            var originalTargetProviderIds = new
+            {
+                target.HardcoverAuthorId,
+                target.GoodreadsAuthorId,
+                target.AudnexusAuthorId,
+                target.OpenLibraryAuthorId,
+                target.GoogleBooksAuthorId
+            };
+
             try
             {
                 MergeIntoSurvivor(target, source, canonicalId);
+
+                // Persist the survivor WITHOUT the unique provider ids first: a failure
+                // here still leaves the source author untouched (the data-loss guarantee
+                // this method is named for). Saving them now would collide with the
+                // source row, which still owns the same values under the UX_Authors_*
+                // unique indexes - the ids are handed over atomically below instead.
+                var mergedHardcoverId = target.HardcoverAuthorId;
+                var mergedGoodreadsId = target.GoodreadsAuthorId;
+                var mergedAudnexusId = target.AudnexusAuthorId;
+                var mergedOpenLibraryId = target.OpenLibraryAuthorId;
+                var mergedGoogleBooksId = target.GoogleBooksAuthorId;
+
+                target.HardcoverAuthorId = originalTargetProviderIds.HardcoverAuthorId;
+                target.GoodreadsAuthorId = originalTargetProviderIds.GoodreadsAuthorId;
+                target.AudnexusAuthorId = originalTargetProviderIds.AudnexusAuthorId;
+                target.OpenLibraryAuthorId = originalTargetProviderIds.OpenLibraryAuthorId;
+                target.GoogleBooksAuthorId = originalTargetProviderIds.GoogleBooksAuthorId;
                 _authorService.UpdateAuthor(target);
+
+                target.HardcoverAuthorId = mergedHardcoverId;
+                target.GoodreadsAuthorId = mergedGoodreadsId;
+                target.AudnexusAuthorId = mergedAudnexusId;
+                target.OpenLibraryAuthorId = mergedOpenLibraryId;
+                target.GoogleBooksAuthorId = mergedGoogleBooksId;
 
                 using var connection = _mainDatabase.OpenConnection();
                 using var transaction = connection.BeginTransaction();
+
+                ReleaseAndTransferUniqueProviderIds(connection, transaction, source.Id, target);
 
                 ReassignAuthorId(connection, transaction, "Books", source.Id, target.Id);
                 ReassignAuthorId(connection, transaction, "AuthorSeries", source.Id, target.Id);
@@ -3107,6 +3141,42 @@ namespace NzbDrone.Core.Books
                 reason = ex.Message;
                 return false;
             }
+        }
+
+        // The unique provider-id handoff has to happen inside the merge transaction:
+        // release the ids on the source row before the survivor takes them over, so
+        // the UX_Authors_* unique indexes never see both rows holding the same value.
+        internal static void ReleaseAndTransferUniqueProviderIds(System.Data.IDbConnection connection, System.Data.IDbTransaction transaction, int sourceId, Author target)
+        {
+            connection.Execute(
+                @"UPDATE ""Authors"" SET
+                    ""HardcoverAuthorId"" = NULL,
+                    ""GoodreadsAuthorId"" = NULL,
+                    ""AudnexusAuthorId"" = NULL,
+                    ""OpenLibraryAuthorId"" = NULL,
+                    ""GoogleBooksAuthorId"" = NULL
+                  WHERE ""Id"" = @Id;",
+                new { Id = sourceId },
+                transaction);
+
+            connection.Execute(
+                @"UPDATE ""Authors"" SET
+                    ""HardcoverAuthorId"" = @HardcoverAuthorId,
+                    ""GoodreadsAuthorId"" = @GoodreadsAuthorId,
+                    ""AudnexusAuthorId"" = @AudnexusAuthorId,
+                    ""OpenLibraryAuthorId"" = @OpenLibraryAuthorId,
+                    ""GoogleBooksAuthorId"" = @GoogleBooksAuthorId
+                  WHERE ""Id"" = @Id;",
+                new
+                {
+                    target.HardcoverAuthorId,
+                    target.GoodreadsAuthorId,
+                    target.AudnexusAuthorId,
+                    target.OpenLibraryAuthorId,
+                    target.GoogleBooksAuthorId,
+                    Id = target.Id
+                },
+                transaction);
         }
 
         private void MergeIntoSurvivor(Author survivor, Author source, string canonicalId)


### PR DESCRIPTION
Fixes #49

## The bug

Exactly as diagnosed in the issue: `TryMergeAuthorsWithoutDataLoss` copies the source's provider ids onto the survivor and calls `UpdateAuthor(target)` **before** the transaction deletes the source row — so the source still owns the same values and the save trips the unique index. All five provider-id columns are covered by unique indexes (`UX_Authors_HardcoverAuthorId`, `GoodreadsAuthorId`, `AudnexusAuthorId`, `OpenLibraryAuthorId`, `GoogleBooksAuthorId`), so any of them can block the merge, and every bulk sync retries and fails the same way.

## Fix

The existing early `UpdateAuthor(target)` isn't accidental — it's the method's abort-safety (a failure leaves the source intact), so the fix keeps it rather than reordering it away:

1. `MergeIntoSurvivor` computes the merged state as before
2. The survivor is persisted **without** the contested provider ids (collision-free; a failure here still aborts cleanly with the source untouched)
3. Inside the existing merge transaction, a new helper `ReleaseAndTransferUniqueProviderIds` clears the ids on the source row and applies the merged ids to the survivor via SQL, then the children are reassigned and the source deleted — all committed atomically, so the unique indexes never see two rows holding the same value and any failure rolls the whole handoff back

## Tests

New `AuthorMergeUniqueProviderIdFixture` running against a real SQLite database with the real five unique indexes and the issue's exact data shape (source `416` owning `az:B000APO0PQ`, survivor `1577`):

- `saving_the_survivor_while_the_source_still_owns_the_id_reproduces_issue_49` — pins the failure mode: `UNIQUE constraint failed: Authors.AudnexusAuthorId`
- `handoff_should_transfer_all_unique_provider_ids_without_violating_the_indexes` — clean transfer + source deletion
- `rollback_should_leave_the_source_untouched` — abort-safety preserved

Books suite: 568/568 passing.