### PR TITLE
Hardcover search never returns any results

### DIFF
--- a/src/Chaptarr.Core.Test/MetadataSource/HardcoverSearchClientFixture.cs
+++ b/src/Chaptarr.Core.Test/MetadataSource/HardcoverSearchClientFixture.cs
@@ -163,34 +163,69 @@ namespace Chaptarr.Core.Test.MetadataSource
             return new HttpResponse(request, new HttpHeader { ContentType = "application/json" }, content, statusCode);
         }
 
-        private static string BuildHttpBatch(params string[] operationResponses)
+        // Hardcover rejects a JSON array body outright, so every operation is now its own request and
+        // each one is answered on its own. Responses are handed back in call order.
+        private static RecordingHttpClient SequencedClient(params string[] responses)
         {
-            return $"[{string.Join(",", operationResponses)}]";
+            var index = 0;
+            return new RecordingHttpClient(request =>
+                JsonResponse(request, responses[Math.Min(index++, responses.Length - 1)]));
+        }
+
+        private static JsonDocument BodyOf(HttpRequest request)
+        {
+            return JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
+        }
+
+        // Every request is now a single GraphQL operation, so stubs classify by what the operation asks for
+        // rather than by position in a batch array.
+        private static string RequestKind(HttpRequest request)
+        {
+            using var body = BodyOf(request);
+            var root = body.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return "unexpected-array";
+            }
+
+            var query = root.TryGetProperty("query", out var queryElement) ? queryElement.GetString() ?? string.Empty : string.Empty;
+            if (query.Contains("SearchEnrichment", StringComparison.Ordinal))
+            {
+                return "enrichment";
+            }
+
+            if (root.TryGetProperty("variables", out var variables) &&
+                variables.TryGetProperty("query_type", out var queryType))
+            {
+                return "search:" + queryType.GetString();
+            }
+
+            return "author-books";
         }
 
         [Test]
-        public void should_send_one_search_root_per_http_batched_operation()
+        public void should_send_each_search_type_as_its_own_request()
         {
-            var httpClient = new RecordingHttpClient(request => JsonResponse(request,
-                BuildHttpBatch(EmptySearchPayload, EmptySearchPayload, EmptySearchPayload)));
+            var httpClient = SequencedClient(EmptySearchPayload, EmptySearchPayload, EmptySearchPayload);
             var client = CreateClient(httpClient);
 
             var results = client.Search("matt dinniman");
 
             Assert.That(results, Is.Not.Null.And.Empty);
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(1));
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(3), "each search type must be its own HTTP request");
 
             var queryTypes = new List<string>();
-            using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(httpClient.Requests.Single().ContentData));
-            Assert.That(payload.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Array));
-            Assert.That(payload.RootElement.GetArrayLength(), Is.EqualTo(3));
-
-            foreach (var operation in payload.RootElement.EnumerateArray())
+            foreach (var request in httpClient.Requests)
             {
-                var query = operation.GetProperty("query").GetString();
-                var variables = operation.GetProperty("variables");
+                using var body = BodyOf(request);
 
-                Assert.That(query.Split("search(", StringSplitOptions.None), Has.Length.EqualTo(2));
+                // The crux: Hardcover answers a single operation with 400 invalid_query if it arrives
+                // inside a JSON array, so the body must be a bare object.
+                Assert.That(body.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Object),
+                    "GraphQL body must be a single operation, not a batched array");
+
+                var variables = body.RootElement.GetProperty("variables");
                 Assert.That(variables.GetProperty("q").GetString(), Is.EqualTo("matt dinniman"));
                 Assert.That(variables.GetProperty("limit").GetInt32(), Is.EqualTo(10));
                 Assert.That(variables.GetProperty("page").GetInt32(), Is.EqualTo(1));
@@ -198,6 +233,27 @@ namespace Chaptarr.Core.Test.MetadataSource
             }
 
             Assert.That(queryTypes, Is.EquivalentTo(new[] { "Author", "Book", "Series" }));
