### PR TITLE
Add health check for root folders missing media type defaults

### DIFF
--- a/src/Chaptarr.Core.Test/HealthCheck/Checks/RootFolderMediaTypeDefaultsCheckFixture.cs
+++ b/src/Chaptarr.Core.Test/HealthCheck/Checks/RootFolderMediaTypeDefaultsCheckFixture.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using NzbDrone.Core.HealthCheck;
+using NzbDrone.Core.HealthCheck.Checks;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.RootFolders;
+
+namespace Chaptarr.Core.Test.HealthCheck.Checks
+{
+    [TestFixture]
+    public class RootFolderMediaTypeDefaultsCheckFixture
+    {
+        private class RootFolderServiceProxy : DispatchProxy
+        {
+            public List<RootFolder> RootFolders { get; set; } = new();
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name switch
+                {
+                    nameof(IRootFolderService.All) => RootFolders,
+                    _ => throw new NotImplementedException($"Test proxy does not implement {targetMethod?.Name}")
+                };
+            }
+        }
+
+        private sealed class StubLocalizationService : ILocalizationService
+        {
+            public Dictionary<string, string> GetLocalizationDictionary()
+            {
+                return new Dictionary<string, string>();
+            }
+
+            public string GetLocalizedString(string phrase)
+            {
+                return phrase switch
+                {
+                    "RootFolderMissingMediaTypeDefaultsSingleMessage" => "Root folder is missing media type defaults and will silently fail to add new authors/books: {0}",
+                    "RootFolderMissingMediaTypeDefaultsMultipleMessage" => "Root folders are missing media type defaults and will silently fail to add new authors/books: {0}",
+                    _ => phrase
+                };
+            }
+
+            public string GetLocalizedString(string phrase, Dictionary<string, object> tokens)
+            {
+                return GetLocalizedString(phrase);
+            }
+        }
+
+        private static RootFolder MixedRootFolder(string path, bool hasAudiobookSettings, bool hasEbookSettings)
+        {
+            var rootFolder = new RootFolder { Path = path, FolderType = FolderType.Mixed };
+            SetSettings(rootFolder, hasAudiobookSettings, hasEbookSettings);
+            return rootFolder;
+        }
+
+        private static void SetSettings(RootFolder rootFolder, bool hasAudiobookSettings, bool hasEbookSettings)
+        {
+            if (hasAudiobookSettings)
+            {
+                rootFolder.SetAudiobookSettings(new MediaTypeSettings { QualityProfileId = 1, MetadataProfileId = 1, MonitorExisting = 1 });
+            }
+
+            if (hasEbookSettings)
+            {
+                rootFolder.SetEbookSettings(new MediaTypeSettings { QualityProfileId = 1, MetadataProfileId = 1, MonitorExisting = 1 });
+            }
+        }
+
+        private static RootFolderMediaTypeDefaultsCheck CreateSubject(params RootFolder[] rootFolders)
+        {
+            var proxy = DispatchProxy.Create<IRootFolderService, RootFolderServiceProxy>();
+            ((RootFolderServiceProxy)(object)proxy).RootFolders = new List<RootFolder>(rootFolders);
+
+            return new RootFolderMediaTypeDefaultsCheck(proxy, new StubLocalizationService());
+        }
+
+        [Test]
+        public void should_be_healthy_when_mixed_root_folder_has_both_defaults_configured()
+        {
+            var result = CreateSubject(MixedRootFolder(@"C:\books", true, true)).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Ok));
+        }
+
+        [Test]
+        public void should_warn_when_mixed_root_folder_is_missing_audiobook_defaults()
+        {
+            var result = CreateSubject(MixedRootFolder(@"C:\books", false, true)).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+            Assert.That(result.Message, Does.Contain(@"C:\books"));
+        }
+
+        [Test]
+        public void should_warn_when_mixed_root_folder_is_missing_ebook_defaults()
+        {
+            var result = CreateSubject(MixedRootFolder(@"C:\books", true, false)).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+            Assert.That(result.Message, Does.Contain(@"C:\books"));
+        }
+
+        [Test]
+        public void should_ignore_missing_ebook_defaults_on_an_audiobook_only_root_folder()
+        {
+            var rootFolder = new RootFolder { Path = @"C:\audiobooks", FolderType = FolderType.Audiobook };
+            SetSettings(rootFolder, hasAudiobookSettings: true, hasEbookSettings: false);
+
+            var result = CreateSubject(rootFolder).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Ok));
+        }
+
+        [Test]
+        public void should_ignore_missing_audiobook_defaults_on_an_ebook_only_root_folder()
+        {
+            var rootFolder = new RootFolder { Path = @"C:\ebooks", FolderType = FolderType.Ebook };
+            SetSettings(rootFolder, hasAudiobookSettings: false, hasEbookSettings: true);
+
+            var result = CreateSubject(rootFolder).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Ok));
+        }
+
+        [Test]
+        public void should_warn_when_audiobook_settings_exist_but_have_no_quality_profile()
+        {
+            var rootFolder = new RootFolder { Path = @"C:\books", FolderType = FolderType.Mixed };
+            rootFolder.SetAudiobookSettings(new MediaTypeSettings { QualityProfileId = null, MetadataProfileId = 1, MonitorExisting = 1 });
+            rootFolder.SetEbookSettings(new MediaTypeSettings { QualityProfileId = 1, MetadataProfileId = 1, MonitorExisting = 1 });
+
+            var result = CreateSubject(rootFolder).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+        }
+
+        [Test]
+        public void should_warn_when_ebook_settings_exist_but_have_no_metadata_profile()
+        {
+            var rootFolder = new RootFolder { Path = @"C:\books", FolderType = FolderType.Mixed };
+            rootFolder.SetAudiobookSettings(new MediaTypeSettings { QualityProfileId = 1, MetadataProfileId = 1, MonitorExisting = 1 });
+            rootFolder.SetEbookSettings(new MediaTypeSettings { QualityProfileId = 1, MetadataProfileId = 0, MonitorExisting = 1 });
+
+            var result = CreateSubject(rootFolder).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+        }
+
+        [Test]
+        public void should_warn_when_stored_settings_json_is_corrupt()
+        {
+            var rootFolder = new RootFolder { Path = @"C:\books", FolderType = FolderType.Audiobook };
+            rootFolder.AudiobookSettings = "not valid json";
+
+            var result = CreateSubject(rootFolder).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+        }
+
+        [Test]
+        public void should_list_every_incomplete_root_folder_in_a_combined_message()
+        {
+            var result = CreateSubject(
+                MixedRootFolder(@"C:\books-one", false, true),
+                MixedRootFolder(@"C:\books-two", true, false)).Check();
+
+            Assert.That(result.Type, Is.EqualTo(HealthCheckResult.Warning));
+            Assert.That(result.Message, Does.Contain(@"C:\books-one"));
+            Assert.That(result.Message, Does.Contain(@"C:\books-two"));
+        }
+    }
+}