+        }
+
+        [Test]
+        public void should_send_exactly_one_search_root_per_request()
+        {
+            var httpClient = SequencedClient(EmptySearchPayload, EmptySearchPayload, EmptySearchPayload);
+            var client = CreateClient(httpClient);
+
+            var results = client.Search("matt dinniman");
+
+            Assert.That(results, Is.Not.Null.And.Empty);
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(3));
+
+            foreach (var request in httpClient.Requests)
+            {
+                using var body = BodyOf(request);
+                var query = body.RootElement.GetProperty("query").GetString();
+
+                // Hardcover allows only one top-level search field per operation.
+                Assert.That(query.Split("search(", StringSplitOptions.None), Has.Length.EqualTo(2));
+            }
         }
 
         [Test]
@@ -225,13 +281,14 @@ namespace Chaptarr.Core.Test.MetadataSource
                 ""errors"": [""top_level_search_limit_exceeded""],
                 ""data"": { ""search"": { ""results"": { ""hits"": [] } } }
             }";
-            var httpClient = new RecordingHttpClient(request => JsonResponse(request,
-                BuildHttpBatch(PartialErrorPayload, EmptySearchPayload, EmptySearchPayload)));
+            var httpClient = SequencedClient(PartialErrorPayload, EmptySearchPayload, EmptySearchPayload);
             var client = CreateClient(httpClient);
 
             var results = client.Search("matt dinniman");
 
             Assert.That(results, Is.Null);
+
+            // The first operation carries the error, so the search abandons the remaining types.
             Assert.That(httpClient.Requests, Has.Count.EqualTo(1));
         }
 
@@ -240,45 +297,21 @@ namespace Chaptarr.Core.Test.MetadataSource
         {
             var httpClient = new RecordingHttpClient(request =>
             {
-                using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
-                var root = payload.RootElement;
-
-                if (root.ValueKind == JsonValueKind.Array)
+                switch (RequestKind(request))
                 {
-                    var operations = root.EnumerateArray().ToList();
-                    var firstQuery = operations[0].GetProperty("query").GetString();
-                    var firstVariables = operations[0].GetProperty("variables");
-
-                    if (firstVariables.TryGetProperty("query_type", out _))
-                    {
-                        var responses = operations.Select(operation =>
-                        {
-                            var queryType = operation.GetProperty("variables").GetProperty("query_type").GetString();
-                            return queryType switch
-                            {
-                                "Author" => AuthorSearchPayload,
-                                "Book" => BookSearchPayload,
-                                "Series" => SeriesSearchPayload,
-                                _ => throw new AssertionException($"Unexpected Hardcover query type {queryType}")
-                            };
-                        }).ToArray();
-
-                        return JsonResponse(request, BuildHttpBatch(responses));
-                    }
-
-                    if (firstQuery.Contains("BooksByAuthors", StringComparison.Ordinal))
-                    {
-                        return JsonResponse(request, BuildHttpBatch(AuthorBooksPayload));
-                    }
+                    case "search:Author":
+                        return JsonResponse(request, AuthorSearchPayload);
+                    case "search:Book":
+                        return JsonResponse(request, BookSearchPayload);
+                    case "search:Series":
+                        return JsonResponse(request, SeriesSearchPayload);
+                    case "author-books":
+                        return JsonResponse(request, AuthorBooksPayload);
+                    case "enrichment":
+                        return JsonResponse(request, EnrichmentPayload);
                 }
 
-                var query = root.GetProperty("query").GetString();
-                if (query.Contains("SearchEnrichment", StringComparison.Ordinal))
-                {
-                    return JsonResponse(request, EnrichmentPayload);
-                }
-
-                throw new AssertionException($"Unexpected Hardcover query: {query}");
+                throw new AssertionException($"Unexpected Hardcover request: {RequestKind(request)}");
             });
             var client = CreateClient(httpClient);
 
@@ -293,7 +326,8 @@ namespace Chaptarr.Core.Test.MetadataSource
             Assert.That(((HardcoverBookResult)results[1]).Title, Is.EqualTo("Dungeon Crawler Carl"));
             Assert.That(results[2], Is.TypeOf<HardcoverSeriesResult>());
             Assert.That(((HardcoverSeriesResult)results[2]).Id, Is.EqualTo("12717"));
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(3));
+            // Three search operations, plus the author-books and enrichment follow-ups.
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(5));
         }
 
         [Test]
@@ -360,19 +394,16 @@ namespace Chaptarr.Core.Test.MetadataSource
 
             var httpClient = new RecordingHttpClient(request =>
             {
-                using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
-                var root = payload.RootElement;
-
-                if (root.ValueKind == JsonValueKind.Array)
+                switch (RequestKind(request))
                 {
-                    var operations = root.EnumerateArray().ToList();
-                    var variables = operations[0].GetProperty("variables");
-                    if (variables.TryGetProperty("query_type", out _))
-                    {
-                        return JsonResponse(request, BuildHttpBatch(authorSearch, bookSearch, seriesSearch));
-                    }
-
-                    return JsonResponse(request, BuildHttpBatch(authorBooks));
+                    case "search:Author":
+                        return JsonResponse(request, authorSearch);
+                    case "search:Book":
+                        return JsonResponse(request, bookSearch);
+                    case "search:Series":
+                        return JsonResponse(request, seriesSearch);
+                    case "author-books":
+                        return JsonResponse(request, authorBooks);
                 }
 
                 return JsonResponse(request, EmptyEnrichmentPayload);
@@ -391,7 +422,8 @@ namespace Chaptarr.Core.Test.MetadataSource
             Assert.That(((HardcoverSeriesResult)results[2]).AuthorId, Is.EqualTo("80626"));
             Assert.That(results[3], Is.TypeOf<HardcoverAuthorResult>());
             Assert.That(((HardcoverAuthorResult)results[3]).Id, Is.EqualTo("92162"));
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(3));
+            // Three search operations, plus the author-books and enrichment follow-ups.
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(5));
         }
 
         [Test]
@@ -466,19 +498,16 @@ namespace Chaptarr.Core.Test.MetadataSource
 
             var httpClient = new RecordingHttpClient(request =>
             {
-                using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
-                var root = payload.RootElement;
-
-                if (root.ValueKind == JsonValueKind.Array)
+                switch (RequestKind(request))
                 {
-                    var operations = root.EnumerateArray().ToList();
-                    var variables = operations[0].GetProperty("variables");
-                    if (variables.TryGetProperty("query_type", out _))
-                    {
-                        return JsonResponse(request, BuildHttpBatch(authorSearch, bookSearch, seriesSearch));
-                    }
-
-                    return JsonResponse(request, BuildHttpBatch(authorBooks));
+                    case "search:Author":
+                        return JsonResponse(request, authorSearch);
+                    case "search:Book":
+                        return JsonResponse(request, bookSearch);
+                    case "search:Series":
+                        return JsonResponse(request, seriesSearch);
+                    case "author-books":
+                        return JsonResponse(request, authorBooks);
                 }
 
                 return JsonResponse(request, EmptyEnrichmentPayload);
@@ -498,7 +527,8 @@ namespace Chaptarr.Core.Test.MetadataSource
             Assert.That(results[2], Is.TypeOf<HardcoverSeriesResult>());
             Assert.That(((HardcoverSeriesResult)results[2]).Id, Is.EqualTo("1185"));
             Assert.That(((HardcoverSeriesResult)results[2]).AuthorId, Is.EqualTo("80626"));
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(3));
+            // Three search operations, plus the author-books and enrichment follow-ups.
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(5));
         }
 
         [Test]