--- a/src/NzbDrone.Core/HealthCheck/Checks/RootFolderMediaTypeDefaultsCheck.cs
+++ b/src/NzbDrone.Core/HealthCheck/Checks/RootFolderMediaTypeDefaultsCheck.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using NzbDrone.Core.Datastore.Events;
+using NzbDrone.Core.Localization;
+using NzbDrone.Core.RootFolders;
+
+namespace NzbDrone.Core.HealthCheck.Checks
+{
+    [CheckOn(typeof(ModelEvent<RootFolder>))]
+    public class RootFolderMediaTypeDefaultsCheck : HealthCheckBase
+    {
+        private readonly IRootFolderService _rootFolderService;
+
+        public RootFolderMediaTypeDefaultsCheck(IRootFolderService rootFolderService, ILocalizationService localizationService)
+            : base(localizationService)
+        {
+            _rootFolderService = rootFolderService;
+        }
+
+        public override HealthCheck Check()
+        {
+            var incomplete = _rootFolderService.All()
+                .Where(IsMissingCompatibleDefaults)
+                .Select(f => f.Path)
+                .ToList();
+
+            if (!incomplete.Any())
+            {
+                return new HealthCheck(GetType());
+            }
+
+            if (incomplete.Count == 1)
+            {
+                return new HealthCheck(
+                    GetType(),
+                    HealthCheckResult.Warning,
+                    string.Format(_localizationService.GetLocalizedString("RootFolderMissingMediaTypeDefaultsSingleMessage"), incomplete.First()),
+                    "#root-folder-missing-media-type-defaults");
+            }
+
+            var message = string.Format(
+                _localizationService.GetLocalizedString("RootFolderMissingMediaTypeDefaultsMultipleMessage"),
+                string.Join(" | ", incomplete));
+
+            return new HealthCheck(GetType(), HealthCheckResult.Warning, message, "#root-folder-missing-media-type-defaults");
+        }
+
+        // A root folder created via the API without going through the UI wizard can be
+        // saved with no AudiobookSettings/EbookSettings (or with settings that have no
+        // quality/metadata profile chosen) for a media type its FolderType accepts.
+        // DiscoveryWorker then fails every author it tries to create there
+        // (AuthorLibraryService.NormalizeMonitoringConfigForMediaType) with a warn-level
+        // log entry that is never surfaced anywhere else and never retried. This mirrors
+        // that method's own null/settings and quality/metadata profile id checks so this
+        // check can't report Ok while DiscoveryWorker is still failing; it does not
+        // detect a profile id that points at a since-deleted profile, since that needs
+        // IQualityProfileService/IMetadataProfileService and was left out of this pass.
+        private static bool IsMissingCompatibleDefaults(RootFolder rootFolder)
+        {
+            var acceptsAudiobooks = rootFolder.FolderType == FolderType.Mixed || rootFolder.FolderType == FolderType.Audiobook;
+            var acceptsEbooks = rootFolder.FolderType == FolderType.Mixed || rootFolder.FolderType == FolderType.Ebook;
+
+            if (acceptsAudiobooks && IsMissingUsableDefaults(rootFolder.GetAudiobookSettings()))
+            {
+                return true;
+            }
+
+            if (acceptsEbooks && IsMissingUsableDefaults(rootFolder.GetEbookSettings()))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsMissingUsableDefaults(MediaTypeSettings settings)
+        {
+            if (settings == null)
+            {
+                return true;
+            }
+
+            return !HasValidProfileId(settings.QualityProfileId) || !HasValidProfileId(settings.MetadataProfileId);
+        }
+
+        private static bool HasValidProfileId(int? profileId)
+        {
+            return profileId.HasValue && profileId.Value > 0;
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1700,6 +1700,8 @@
   "RootFolderEbookMonitorFutureHelpText": "Monitor future ebook releases from this author",
   "RootFolderErrorInDeleteModal": "Error in delete modal",
   "RootFolderFreeSpace": "{space} Free",
+  "RootFolderMissingMediaTypeDefaultsMultipleMessage": "Root folders are missing media type defaults and will silently fail to add new authors/books: {0}",
+  "RootFolderMissingMediaTypeDefaultsSingleMessage": "Root folder is missing media type defaults and will silently fail to add new authors/books: {0}",
   "RootFolderPathHelpText": "Root Folder list items will be added to",
   "RootFolderTypeChangeAssignedMessage": "You can't split a mixed-content root folder or switch an assigned single-type root folder. Remove it and re-add it as audiobook-only or eBook-only.",
   "RootFolders": "Root Folders",


### PR DESCRIPTION
## Summary
Fixes #31.

`POST /api/v1/rootfolder` lets you create a root folder with no `AudiobookSettings`/`EbookSettings` (or with settings that have no quality/metadata profile chosen) configured for a media type its `FolderType` accepts. When `DiscoveryWorker` later tries to auto-create an author/book there, `AuthorLibraryService.NormalizeMonitoringConfigForMediaType` throws - but that's a warn-level log entry deep in an async import path with no retry and no other visible surfacing, so the failure is invisible outside manually paging through `/api/v1/log`.

This adds `RootFolderMediaTypeDefaultsCheck`, a health check that flags any root folder missing usable defaults for a media type its `FolderType` is compatible with, so the gap shows up in the UI's health/system status instead. It mirrors `NormalizeMonitoringConfigForMediaType`'s own checks (settings present, quality profile id set, metadata profile id set) so it can't report healthy while that method is still failing for the same root folder. It's wired with `[CheckOn(typeof(ModelEvent<RootFolder>))]` (same pattern as `CalibreRootFolderCheck`/`DownloadClientRootFolderCheck`) so it re-evaluates immediately on root folder create/update/delete, plus the usual startup/scheduled runs.

**Known gap, left out of this pass:** it doesn't detect a quality/metadata profile id that points at a since-deleted profile (the other thing `NormalizeMonitoringConfigForMediaType` validates) - that needs `IQualityProfileService`/`IMetadataProfileService` injected and felt like a separate, slightly bigger change. Happy to add it here if preferred.

Deliberately did not touch `DiscoveryWorker`'s async retry path or add blocking validation to `POST /api/v1/rootfolder` itself, to keep this additive and low-risk rather than changing existing create/update behavior.

## Test plan
- [x] New unit tests in `RootFolderMediaTypeDefaultsCheckFixture` (9 cases: healthy mixed folder, missing audiobook/ebook settings, single-type folders correctly ignoring the incompatible media type, missing quality/metadata profile ids, corrupt stored settings JSON, multi-folder combined message)
- [x] Full existing test suite passes unchanged (2861/2861)