@@ -525,10 +555,14 @@ namespace Chaptarr.Core.Test.MetadataSource
 
             var httpClient = new RecordingHttpClient(request =>
             {
-                using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
-                if (payload.RootElement.ValueKind == JsonValueKind.Array)
+                switch (RequestKind(request))
                 {
-                    return JsonResponse(request, BuildHttpBatch(EmptySearchPayload, bookSearch, seriesSearch));
+                    case "search:Author":
+                        return JsonResponse(request, EmptySearchPayload);
+                    case "search:Book":
+                        return JsonResponse(request, bookSearch);
+                    case "search:Series":
+                        return JsonResponse(request, seriesSearch);
                 }
 
                 return JsonResponse(request, EmptyEnrichmentPayload);
@@ -542,7 +576,8 @@ namespace Chaptarr.Core.Test.MetadataSource
             Assert.That(((HardcoverSeriesResult)results[0]).Id, Is.EqualTo("3022"));
             Assert.That(((HardcoverSeriesResult)results[0]).SearchScore, Is.EqualTo(3000));
             Assert.That(results[1], Is.TypeOf<HardcoverBookResult>());
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(2));
+            // No author hits, so only the three search operations and the enrichment follow-up.
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(4));
         }
 
         [Test]
@@ -558,18 +593,20 @@ namespace Chaptarr.Core.Test.MetadataSource
                     throw new HttpException(request, response);
                 }
 
-                return JsonResponse(request, BuildHttpBatch(EmptySearchPayload, EmptySearchPayload, EmptySearchPayload));
+                return JsonResponse(request, EmptySearchPayload);
             });
             var client = CreateClient(httpClient);
 
             var results = client.Search("matt dinniman");
 
             Assert.That(results, Is.Not.Null.And.Empty);
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(2));
+
+            // One failed attempt, one retry of that same operation, then the two remaining search types.
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(4));
         }
 
         [Test]
-        public void should_chunk_ten_author_book_roots_into_two_http_batched_operations()
+        public void should_chunk_ten_author_book_roots_into_two_separate_requests()
         {
             var authorHits = Enumerable.Range(1, 10)
                 .Select(id => new
@@ -597,43 +634,42 @@ namespace Chaptarr.Core.Test.MetadataSource
 
             var httpClient = new RecordingHttpClient(request =>
             {
-                using var payload = JsonDocument.Parse(Encoding.UTF8.GetString(request.ContentData));
-                var operations = payload.RootElement.EnumerateArray().ToList();
-                var variables = operations[0].GetProperty("variables");
-
-                if (variables.TryGetProperty("query_type", out _))
+                switch (RequestKind(request))
                 {
-                    return JsonResponse(request,
-                        BuildHttpBatch(authorSearchPayload, EmptySearchPayload, EmptySearchPayload));
+                    case "search:Author":
+                        return JsonResponse(request, authorSearchPayload);
+                    case "search:Book":
+                    case "search:Series":
+                        return JsonResponse(request, EmptySearchPayload);
                 }
 
-                var responses = operations.Select(operation =>
+                using var payload = BodyOf(request);
+                var query = payload.RootElement.GetProperty("query").GetString();
+                var data = new Dictionary<string, object>();
+                var aliasCount = query.Split(": books(", StringSplitOptions.None).Length - 1;
+                for (var index = 0; index < aliasCount; index++)
                 {
-                    var query = operation.GetProperty("query").GetString();
-                    var data = new Dictionary<string, object>();
-                    var aliasCount = query.Split(": books(", StringSplitOptions.None).Length - 1;
-                    for (var index = 0; index < aliasCount; index++)
-                    {
-                        data[$"author{index}"] = Array.Empty<object>();
-                    }
+                    data[$"author{index}"] = Array.Empty<object>();
+                }
 
-                    return JsonSerializer.Serialize(new { data });
-                }).ToArray();
-
-                return JsonResponse(request, BuildHttpBatch(responses));
+                return JsonResponse(request, JsonSerializer.Serialize(new { data }));
             });
             var client = CreateClient(httpClient);
 
             var results = client.Search("smith");
 
             Assert.That(results, Is.Not.Null.And.Empty);
-            Assert.That(httpClient.Requests, Has.Count.EqualTo(2));
 
-            using var authorBooksPayload = JsonDocument.Parse(Encoding.UTF8.GetString(httpClient.Requests[1].ContentData));
-            Assert.That(authorBooksPayload.RootElement.GetArrayLength(), Is.EqualTo(2));
-            foreach (var operation in authorBooksPayload.RootElement.EnumerateArray())
+            // Three search operations, then the ten author ids split across two author-books requests.
+            var authorBooksRequests = httpClient.Requests.Where(r => RequestKind(r) == "author-books").ToList();
+            Assert.That(httpClient.Requests, Has.Count.EqualTo(5));
+            Assert.That(authorBooksRequests, Has.Count.EqualTo(2));
+
+            foreach (var request in authorBooksRequests)
             {
-                var query = operation.GetProperty("query").GetString();
+                using var authorBooksPayload = BodyOf(request);
+                Assert.That(authorBooksPayload.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Object));
+                var query = authorBooksPayload.RootElement.GetProperty("query").GetString();
                 Assert.That(query.Split(": books(", StringSplitOptions.None), Has.Length.EqualTo(6));
             }
         }
@@ -746,5 +782,6 @@ namespace Chaptarr.Core.Test.MetadataSource
             Assert.That(authorArrays.AuthorNames, Is.EqualTo(new[] { "Neil Gaiman", "Terry Pratchett" }));
             Assert.That(authorArrays.AuthorIds, Is.EqualTo(new[] { "10", "13" }));
         }
+
     }
 }

--- a/src/NzbDrone.Core/MetadataSource/Hardcover/HardcoverSearchClient.cs
+++ b/src/NzbDrone.Core/MetadataSource/Hardcover/HardcoverSearchClient.cs
@@ -134,20 +134,42 @@ namespace NzbDrone.Core.MetadataSource.Hardcover
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
             };
 
-            var graphqlRequests = SearchTargets.Select(target => new
+            var searchPayloads = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+
+            // Hardcover answers a JSON array body with 400 invalid_query ("Unexpected end of document"),
+            // so each search type is sent as its own request rather than as one batched operation list.
+            foreach (var target in SearchTargets)
             {
-                query = SEARCH_QUERY,
-                variables = new
+                var jsonContent = JsonSerializer.Serialize(
+                    new
+                    {
+                        query = SEARCH_QUERY,
+                        variables = new
+                        {
+                            q = query,
+                            query_type = target.QueryType,
+                            limit = MAX_RESULTS_PER_TYPE,
+                            page = 1
+                        }
+                    },
+                    jsonOptions);
+
+                var response = ExecuteWithRetry(BuildGraphQlRequest(jsonContent));
+                if (response == null ||
+                    !TryExtractSearchPayload(target.QueryType, response.Content, out var searchPayload))
                 {
-                    q = query,
-                    query_type = target.QueryType,
-                    limit = MAX_RESULTS_PER_TYPE,
-                    page = 1
+                    return null;
                 }
-            }).ToList();
 
-            var jsonContent = JsonSerializer.Serialize(graphqlRequests, jsonOptions);
+                searchPayloads[target.ResponseProperty] = searchPayload;
+            }
 
+            var combinedContent = JsonSerializer.Serialize(new { data = searchPayloads }, jsonOptions);
+            return ParseSearchResponse(query, combinedContent, jsonOptions);
+        }
+
+        private HttpRequest BuildGraphQlRequest(string jsonContent)
+        {
             var request = new HttpRequestBuilder(HARDCOVER_ENDPOINT)
                 .SetHeader("Content-Type", "application/json")
                 .SetHeader("Accept", "application/json")
@@ -156,57 +178,25 @@ namespace NzbDrone.Core.MetadataSource.Hardcover
 
             request.Method = HttpMethod.Post;
             request.SetContent(jsonContent);
-            
+
             // Add Authorization AFTER building to avoid duplication
             request.Headers.Add("Authorization", $"Bearer {_configService.HardcoverApiToken}");
 
-            var response = ExecuteWithRetry(request);
-            if (response == null || !TryExtractSearchPayloads(response.Content, out var searchPayloads))
-            {
-                return null;
-            }
-
-            var combinedContent = JsonSerializer.Serialize(new { data = searchPayloads }, jsonOptions);
-            return ParseSearchResponse(query, combinedContent, jsonOptions);
+            return request;
         }
 
-        private bool TryExtractSearchPayloads(string responseContent, out Dictionary<string, JsonElement> searchPayloads)
+        private bool TryExtractSearchPayload(string queryType, string responseContent, out JsonElement searchPayload)
         {
-            searchPayloads = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            searchPayload = default;
 
             try
             {
                 using var document = JsonDocument.Parse(responseContent);
-                var root = document.RootElement;
-
-                if (root.ValueKind != JsonValueKind.Array)
-                {
-                    _logger.Error("Hardcover search batch response was not an array");
-                    return false;
-                }
-
-                if (root.GetArrayLength() != SearchTargets.Length)
-                {
-                    _logger.Error($"Hardcover search batch returned {root.GetArrayLength()} operations; expected {SearchTargets.Length}");
-                    return false;
-                }
-
-                for (var index = 0; index < SearchTargets.Length; index++)
-                {
-                    var target = SearchTargets[index];
-                    if (!TryExtractSearchPayload(target.QueryType, root[index], out var searchPayload))
-                    {
-                        return false;
-                    }
-
-                    searchPayloads[target.ResponseProperty] = searchPayload;
-                }
-
-                return true;
+                return TryExtractSearchPayload(queryType, document.RootElement, out searchPayload);
             }
             catch (JsonException ex)
             {
-                _logger.Error(ex, $"Failed to parse Hardcover search batch response: {ex.Message}");
+                _logger.Error(ex, $"Failed to parse Hardcover {queryType} search response: {ex.Message}");
                 return false;
             }
         }
@@ -842,44 +832,37 @@ namespace NzbDrone.Core.MetadataSource.Hardcover
                     .Chunk(MAX_AUTHOR_BOOK_FIELDS_PER_OPERATION)
                     .Select(chunk => chunk.ToList())
                     .ToList();
-                var graphqlRequests = authorIdChunks.Select(chunk => new
-                {
-                    query = BuildAuthorBooksBatchQuery(chunk),
-                    variables = new
-                    {
-                        limit = MAX_RESULTS_PER_TYPE
-                    }
-                }).ToList();
-
-                var jsonContent = JsonSerializer.Serialize(graphqlRequests, jsonOptions);
-
-	                var request = new HttpRequestBuilder(HARDCOVER_ENDPOINT)
-	                    .SetHeader("Content-Type", "application/json")
-	                    .SetHeader("Accept", "application/json")
-	                    .SetHeader("User-Agent", ExternalImageRequestHeaders.GetRandomUserAgent())
-	                    .Build();
-
-                request.Method = HttpMethod.Post;
-                request.SetContent(jsonContent);
-                request.Headers.Add("Authorization", $"Bearer {_configService.HardcoverApiToken}");
-
-                var response = ExecuteWithRetry(request);
-                if (response == null || response.HasHttpError || string.IsNullOrWhiteSpace(response.Content))
-                {
-                    return null;
-                }
-
-                using var document = JsonDocument.Parse(response.Content);
-                var root = document.RootElement;
-                if (root.ValueKind != JsonValueKind.Array || root.GetArrayLength() != authorIdChunks.Count)
-                {
-                    return null;
-                }
-
                 var results = ids.ToDictionary(id => id, _ => new List<HardcoverBookResult>());
+
+                // As with search, Hardcover rejects a batched array body, so each chunk is its own request.
                 for (var chunkIndex = 0; chunkIndex < authorIdChunks.Count; chunkIndex++)
                 {
-                    var operation = root[chunkIndex];
+                    var chunk = authorIdChunks[chunkIndex];
+
+                    var jsonContent = JsonSerializer.Serialize(
+                        new
+                        {
+                            query = BuildAuthorBooksBatchQuery(chunk),
+                            variables = new
+                            {
+                                limit = MAX_RESULTS_PER_TYPE
+                            }
+                        },
+                        jsonOptions);
+
+                    var response = ExecuteWithRetry(BuildGraphQlRequest(jsonContent));
+                    if (response == null || response.HasHttpError || string.IsNullOrWhiteSpace(response.Content))
+                    {
+                        return null;
+                    }
+
+                    using var document = JsonDocument.Parse(response.Content);
+                    var operation = document.RootElement;
+                    if (operation.ValueKind != JsonValueKind.Object)
+                    {
+                        return null;
+                    }
+
                     if (operation.TryGetProperty("errors", out var errors))
                     {
                         _logger.Debug("Hardcover author-books operation failed: {0}", errors.GetRawText());
@@ -891,7 +874,6 @@ namespace NzbDrone.Core.MetadataSource.Hardcover
                         return null;
                     }
 
-                    var chunk = authorIdChunks[chunkIndex];
                     for (var authorIndex = 0; authorIndex < chunk.Count; authorIndex++)
                     {
                         var authorId = chunk[authorIndex];


### PR DESCRIPTION
#### Description

Hardcover search never returns any results. Chaptarr packs its three lookups — Author, Book and Series — into a single HTTP request as a JSON array of GraphQL operations, and Hardcover rejects an array body outright with `400 invalid_query`. The same thing happens on the author-books follow-up, which batches its id chunks the same way. Because the failure is at the transport layer rather than the query layer, it happens for every user with every valid token, and the surfaced error points somewhere else entirely — mine said *"Hardcover's API is currently unavailable. Please try again later."* while Hardcover was perfectly healthy. This sends each operation as its own request. The queries, the variables and all of the response handling are unchanged.

**Reproduced against the live API** with a valid token, changing nothing but the shape of the body:

| Request body | Result |
| --- | --- |
| `[{query,variables}, {…}, {…}]` — what Chaptarr sends | **`400`** `{"error":"invalid_query","error_description":"Unexpected end of document"}` |
| `{query,variables}` — one operation | **`200`**, 817 hits |

That is the whole bug. The GraphQL itself is fine — Chaptarr's exact search query, and its exact token-validation query, both return `200` when sent on their own.

<details>
<summary>Technical detail</summary>

Two call sites build an array body:

- `ExecuteSearch` — `SearchTargets.Select(...).ToList()` serialised straight into the request, so all three search types travel together.
- The author-books lookup — `authorIdChunks.Select(...).ToList()`, one operation per chunk of five author ids.

Both now loop and send one operation per request. To keep that from duplicating request setup a third time, the builder is extracted into `BuildGraphQlRequest(jsonContent)`, which is the same construction as before including adding `Authorization` after `Build()`.

Response handling follows the body shape. `TryExtractSearchPayloads` (which required a top-level array whose length matched `SearchTargets.Length`) is replaced by a `TryExtractSearchPayload(queryType, responseContent, …)` overload that parses one response and delegates to the existing per-operation logic. That per-operation method — including its GraphQL `errors` handling and the `UNAUTHENTICATED` detection — is untouched. The author-books loop likewise now reads `data` from each response directly instead of indexing into `root[chunkIndex]`.

`ENRICHMENT_QUERY` already sent a single operation and is not affected.

</details>

Deliberate choices worth flagging for review:

- **This trades one request for three** (plus one per author-books chunk, as before, but now unbatched). That is the honest cost and the thing most worth challenging here. Batching existed to be frugal, and I have not tried to preserve it — because there is no batch form Hardcover currently accepts, so the choice is three requests or zero results. If you would rather gate this behind a capability probe, or serialise them with a small delay to be gentler on rate limits, say so and I will rework it.
- **Failure semantics are unchanged in kind, but earlier in time.** A failing operation still abandons the whole search rather than merging partial results — the existing comment *"Do not silently merge partial operation data with successful result types"* still holds. The difference is that a first-operation failure now short-circuits before the remaining types are requested, which is strictly less work.
- **Existing tests asserted the broken behaviour.** `should_send_one_search_root_per_http_batched_operation` explicitly asserted `ValueKind == Array` with three operations, and `should_chunk_ten_author_book_roots_into_two_http_batched_operations` asserted a two-element array body. Both are rewritten to assert the per-request shape and renamed accordingly. I have kept every assertion that was about *content* and changed only the ones about *packaging*, so the coverage those tests provided is not lost.
- **No capability detection.** I did not add a fallback that tries a batch first and retries unbatched, because a 400 on every search is not a state worth optimising for, and the retry would double the failure latency for anyone Hardcover has already stopped accepting batches from.

**Known gap, deliberately not addressed:** `ValidateHardcoverToken` maps any unrecognised status to "Hardcover's API is currently unavailable", which is what sent me looking at Hardcover's status page instead of at this. Improving that message is a separate, unrelated change and I did not want to bundle it. Happy to follow up.

#### Database Migration

**NO.** No schema changes, no new columns, no stored data of any kind. The change affects only how an outbound HTTP request is framed; nothing is persisted, so there is nothing to migrate or back-fill and reverting the commit fully reverts the behaviour.

#### How was this tested?

Built and tested on Linux, .NET 10, in the `mcr.microsoft.com/dotnet/sdk:10.0` image, using the same steps `build.yml` runs:

| Step | Result |
| --- | --- |
| `git grep` merge-conflict markers | clean |
| `package.json` parses | ok |
| `version_guard.py sync` | `Version sync OK for working tree: 0.9.929` |
| `version_guard.py monotonic --compare-ref origin/develop` | `Version monotonic OK: 0.9.929` |
| `version_guard.py commit-hygiene --compare-ref origin/develop` | `OK for range origin/develop..HEAD` |
| `dotnet build src/Chaptarr.NoTests.sln -c Release` | **0 warnings, 0 errors** |
| `dotnet test src/Chaptarr.Core.Test -c Release` | **2839 passed, 0 failed** |

**Test counts.** Clean `origin/develop` at `5713d83`: **2838 passed**. This branch: **2839 passed**, 0 failing. Both measured from a hard-reset, `git clean`ed tree with `_output`/`_tests` removed. `HardcoverSearchClientFixture` itself goes from 42 to 43 tests.

No frontend files are touched — 2 files changed, both `.cs` — so the yarn steps outside `build.yml` are not applicable.

**New test:** `should_send_each_search_type_as_its_own_request` asserts three separate requests, each with a top-level JSON **object** body, carrying the three distinct `query_type` values and the same `q` / `limit` / `page` variables as before.

**Confirmed the tests catch the bug** by restoring only `HardcoverSearchClient.cs` to its `develop` version while keeping the new tests, then re-running the fixture:

```
Failed should_send_each_search_type_as_its_own_request
Failed should_send_exactly_one_search_root_per_request
Failed should_chunk_ten_author_book_roots_into_two_separate_requests
Failed should_merge_live_shaped_author_book_and_series_results
Failed should_retry_a_server_error_once_then_continue_the_search
Failed should_anchor_an_exact_author_then_place_provider_id_books_and_series_below_them
Failed should_anchor_the_closest_book_then_place_its_provider_id_author_and_series_below_it
Failed should_use_hardcover_text_match_to_choose_between_non_exact_entity_types
Failed!  - Failed: 8, Passed: 35, Total: 43
```

Restoring the fix returns `Passed! - Failed: 0, Passed: 43`.

**End to end**, Docker on Linux, against a real instance with a valid Hardcover token. Before this change every Hardcover search failed with `400 BadRequest`, logged as `Hardcover search failed`. After:

| Call | Before | After |
| --- | --- | --- |
| `GET /api/v1/search?term=Harry Potter and the Philosopher's Stone` | `503`, `Hardcover search failed` | **`200`, 21 results** — correct book, author and series all present |
| `GET /api/v1/series/lookup?foreignSeriesId=…` | `400` | **`200`** — `Harry Potter`, `workCount 7`, `primaryWorkCount 7`, books returned in positions 1–7 |

Both search and the series lookup path exercise the batching code, and both were dead before the change.

#### Screenshots (UI changes only)

None — no UI changes.
