### PR TITLE
Cascade explicit PUT monitored into tri-state fields so it actually persists

### DIFF
--- a/src/Chaptarr.Api.V1/Author/AuthorController.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorController.cs
@@ -916,34 +916,69 @@ namespace Chaptarr.Api.V1.Author
         // it one, at which point an explicit "monitored" on the same request needs to apply there too,
         // whether or not the top-level flag also happened to change.
         //
-        // Per media type, independently: a media type whose own tri-state fields the client's request
-        // genuinely changes is left alone entirely (that explicit edit wins, same as it always has),
-        // and a media type with no root folder - on the author as it's stored OR as this same request
-        // is assigning one - is skipped since there's nothing to monitor there. This mirrors, and runs
-        // alongside, the equivalent single-media-type cascade ToModel already does for a Readarr-facade
-        // request - kept as a separate pass here (rather than folded into ToModel) because it needs the
-        // author's stored state, not just what's on the incoming resource.
+        // Per FIELD (not per media type - see the comment further down for why that distinction
+        // matters), a field the client's request genuinely changes is left alone entirely (that
+        // explicit edit wins, same as it always has), and a media type with no root folder - on the
+        // author as it's stored OR as this same request is assigning one - is skipped entirely since
+        // there's nothing to monitor there. This mirrors, and runs alongside, the equivalent single-
+        // media-type cascade ToModel already does for a Readarr-facade request - kept as a separate
+        // pass here (rather than folded into ToModel) because it needs the author's stored state, not
+        // just what's on the incoming resource.
         // Internal (rather than private) so the test fixture can call it directly instead of via
         // reflection - a reflection-based call would only fail at test runtime, not compile time, if
-        // this signature's parameter order or count ever changed.
+        // this signature's parameter order or count ever changed. Thin AuthorResource-shaped wrapper
+        // around the primitive-parameter overload below, which AuthorEditorController's bulk PUT also
+        // calls directly (AuthorEditorResource has the same four tri-state fields plus Monitored, but
+        // isn't an AuthorResource) - the underlying "is this a genuine change, per media type" logic is
+        // identical for both endpoints, only the source of the requested values differs.
         internal static void CascadeExplicitMonitoredIntoMediaTypeSettings(
             AuthorResource authorResource,
             NzbDrone.Core.Books.Author model,
             ReadarrFacadeContext facadeContext,
             StoredAuthorMonitoringState stored)
         {
-            if (facadeContext != null || !authorResource.Monitored.HasValue)
+            if (facadeContext != null)
             {
                 return;
             }
 
-            var monitored = authorResource.Monitored.Value;
+            CascadeExplicitMonitoredIntoMediaTypeSettings(
+                authorResource.Monitored,
+                authorResource.AudiobookMonitorExisting,
+                authorResource.AudiobookMonitorFuture,
+                authorResource.EbookMonitorExisting,
+                authorResource.EbookMonitorFuture,
+                model,
+                stored);
+        }
+
+        internal static void CascadeExplicitMonitoredIntoMediaTypeSettings(
+            bool? requestedMonitored,
+            int? requestedAudiobookMonitorExisting,
+            bool? requestedAudiobookMonitorFuture,
+            int? requestedEbookMonitorExisting,
+            bool? requestedEbookMonitorFuture,
+            NzbDrone.Core.Books.Author model,
+            StoredAuthorMonitoringState stored)
+        {
+            if (!requestedMonitored.HasValue)
+            {
+                return;
+            }
+
+            var monitored = requestedMonitored.Value;
             var isGenuineChange = monitored != stored.WasMonitoredFromMediaSettings;
 
+            // Per FIELD, not per media type: a client that explicitly sends one of a media type's two
+            // tri-state fields but not the other (e.g. Chaptarr's own bulk author editor, which always
+            // sends MonitorExisting when changing monitoring but never sends MonitorFuture) still needs
+            // the untouched field to pick up the top-level flag - otherwise that field is left wherever
+            // it was, `IsMonitoredFromMediaSettings()` still reads it, and the requested change can
+            // silently fail to take effect even though the field the client DID send applied correctly.
+            // An earlier version of this gated on either field being present, which protected the whole
+            // media type from any cascading the moment ONE field was touched - safe for the single-
+            // author PUT's echo scenarios, but a no-op for exactly the real bulk-editor payload shape.
             var audiobookHasNewRootFolder = stored.AudiobookRootFolderPath.IsNullOrWhiteSpace() && !model.AudiobookRootFolderPath.IsNullOrWhiteSpace();
-            var audiobookTouched =
-                (authorResource.AudiobookMonitorExisting.HasValue && authorResource.AudiobookMonitorExisting != stored.AudiobookMonitorExisting) ||
-                (authorResource.AudiobookMonitorFuture.HasValue && authorResource.AudiobookMonitorFuture != stored.AudiobookMonitorFuture);
             var audiobookConfigured = !stored.AudiobookRootFolderPath.IsNullOrWhiteSpace() || audiobookHasNewRootFolder;
 
             // isGenuineChange alone would miss a media type gaining a root folder in THIS same
@@ -955,32 +990,63 @@ namespace Chaptarr.Api.V1.Author
             // gives it a root folder, it's a real candidate, and the explicit "monitored" on this same
             // request should apply there too - whether or not the top-level flag also happened to
             // change relative to the author's overall prior state.
-            if (!audiobookTouched && audiobookConfigured && (isGenuineChange || audiobookHasNewRootFolder))
+            if (audiobookConfigured && (isGenuineChange || audiobookHasNewRootFolder))
             {
-                model.AudiobookMonitorFuture = monitored;
-                if (!monitored)
+                var audiobookFutureChanged = requestedAudiobookMonitorFuture.HasValue && requestedAudiobookMonitorFuture != stored.AudiobookMonitorFuture;
+                var audiobookExistingChanged = requestedAudiobookMonitorExisting.HasValue && requestedAudiobookMonitorExisting != stored.AudiobookMonitorExisting;
+                var overrodeSomething = false;
+
+                // Turning off needs both fields cleared - MonitorExisting > 0 alone would still keep
+                // the author monitored, so if the client isn't already clearing Future itself, this has
+                // to. Turning on doesn't have that asymmetry: MonitorExisting > 0 alone already
+                // satisfies "monitored", so only force Future when Existing (as this request leaves it)
+                // won't - otherwise this would silently flip on "monitor new releases" for a media type
+                // whose future-monitoring preference nobody asked to change.
+                var audiobookNeedsFuture = !monitored || (model.AudiobookMonitorExisting ?? 0) <= 0;
+                if (!audiobookFutureChanged && audiobookNeedsFuture)
                 {
-                    model.AudiobookMonitorExisting = 0;
+                    model.AudiobookMonitorFuture = monitored;
+                    overrodeSomething = true;
                 }
 
-                model.AudiobookSettingsManuallyOverridden = true;
+                if (!monitored && !audiobookExistingChanged)
+                {
+                    model.AudiobookMonitorExisting = 0;
+                    overrodeSomething = true;
+                }
+
+                if (overrodeSomething)
+                {
+                    model.AudiobookSettingsManuallyOverridden = true;
+                }
             }
 
             var ebookHasNewRootFolder = stored.EbookRootFolderPath.IsNullOrWhiteSpace() && !model.EbookRootFolderPath.IsNullOrWhiteSpace();
-            var ebookTouched =
-                (authorResource.EbookMonitorExisting.HasValue && authorResource.EbookMonitorExisting != stored.EbookMonitorExisting) ||
-                (authorResource.EbookMonitorFuture.HasValue && authorResource.EbookMonitorFuture != stored.EbookMonitorFuture);
             var ebookConfigured = !stored.EbookRootFolderPath.IsNullOrWhiteSpace() || ebookHasNewRootFolder;
 
-            if (!ebookTouched && ebookConfigured && (isGenuineChange || ebookHasNewRootFolder))
+            if (ebookConfigured && (isGenuineChange || ebookHasNewRootFolder))
             {
-                model.EbookMonitorFuture = monitored;
-                if (!monitored)
+                var ebookFutureChanged = requestedEbookMonitorFuture.HasValue && requestedEbookMonitorFuture != stored.EbookMonitorFuture;
+                var ebookExistingChanged = requestedEbookMonitorExisting.HasValue && requestedEbookMonitorExisting != stored.EbookMonitorExisting;
+                var overrodeSomething = false;
+
+                var ebookNeedsFuture = !monitored || (model.EbookMonitorExisting ?? 0) <= 0;
+                if (!ebookFutureChanged && ebookNeedsFuture)
                 {
-                    model.EbookMonitorExisting = 0;
+                    model.EbookMonitorFuture = monitored;
+                    overrodeSomething = true;
                 }
 
-                model.EbookSettingsManuallyOverridden = true;
+                if (!monitored && !ebookExistingChanged)
+                {
+                    model.EbookMonitorExisting = 0;
+                    overrodeSomething = true;
+                }
+
+                if (overrodeSomething)
+                {
+                    model.EbookSettingsManuallyOverridden = true;
+                }
             }
         }
 

--- a/src/Chaptarr.Api.V1/Author/AuthorController.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorController.cs
@@ -358,16 +358,16 @@ namespace Chaptarr.Api.V1.Author
                 authorResource.AudiobookQualityProfileId ??= authorResource.QualityProfileId;
                 authorResource.AudiobookRootFolderPath ??= authorResource.RootFolderPath;
                 authorResource.AudiobookTags ??= authorResource.Tags;
-                authorResource.AudiobookMonitorExisting ??= authorResource.Monitored ? 1 : 0;
-                authorResource.AudiobookMonitorFuture ??= authorResource.Monitored;
+                authorResource.AudiobookMonitorExisting ??= authorResource.Monitored == true ? 1 : 0;
+                authorResource.AudiobookMonitorFuture ??= authorResource.Monitored ?? false;
             }
             else if (facadeContext.MediaType == "ebook")
             {
                 authorResource.EbookQualityProfileId ??= authorResource.QualityProfileId;
                 authorResource.EbookRootFolderPath ??= authorResource.RootFolderPath;
                 authorResource.EbookTags ??= authorResource.Tags;
-                authorResource.EbookMonitorExisting ??= authorResource.Monitored ? 1 : 0;
-                authorResource.EbookMonitorFuture ??= authorResource.Monitored;
+                authorResource.EbookMonitorExisting ??= authorResource.Monitored == true ? 1 : 0;
+                authorResource.EbookMonitorFuture ??= authorResource.Monitored ?? false;
             }
         }
 
@@ -414,7 +414,7 @@ namespace Chaptarr.Api.V1.Author
 
             var config = new MonitoringConfig
             {
-                MonitorNewItems = authorResource.Monitored,
+                MonitorNewItems = authorResource.Monitored ?? false,
                 IsManualAddition = true,
                 CreateAudiobook = !string.IsNullOrWhiteSpace(authorResource.AudiobookRootFolderPath),
                 CreateEbook = !string.IsNullOrWhiteSpace(authorResource.EbookRootFolderPath),
@@ -822,6 +822,14 @@ namespace Chaptarr.Api.V1.Author
 	            var author = _authorService.GetAuthor(authorResource.Id);
                 var wasSyncEnabled = author.SyncMonitoredAcrossFormats == true;
 
+                // ToModel/ApplyChanges mutate `author` in place (the returned `model` below is the same
+                // object), so everything the cascade below needs to know about the author's state
+                // BEFORE this request - root folders, tri-state fields, derived monitored status - has
+                // to be captured before that call, not read off `model` afterwards. Bundled into one
+                // struct, captured in one line, specifically so there's nothing here for a later edit
+                // to accidentally reorder relative to the ToModel call below.
+                var storedMonitoringState = StoredAuthorMonitoringState.Capture(author);
+
 	            if (moveFiles)
 	            {
 	                var sourcePath = author.Path;
@@ -837,6 +845,7 @@ namespace Chaptarr.Api.V1.Author
 	            }
 
 	            var model = authorResource.ToModel(author, facadeContext);
+	            CascadeExplicitMonitoredIntoMediaTypeSettings(authorResource, model, facadeContext, storedMonitoringState);
 	            var updatedAuthor = _authorService.UpdateAuthor(model);
 
                 var shouldReconcile = updatedAuthor.SyncMonitoredAcrossFormats == true &&
@@ -853,6 +862,127 @@ namespace Chaptarr.Api.V1.Author
 
 	            return Accepted(updatedAuthor.Id);
 	        }
+
+        // Everything about the author's state BEFORE this request that the cascade below needs to
+        // reason about - captured before ToModel/ApplyChanges mutate the author in place. Bundled into
+        // one type, captured in one line at the top of UpdateAuthor, so there's no set of loose local
+        // variables for a later edit to accidentally reorder relative to the ToModel call.
+        internal readonly record struct StoredAuthorMonitoringState(
+            string AudiobookRootFolderPath,
+            string EbookRootFolderPath,
+            int? AudiobookMonitorExisting,
+            bool? AudiobookMonitorFuture,
+            int? EbookMonitorExisting,
+            bool? EbookMonitorFuture,
+            bool WasMonitoredFromMediaSettings)
+        {
+            public static StoredAuthorMonitoringState Capture(NzbDrone.Core.Books.Author author)
+            {
+                return new StoredAuthorMonitoringState(
+                    author.AudiobookRootFolderPath,
+                    author.EbookRootFolderPath,
+                    author.AudiobookMonitorExisting,
+                    author.AudiobookMonitorFuture,
+                    author.EbookMonitorExisting,
+                    author.EbookMonitorFuture,
+                    author.IsMonitoredFromMediaSettings());
+            }
+        }
+
+        // AuthorService.UpdateAuthor recomputes the legacy Monitored flag from the per-media-type
+        // tri-state settings on every save (author.Monitored = author.IsMonitoredFromMediaSettings()),
+        // and separately fills any still-null tri-state field from the root folder's defaults before
+        // that recompute runs. So a request that only sets the top-level "monitored" field - without
+        // touching any of the four tri-state fields for a media type - has it silently discarded:
+        // whatever those fields already were (or get defaulted to) wins, and the recompute overwrites
+        // the requested value right back.
+        //
+        // The tricky part: almost every real client, including Chaptarr's own UI toggle and any script
+        // that does GET -> flip one field -> PUT the whole object back, sends a full object on every
+        // PUT - so both `monitored` AND the four tri-state fields ride along unchanged from the last
+        // GET on saves that have nothing to do with monitoring. A client that only means to flip
+        // `monitored` is indistinguishable, at the JSON level, from one that's echoing it - and the
+        // same is true of each tri-state field individually. Treating a tri-state field's mere presence
+        // in the request as "the client edited this" (an earlier version of this fix did exactly that)
+        // breaks the GET-modify-PUT case specifically: the four tri-state fields ride along unchanged,
+        // read as "touched", and the cascade skips every media type - the original bug, undisturbed.
+        // The only reliable signal, for `monitored` and for each tri-state field alike, is whether the
+        // request's value actually differs from what was already stored - a same-value echo is then
+        // always a no-op, by construction, whichever fields happen to be present.
+        //
+        // The one case that signal alone would miss: a media type gaining a root folder in this exact
+        // request. AuthorService's root-folder-defaults fill only resolves a media type that has a
+        // root folder, so a media type with none yet isn't at risk from it - until this request gives
+        // it one, at which point an explicit "monitored" on the same request needs to apply there too,
+        // whether or not the top-level flag also happened to change.
+        //
+        // Per media type, independently: a media type whose own tri-state fields the client's request
+        // genuinely changes is left alone entirely (that explicit edit wins, same as it always has),
+        // and a media type with no root folder - on the author as it's stored OR as this same request
+        // is assigning one - is skipped since there's nothing to monitor there. This mirrors, and runs
+        // alongside, the equivalent single-media-type cascade ToModel already does for a Readarr-facade
+        // request - kept as a separate pass here (rather than folded into ToModel) because it needs the
+        // author's stored state, not just what's on the incoming resource.
+        // Internal (rather than private) so the test fixture can call it directly instead of via
+        // reflection - a reflection-based call would only fail at test runtime, not compile time, if
+        // this signature's parameter order or count ever changed.
+        internal static void CascadeExplicitMonitoredIntoMediaTypeSettings(
+            AuthorResource authorResource,
+            NzbDrone.Core.Books.Author model,
+            ReadarrFacadeContext facadeContext,
+            StoredAuthorMonitoringState stored)
+        {
+            if (facadeContext != null || !authorResource.Monitored.HasValue)
+            {
+                return;
+            }
+
+            var monitored = authorResource.Monitored.Value;
+            var isGenuineChange = monitored != stored.WasMonitoredFromMediaSettings;
+
+            var audiobookHasNewRootFolder = stored.AudiobookRootFolderPath.IsNullOrWhiteSpace() && !model.AudiobookRootFolderPath.IsNullOrWhiteSpace();
+            var audiobookTouched =
+                (authorResource.AudiobookMonitorExisting.HasValue && authorResource.AudiobookMonitorExisting != stored.AudiobookMonitorExisting) ||
+                (authorResource.AudiobookMonitorFuture.HasValue && authorResource.AudiobookMonitorFuture != stored.AudiobookMonitorFuture);
+            var audiobookConfigured = !stored.AudiobookRootFolderPath.IsNullOrWhiteSpace() || audiobookHasNewRootFolder;
+
+            // isGenuineChange alone would miss a media type gaining a root folder in THIS same
+            // request. A media type with no root folder before this PUT isn't a candidate for
+            // monitoring at all yet, whatever its tri-state fields happen to hold - AuthorService's
+            // root-folder-defaults fill (which resolves any still-null field once a media type has a
+            // root folder) is the common way that becomes reachable, but stale non-null values from a
+            // previous, since-removed root folder are also possible. Either way, once this request
+            // gives it a root folder, it's a real candidate, and the explicit "monitored" on this same
+            // request should apply there too - whether or not the top-level flag also happened to
+            // change relative to the author's overall prior state.
+            if (!audiobookTouched && audiobookConfigured && (isGenuineChange || audiobookHasNewRootFolder))
+            {
+                model.AudiobookMonitorFuture = monitored;
+                if (!monitored)
+                {
+                    model.AudiobookMonitorExisting = 0;
+                }
+
+                model.AudiobookSettingsManuallyOverridden = true;
+            }
+
+            var ebookHasNewRootFolder = stored.EbookRootFolderPath.IsNullOrWhiteSpace() && !model.EbookRootFolderPath.IsNullOrWhiteSpace();
+            var ebookTouched =
+                (authorResource.EbookMonitorExisting.HasValue && authorResource.EbookMonitorExisting != stored.EbookMonitorExisting) ||
+                (authorResource.EbookMonitorFuture.HasValue && authorResource.EbookMonitorFuture != stored.EbookMonitorFuture);
+            var ebookConfigured = !stored.EbookRootFolderPath.IsNullOrWhiteSpace() || ebookHasNewRootFolder;
+
+            if (!ebookTouched && ebookConfigured && (isGenuineChange || ebookHasNewRootFolder))
+            {
+                model.EbookMonitorFuture = monitored;
+                if (!monitored)
+                {
+                    model.EbookMonitorExisting = 0;
+                }
+
+                model.EbookSettingsManuallyOverridden = true;
+            }
+        }
 
         private bool HasSyncMonitoredAcrossFormatsEligibility(NzbDrone.Core.Books.Author author)
         {

--- a/src/Chaptarr.Api.V1/Author/AuthorEditorController.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorEditorController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Chaptarr.Http;
+using Chaptarr.Http.Middleware;
 using Microsoft.AspNetCore.Mvc;
 using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Books;
@@ -42,6 +43,7 @@ namespace Chaptarr.Api.V1.Author
             var authorsToUpdate = _authorService.GetAuthors(resource.AuthorIds);
             var previousSyncByAuthorId = authorsToUpdate.ToDictionary(author => author.Id, author => author.SyncMonitoredAcrossFormats == true);
             var previousRootFoldersByAuthorId = authorsToUpdate.ToDictionary(author => author.Id, author => (author.AudiobookRootFolderPath, author.EbookRootFolderPath));
+            var previousMonitoringByAuthorId = authorsToUpdate.ToDictionary(author => author.Id, AuthorController.StoredAuthorMonitoringState.Capture);
             var audiobookMoves = new List<BulkMoveAuthor>();
             var ebookMoves = new List<BulkMoveAuthor>();
             var rootFolders = _rootFolderService.All();
@@ -154,6 +156,29 @@ namespace Chaptarr.Api.V1.Author
                             MediaType = "ebook"
                         });
                     }
+                }
+
+                // AuthorService.UpdateAuthors recomputes the legacy Monitored flag from the tri-state
+                // fields on every save, so setting it via the "resource.Monitored.HasValue" write near
+                // the top of this loop doesn't stick on its own unless the tri-state fields end up
+                // agreeing with it - the same underlying problem the single-author PUT path has (see
+                // AuthorController.UpdateAuthor). This bulk endpoint already gates every field write on
+                // the resource actually providing it, so - unlike the single-author PUT path - there's
+                // no risk of a root folder being silently cleared by omission here; the per-author
+                // "before this request" snapshot captured above is all this needs. Skipped under a
+                // Readarr-facade request for the same reason AuthorController.UpdateAuthor skips it:
+                // this endpoint isn't facade-media-type-scoped the way that PUT is, so nothing here
+                // guarantees the request is only about one media type.
+                if (HttpContext.GetReadarrFacadeContext() == null)
+                {
+                    AuthorController.CascadeExplicitMonitoredIntoMediaTypeSettings(
+                        resource.Monitored,
+                        resource.AudiobookMonitorExisting,
+                        resource.AudiobookMonitorFuture,
+                        resource.EbookMonitorExisting,
+                        resource.EbookMonitorFuture,
+                        author,
+                        previousMonitoringByAuthorId[author.Id]);
                 }
 
                 if (resource.SyncMonitoredAcrossFormats.HasValue)

--- a/src/Chaptarr.Api.V1/Author/AuthorResource.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorResource.cs
@@ -50,7 +50,9 @@ namespace Chaptarr.Api.V1.Author
         public int? EbookMetadataProfileId { get; set; }
 
         //Editing Only
-        public bool Monitored { get; set; }
+        // NULL = client didn't send this field (leave the effective monitored status as whatever the
+        // tri-state fields below already say); non-null = client explicitly wants this legacy flag set.
+        public bool? Monitored { get; set; }
         // TRI-STATE MONITORING SYSTEM - Integer per media type
         // Values: 0 = None (monitor nothing), 1 = All (monitor everything), 2 = Selected (monitor specific books only)
         // NULL = not configured for this media type yet (treated as unmonitored until root-folder discovery or user config)
@@ -425,15 +427,18 @@ namespace Chaptarr.Api.V1.Author
             var ebookMonitorExisting = resource.EbookMonitorExisting;
             var ebookMonitorFuture = resource.EbookMonitorFuture;
 
+            // Preserves this block's pre-existing (resource.Monitored used to be a non-nullable bool,
+            // defaulting to false when omitted) behavior for the facade write path unchanged - an
+            // omitted Monitored still backfills as false here, exactly as it always did.
             if (facadeContext?.MediaType == "audiobook")
             {
-                audiobookMonitorExisting ??= resource.Monitored ? 1 : 0;
-                audiobookMonitorFuture ??= resource.Monitored;
+                audiobookMonitorExisting ??= resource.Monitored == true ? 1 : 0;
+                audiobookMonitorFuture ??= resource.Monitored ?? false;
             }
             else if (facadeContext?.MediaType == "ebook")
             {
-                ebookMonitorExisting ??= resource.Monitored ? 1 : 0;
-                ebookMonitorFuture ??= resource.Monitored;
+                ebookMonitorExisting ??= resource.Monitored == true ? 1 : 0;
+                ebookMonitorFuture ??= resource.Monitored ?? false;
             }
 
             var hasTagInput = resource.Tags != null || resource.AudiobookTags != null || resource.EbookTags != null;
@@ -469,7 +474,11 @@ namespace Chaptarr.Api.V1.Author
                 AudiobookMetadataProfileId = resource.AudiobookMetadataProfileId,
                 EbookMetadataProfileId = resource.EbookMetadataProfileId,
 
-                Monitored = resource.Monitored,
+                // Author.Monitored is non-nullable; an omitted resource.Monitored maps to false here,
+                // matching this field's pre-existing (bool, not bool?) deserialization default. Callers
+                // that need to distinguish "omitted" from "explicitly false" (see AuthorController.
+                // UpdateAuthor's cascade) read resource.Monitored directly before calling ToModel.
+                Monitored = resource.Monitored ?? false,
                 // TRI-STATE MONITORING SYSTEM
                 AudiobookMonitorExisting = audiobookMonitorExisting,
                 AudiobookMonitorFuture = audiobookMonitorFuture,

--- a/src/Chaptarr.Api.V1/openapi.json
+++ b/src/Chaptarr.Api.V1/openapi.json
@@ -12900,7 +12900,8 @@
             "nullable": true
           },
           "monitored": {
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           },
           "audiobookMonitorExisting": {
             "type": "integer",

--- a/src/Chaptarr.Core.Test/Api/AuthorControllerMonitoredCascadeFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/AuthorControllerMonitoredCascadeFixture.cs
@@ -1,0 +1,387 @@
+using Chaptarr.Api.V1.Author;
+using Chaptarr.Http.Middleware;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+
+namespace Chaptarr.Core.Test.Api
+{
+    [TestFixture]
+    public class AuthorControllerMonitoredCascadeFixture
+    {
+        // AuthorController.CascadeExplicitMonitoredIntoMediaTypeSettings and StoredAuthorMonitoringState
+        // are internal (not public) but have no dependency on controller state, so they're called
+        // directly here - via [assembly: InternalsVisibleTo("Chaptarr.Core.Test")] on Chaptarr.Api.V1 -
+        // rather than standing up the full controller (20+ constructor dependencies unrelated to this
+        // logic).
+        private static void Cascade(
+            AuthorResource resource,
+            Author model,
+            string storedAudiobookRootFolderPath,
+            string storedEbookRootFolderPath,
+            bool wasMonitoredFromMediaSettings,
+            int? storedAudiobookMonitorExisting = null,
+            bool? storedAudiobookMonitorFuture = null,
+            int? storedEbookMonitorExisting = null,
+            bool? storedEbookMonitorFuture = null,
+            ReadarrFacadeContext facadeContext = null)
+        {
+            var stored = new AuthorController.StoredAuthorMonitoringState(
+                storedAudiobookRootFolderPath,
+                storedEbookRootFolderPath,
+                storedAudiobookMonitorExisting,
+                storedAudiobookMonitorFuture,
+                storedEbookMonitorExisting,
+                storedEbookMonitorFuture,
+                wasMonitoredFromMediaSettings);
+
+            AuthorController.CascadeExplicitMonitoredIntoMediaTypeSettings(resource, model, facadeContext, stored);
+        }
+
+        private static Author FullyConfiguredMonitoredAuthor()
+        {
+            return new Author
+            {
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+        }
+
+        [Test]
+        public void should_cascade_explicit_unmonitor_into_both_media_types_when_tri_state_untouched()
+        {
+            var model = FullyConfiguredMonitoredAuthor();
+            var resource = new AuthorResource { Monitored = false };
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true,
+                storedEbookMonitorExisting: 2, storedEbookMonitorFuture: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.False);
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.EbookMonitorFuture, Is.False);
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_unmonitor_when_client_echoes_unchanged_tri_state_fields_from_a_prior_get()
+        {
+            // The gap an earlier version of this fix had: a client that does GET -> flip `monitored`
+            // -> PUT the whole object back (arguably the most common *arr API usage pattern, and
+            // exactly how issue #17's own repro style reads) sends the four tri-state fields back
+            // unchanged. Treating their mere presence as "the client edited this" - which an earlier
+            // version of this cascade did - made the cascade skip every media type, silently
+            // reproducing the original bug for this exact client shape. It has to fire here too.
+            var model = FullyConfiguredMonitoredAuthor();
+            var resource = new AuthorResource
+            {
+                Monitored = false,
+                AudiobookMonitorExisting = 1, // echoed back unchanged from the prior GET
+                AudiobookMonitorFuture = true,
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true,
+                storedEbookMonitorExisting: 2, storedEbookMonitorFuture: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.False);
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.EbookMonitorFuture, Is.False);
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_cascade_explicit_monitor_true_without_touching_existing()
+        {
+            var model = new Author { AudiobookMonitorExisting = 0, AudiobookMonitorFuture = false };
+            var resource = new AuthorResource { Monitored = true };
+
+            Cascade(resource, model, @"C:\audiobooks", null, wasMonitoredFromMediaSettings: false,
+                storedAudiobookMonitorExisting: 0, storedAudiobookMonitorFuture: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.True);
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0), "MonitorFuture=true alone is enough to make the author monitored; MonitorExisting is a separate, unrelated choice this request never asked to change");
+            });
+        }
+
+        [Test]
+        public void should_be_a_no_op_when_the_requested_value_already_matches_current_truth()
+        {
+            // The critical case: a client (Chaptarr's own UI toggle included) that spreads the last
+            // GET response onto a PUT sends back a `monitored` that already matches reality whenever
+            // its edit was to something else entirely. Nothing should move here.
+            var model = new Author { AudiobookMonitorExisting = 2, AudiobookMonitorFuture = false };
+            var resource = new AuthorResource { Monitored = true };
+
+            Cascade(resource, model, @"C:\audiobooks", null, wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 2, storedAudiobookMonitorFuture: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.False, "unchanged - nothing was actually requested here");
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(2), "an already-configured Selected(2) must not be silently promoted to All(1)");
+            });
+        }
+
+        [Test]
+        public void should_only_touch_media_types_the_author_is_configured_for()
+        {
+            var model = new Author { AudiobookMonitorExisting = 1, AudiobookMonitorFuture = true };
+            var resource = new AuthorResource { Monitored = false };
+
+            Cascade(resource, model, @"C:\audiobooks", storedEbookRootFolderPath: null, wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.False);
+                Assert.That(model.EbookMonitorFuture, Is.Null);
+                Assert.That(model.EbookMonitorExisting, Is.Null);
+            });
+        }
+
+        [Test]
+        public void should_use_the_stored_root_folder_paths_not_whatever_is_currently_on_model()
+        {
+            // Regression case: ToModel/ApplyChanges run BEFORE this cascade and, for a PUT that omits
+            // AudiobookRootFolderPath (whatever else it does or doesn't include), will already have
+            // overwritten model's path with the (null) value off the request. The caller is
+            // responsible for passing the paths captured from the STORED author before ToModel ran -
+            // this test locks in that this method uses whatever it's handed, not
+            // model.AudiobookRootFolderPath, so that contract can't silently regress back to reading
+            // the wrong (post-mutation) value.
+            var model = new Author
+            {
+                AudiobookRootFolderPath = null, // as it would be after ToModel on a request that omits this field
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true
+            };
+            var resource = new AuthorResource { Monitored = false };
+
+            Cascade(resource, model, storedAudiobookRootFolderPath: @"C:\audiobooks", storedEbookRootFolderPath: null, wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true);
+
+            Assert.That(model.AudiobookMonitorFuture, Is.False, "must cascade using the stored path, not model's (already-nulled) path");
+        }
+
+        [Test]
+        public void should_not_cascade_a_media_type_the_client_genuinely_changed()
+        {
+            // model reflects the state AFTER ApplyChanges has already applied the client's edit
+            // (AudiobookMonitorFuture: false -> true); `stored` reflects what was there BEFORE this
+            // request. The two differing is what makes this a genuine edit, not an echo.
+            var model = new Author
+            {
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true, // just changed by the client's explicit edit
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+            var resource = new AuthorResource { Monitored = false, AudiobookMonitorFuture = true };
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: false, // was false before this request
+                storedEbookMonitorExisting: 2, storedEbookMonitorFuture: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.True, "client's genuine edit should win, not be overridden by the legacy flag");
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(1));
+                Assert.That(model.EbookMonitorFuture, Is.False, "ebook wasn't touched by the client, so the legacy flag should still cascade into it");
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_not_leak_a_stale_echoed_monitored_into_an_untouched_media_type_edited_elsewhere()
+        {
+            // The exact shape of Chaptarr's own UI toggle: the user turns audiobook monitoring off
+            // (touching audiobook's own tri-state fields directly, a genuine change from stored), and
+            // the full-object PUT body carries `monitored: true` unchanged from the last GET, since
+            // the author was (still is, per the pre-request derived value) monitored via audiobook at
+            // the time of that GET. Ebook has never been configured (null tri-state) but does have a
+            // root folder. Ebook must stay exactly as it was - it must NOT get silently turned on
+            // because a field elsewhere in the same request happened to still read "true".
+            var model = new Author
+            {
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 0, // just written by ApplyChanges from the client's genuine edit
+                AudiobookMonitorFuture = true, // untouched by the client, preserved from storage
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = null,
+                EbookMonitorFuture = null
+            };
+            var resource = new AuthorResource { Monitored = true, AudiobookMonitorExisting = 0 };
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true); // was 1/All before this request
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0), "the client's own genuine edit, left untouched by this cascade");
+                Assert.That(model.EbookMonitorFuture, Is.Null, "must not be materialized just because the stale echoed flag happens to still read true");
+                Assert.That(model.EbookMonitorExisting, Is.Null);
+            });
+        }
+
+        [Test]
+        public void should_cascade_a_newly_added_root_folder_media_type_even_when_top_level_flag_is_unchanged()
+        {
+            // Same PUT both assigns ebook a root folder for the first time AND asks for monitored:false.
+            // wasMonitoredFromMediaSettings is already false (nothing was monitored before this request),
+            // so the top-level flag isn't "changing" by the simple equality check - but AuthorService's
+            // root-folder-defaults fill is about to see a media type with a root folder and null tri-state
+            // fields for the first time and resolve them from the root folder's own defaults, which could
+            // silently re-enable monitoring right after this explicit false. Forcing explicit values here
+            // pre-empts that.
+            var model = new Author
+            {
+                EbookRootFolderPath = @"C:\ebooks", // just assigned by this same PUT
+                EbookMonitorExisting = null,
+                EbookMonitorFuture = null
+            };
+            var resource = new AuthorResource { Monitored = false };
+
+            Cascade(resource, model, storedAudiobookRootFolderPath: null, storedEbookRootFolderPath: null, wasMonitoredFromMediaSettings: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.EbookMonitorFuture, Is.False);
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_leave_a_long_configured_but_never_set_media_type_alone_when_nothing_actually_changed()
+        {
+            // Deliberately the mirror image of the previous test: ebook has HAD a root folder all
+            // along (not newly assigned by this request) and its tri-state fields are still null, but
+            // the top-level flag isn't actually changing either. This PUT isn't asking for anything
+            // regarding ebook, so it's left for AuthorService's normal (unrelated) first-time
+            // root-folder-defaults resolution to decide, same as it would if this cascade didn't exist.
+            var model = new Author
+            {
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = null,
+                EbookMonitorFuture = null
+            };
+            var resource = new AuthorResource { Monitored = false };
+
+            Cascade(resource, model, storedAudiobookRootFolderPath: null, storedEbookRootFolderPath: @"C:\ebooks", wasMonitoredFromMediaSettings: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.EbookMonitorFuture, Is.Null);
+                Assert.That(model.EbookMonitorExisting, Is.Null);
+            });
+        }
+
+        [Test]
+        public void should_do_nothing_when_monitored_was_omitted()
+        {
+            var model = FullyConfiguredMonitoredAuthor();
+            var resource = new AuthorResource { Monitored = null };
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true,
+                storedEbookMonitorExisting: 2, storedEbookMonitorFuture: true);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.True);
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(1));
+                Assert.That(model.EbookMonitorFuture, Is.True);
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(2));
+            });
+        }
+
+        [Test]
+        public void should_not_cascade_under_readarr_facade_context()
+        {
+            var model = FullyConfiguredMonitoredAuthor();
+            var resource = new AuthorResource { Monitored = false };
+            var facadeContext = new ReadarrFacadeContext("gr", "audiobook", "readarr");
+
+            Cascade(resource, model, @"C:\audiobooks", @"C:\ebooks", wasMonitoredFromMediaSettings: true,
+                storedAudiobookMonitorExisting: 1, storedAudiobookMonitorFuture: true,
+                storedEbookMonitorExisting: 2, storedEbookMonitorFuture: true,
+                facadeContext: facadeContext);
+
+            Assert.That(model.AudiobookMonitorFuture, Is.True, "facade requests already get single-media-type cascade from ToModel; this helper should stay out of the way");
+        }
+
+        // End-to-end seam test wiring the real AuthorResource.ToModel(author, facadeContext) call
+        // together with the cascade, using the exact "snapshot stored state before ToModel mutates the
+        // author" sequence AuthorController.UpdateAuthor follows. This is the case that would have
+        // caught reading paths off the (already-mutated) model instead of the pre-mutation snapshot.
+        // The request body below deliberately still omits AudiobookRootFolderPath/EbookRootFolderPath/
+        // RootFolderPath and all four tri-state fields - the minimal shape a client would send to
+        // "just" flip the legacy on/off switch - while including Path and AudiobookQualityProfileId,
+        // since AuthorController.UpdateAuthor's own PutValidator/SharedValidator rules reject Path
+        // being absent and reject neither quality profile being set, on every PUT, unconditionally; a
+        // body missing those two fields would never reach this code in the real endpoint, whatever
+        // else it carries. ToModel's native (non-facade) branch nulls AudiobookRootFolderPath out on
+        // exactly this shape (it falls back through the also-empty legacy RootFolderPath field), so
+        // this only passes if the cascade is driven by the pre-ToModel snapshot rather than model's
+        // post-ToModel state.
+        [Test]
+        public void end_to_end_a_minimal_put_body_still_unmonitors_a_configured_author()
+        {
+            var storedAuthor = new Author
+            {
+                Id = 42,
+                Path = @"C:\audiobooks\Some Author",
+                AudiobookQualityProfileId = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 1,
+                EbookMonitorFuture = true
+            };
+
+            // What a client sends when it only means to flip the legacy on/off switch, but still has
+            // to satisfy the endpoint's other required fields to get this far at all.
+            var requestResource = new AuthorResource
+            {
+                Id = 42,
+                Path = @"C:\audiobooks\Some Author",
+                AudiobookQualityProfileId = 1,
+                Monitored = false
+            };
+
+            // Mirrors AuthorController.UpdateAuthor exactly: capture, then mutate.
+            var stored = AuthorController.StoredAuthorMonitoringState.Capture(storedAuthor);
+            var model = requestResource.ToModel(storedAuthor, null);
+
+            // Confirms the premise this test exists to guard: ToModel really does null the path out on
+            // this shape of body, so a cascade reading paths off `model` (rather than the pre-call
+            // snapshot) would see nothing configured and silently do nothing - the exact v1 regression.
+            Assert.That(model.AudiobookRootFolderPath, Is.Null, "sanity check on ToModel's own behavior for this request shape - if this ever stops being null, this test stops proving anything");
+
+            AuthorController.CascadeExplicitMonitoredIntoMediaTypeSettings(requestResource, model, null, stored);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorFuture, Is.False);
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.EbookMonitorFuture, Is.False);
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.IsMonitoredFromMediaSettings(), Is.False, "this is what AuthorService.UpdateAuthor's recompute reads - it must land on false");
+            });
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/Api/AuthorControllerMonitoredCascadeFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/AuthorControllerMonitoredCascadeFixture.cs
@@ -70,6 +70,27 @@ namespace Chaptarr.Core.Test.Api
         }
 
         [Test]
+        public void should_not_force_future_monitoring_on_when_existing_alone_already_satisfies_monitored_true()
+        {
+            // MonitorExisting > 0 alone already makes IsMonitoredForMediaType true, so forcing
+            // MonitorFuture too on a monitored:true request isn't needed to satisfy it - and doing so
+            // anyway would silently flip on "monitor new releases" for a field the client never
+            // mentioned. Turning OFF genuinely needs both fields cleared (Existing > 0 alone would keep
+            // the author monitored even with Future false); turning ON does not have that asymmetry.
+            var model = new Author { AudiobookMonitorExisting = 1, AudiobookMonitorFuture = false }; // Existing just set by the client's genuine edit
+            var resource = new AuthorResource { Monitored = true, AudiobookMonitorExisting = 1 };
+
+            Cascade(resource, model, @"C:\audiobooks", null, wasMonitoredFromMediaSettings: false,
+                storedAudiobookMonitorExisting: 0, storedAudiobookMonitorFuture: false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(1), "client's genuine edit");
+                Assert.That(model.AudiobookMonitorFuture, Is.False, "not forced on - Existing alone already satisfies monitored:true");
+            });
+        }
+
+        [Test]
         public void should_unmonitor_when_client_echoes_unchanged_tri_state_fields_from_a_prior_get()
         {
             // The gap an earlier version of this fix had: a client that does GET -> flip `monitored`
@@ -178,11 +199,15 @@ namespace Chaptarr.Core.Test.Api
         }
 
         [Test]
-        public void should_not_cascade_a_media_type_the_client_genuinely_changed()
+        public void should_not_override_a_tri_state_field_the_client_genuinely_changed()
         {
-            // model reflects the state AFTER ApplyChanges has already applied the client's edit
-            // (AudiobookMonitorFuture: false -> true); `stored` reflects what was there BEFORE this
-            // request. The two differing is what makes this a genuine edit, not an echo.
+            // The protection is per FIELD, not per media type: the client explicitly changed
+            // AudiobookMonitorFuture (false -> true, a genuine edit) but said nothing about
+            // AudiobookMonitorExisting, so Future must be left as the client set it while Existing -
+            // untouched by the request - still picks up the top-level monitored:false. This is exactly
+            // the shape Chaptarr's own bulk author editor sends (MonitorExisting alone, never
+            // MonitorFuture) - protecting the whole media type the moment either field is present, as
+            // an earlier version of this did, made the cascade a no-op for that payload.
             var model = new Author
             {
                 AudiobookMonitorExisting = 1,
@@ -198,9 +223,9 @@ namespace Chaptarr.Core.Test.Api
 
             Assert.Multiple(() =>
             {
-                Assert.That(model.AudiobookMonitorFuture, Is.True, "client's genuine edit should win, not be overridden by the legacy flag");
-                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(1));
-                Assert.That(model.EbookMonitorFuture, Is.False, "ebook wasn't touched by the client, so the legacy flag should still cascade into it");
+                Assert.That(model.AudiobookMonitorFuture, Is.True, "client's genuine edit to this field should win, not be overridden by the legacy flag");
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0), "untouched by the request, so the legacy flag cascades into it despite Future being protected");
+                Assert.That(model.EbookMonitorFuture, Is.False, "ebook wasn't touched at all by the client, so the legacy flag should still cascade into it");
                 Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
             });
         }

--- a/src/Chaptarr.Core.Test/Api/AuthorEditorControllerMonitoredCascadeFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/AuthorEditorControllerMonitoredCascadeFixture.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Chaptarr.Api.V1.Author;
+using Chaptarr.Core.Test;
+using Chaptarr.Http.Middleware;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.RootFolders;
+using CoreAuthor = NzbDrone.Core.Books.Author;
+
+namespace Chaptarr.Core.Test.Api
+{
+    [TestFixture]
+    public class AuthorEditorControllerMonitoredCascadeFixture
+    {
+        // Reuses the AuthorServiceProxy/RootFolderServiceProxy/RecordingCommandQueue conventions
+        // already established in AuthorEditorMissingRootHydrationFixture, rather than hand-rolling
+        // weaker doubles. Unlike that fixture's proxy, UpdateAuthors here also applies the real
+        // Monitored recompute (author.Monitored = author.IsMonitoredFromMediaSettings()) that
+        // AuthorService.UpdateAuthors actually does - that recompute IS the bug this fixture guards
+        // against, so a stub that skips it would only prove the cascade wrote plausible-looking
+        // tri-state fields, not that persisting monitored:false through this endpoint actually works.
+        private class AuthorServiceProxy : DispatchProxy
+        {
+            public List<CoreAuthor> Authors { get; set; } = new();
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                switch (targetMethod?.Name)
+                {
+                    case nameof(IAuthorService.GetAuthors):
+                        var ids = ((IEnumerable<int>)args[0]).ToHashSet();
+                        return Authors.Where(author => ids.Contains(author.Id)).ToList();
+                    case nameof(IAuthorService.UpdateAuthors):
+                        var updated = (List<CoreAuthor>)args[0];
+                        foreach (var author in updated)
+                        {
+                            author.Monitored = author.IsMonitoredFromMediaSettings();
+                        }
+
+                        Authors = updated.ToList();
+                        return Authors;
+                    default:
+                        throw new NotImplementedException($"Test proxy does not implement {targetMethod?.Name}");
+                }
+            }
+        }
+
+        private class RootFolderServiceProxy : DispatchProxy
+        {
+            public List<RootFolder> RootFolders { get; set; } = new();
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                return targetMethod?.Name switch
+                {
+                    nameof(IRootFolderService.All) => RootFolders,
+                    _ => throw new NotImplementedException($"Test proxy does not implement {targetMethod?.Name}")
+                };
+            }
+        }
+
+        private sealed class RecordingCommandQueue : IManageCommandQueue
+        {
+            public List<CommandModel> PushedCommands { get; } = new();
+
+            public List<CommandModel> PushMany<TCommand>(List<TCommand> commands) where TCommand : Command
+            {
+                return commands.Select(command => Push(command)).ToList();
+            }
+
+            public CommandModel Push<TCommand>(TCommand command, CommandPriority priority = CommandPriority.Normal, CommandTrigger trigger = CommandTrigger.Unspecified) where TCommand : Command
+            {
+                var model = new CommandModel
+                {
+                    Name = command.Name,
+                    Body = command,
+                    Priority = priority,
+                    Trigger = trigger,
+                    Status = CommandStatus.Queued
+                };
+
+                PushedCommands.Add(model);
+                return model;
+            }
+
+            public CommandModel Push(string commandName, DateTime? lastExecutionTime, DateTime? lastStartTime, CommandPriority priority = CommandPriority.Normal, CommandTrigger trigger = CommandTrigger.Unspecified) => throw new NotImplementedException();
+            public IEnumerable<CommandModel> Queue(CancellationToken cancellationToken) => throw new NotImplementedException();
+            public List<CommandModel> All() => throw new NotImplementedException();
+            public CommandModel Get(int id) => throw new NotImplementedException();
+            public List<CommandModel> GetStarted() => throw new NotImplementedException();
+            public void SetMessage(CommandModel command, string message) => throw new NotImplementedException();
+            public void TouchProgress(CommandModel command) => throw new NotImplementedException();
+            public void SetResult(CommandModel command, CommandResult result) => throw new NotImplementedException();
+            public void Start(CommandModel command) => throw new NotImplementedException();
+            public void Complete(CommandModel command, string message) => throw new NotImplementedException();
+            public void Fail(CommandModel command, string message, Exception e) => throw new NotImplementedException();
+            public void Requeue() => throw new NotImplementedException();
+            public void Cancel(int id) => throw new NotImplementedException();
+            public void Pause(int id) => throw new NotImplementedException();
+            public void Resume(int id) => throw new NotImplementedException();
+            public void CleanCommands() => throw new NotImplementedException();
+            public CancellationToken GetCancellationToken(int commandId) => throw new NotImplementedException();
+            public void RegisterCancellationToken(int commandId, CancellationTokenSource cancellationTokenSource) => throw new NotImplementedException();
+            public void UnregisterCancellationToken(int commandId) => throw new NotImplementedException();
+        }
+
+        private static AuthorEditorController BuildController(
+            AuthorServiceProxy authorServiceProxy,
+            List<RootFolder> rootFolders = null,
+            RecordingCommandQueue commandQueue = null)
+        {
+            var authorService = DispatchProxy.Create<IAuthorService, AuthorServiceProxy>();
+            ((AuthorServiceProxy)(object)authorService).Authors = authorServiceProxy.Authors;
+
+            var rootFolderService = DispatchProxy.Create<IRootFolderService, RootFolderServiceProxy>();
+            ((RootFolderServiceProxy)(object)rootFolderService).RootFolders = rootFolders ?? new List<RootFolder>();
+
+            return new AuthorEditorController(
+                authorService,
+                commandQueue ?? new RecordingCommandQueue(),
+                rootFolderService,
+                new TestQualityProfileService(),
+                new TestMetadataProfileService());
+        }
+
+        [Test]
+        public void should_persist_monitored_false_for_the_real_bulk_editor_ui_payload_shape()
+        {
+            // AuthorEditorFooter.js's buildMonitoringPayload sends { monitored, audiobookMonitorExisting,
+            // ebookMonitorExisting } when the user picks "Unmonitored" in the bulk editor - MonitorFuture
+            // is never included. An earlier version of this fix protected a whole media type the moment
+            // EITHER of its two tri-state fields was present in the request, which meant the explicit
+            // MonitorExisting:0 the UI sends made the cascade treat audiobook as "already handled" and
+            // skip it - leaving MonitorFuture at its old `true`, so IsMonitoredFromMediaSettings() (and
+            // therefore the recomputed Monitored flag) stayed true. This is the actual reported bug,
+            // reached through the actual UI.
+            var author = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var controller = BuildController(authorServiceProxy);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = false,
+                AudiobookMonitorExisting = 0,
+                EbookMonitorExisting = 0
+                // AudiobookMonitorFuture / EbookMonitorFuture deliberately omitted - the UI never sends these
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.AudiobookMonitorExisting, Is.EqualTo(0), "the client's explicit edit");
+                Assert.That(updatedAuthor.AudiobookMonitorFuture, Is.False, "untouched by the request, so the legacy flag must cascade into it");
+                Assert.That(updatedAuthor.EbookMonitorExisting, Is.EqualTo(0));
+                Assert.That(updatedAuthor.EbookMonitorFuture, Is.False);
+                Assert.That(updatedAuthor.Monitored, Is.False, "this is what AuthorService.UpdateAuthors' real recompute reads - it must land on false, not silently stay true");
+            });
+        }
+
+        [Test]
+        public void should_not_force_future_monitoring_on_for_the_real_bulk_editor_monitored_true_payload()
+        {
+            // The bulk editor's "Monitored" (on) action sends the same shape as "Unmonitored" - just
+            // MonitorExisting, never MonitorFuture. Unlike turning off, MonitorExisting alone already
+            // satisfies monitored:true, so this must NOT silently flip on "monitor new releases" for a
+            // media type whose future-monitoring preference this request never touched.
+            var author = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 0,
+                AudiobookMonitorFuture = false,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 0,
+                EbookMonitorFuture = false
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var controller = BuildController(authorServiceProxy);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = true,
+                AudiobookMonitorExisting = 1,
+                EbookMonitorExisting = 1
+                // AudiobookMonitorFuture / EbookMonitorFuture deliberately omitted, same as the real UI
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.AudiobookMonitorExisting, Is.EqualTo(1), "the client's explicit edit");
+                Assert.That(updatedAuthor.AudiobookMonitorFuture, Is.False, "not forced on - Existing alone already satisfies monitored:true");
+                Assert.That(updatedAuthor.EbookMonitorExisting, Is.EqualTo(1));
+                Assert.That(updatedAuthor.EbookMonitorFuture, Is.False);
+                Assert.That(updatedAuthor.Monitored, Is.True);
+            });
+        }
+
+        [Test]
+        public void should_cascade_bulk_unmonitor_independently_per_author()
+        {
+            // Two authors with genuinely different prior monitoring states in the same bulk request:
+            // author 1 is monitored via audiobook only, author 2 via ebook only. Both should end up
+            // fully unmonitored, and neither author's snapshot/cascade should leak into the other's.
+            var audiobookMonitoredAuthor = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 0,
+                EbookMonitorFuture = false
+            };
+            var ebookMonitoredAuthor = new CoreAuthor
+            {
+                Id = 2,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 0,
+                AudiobookMonitorFuture = false,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { audiobookMonitoredAuthor, ebookMonitoredAuthor } };
+            var controller = BuildController(authorServiceProxy);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1, 2 },
+                Monitored = false
+            });
+
+            var updatedAuthor1 = authorServiceProxy.Authors.Single(a => a.Id == 1);
+            var updatedAuthor2 = authorServiceProxy.Authors.Single(a => a.Id == 2);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor1.AudiobookMonitorFuture, Is.False);
+                Assert.That(updatedAuthor1.AudiobookMonitorExisting, Is.EqualTo(0));
+                Assert.That(updatedAuthor1.Monitored, Is.False);
+
+                Assert.That(updatedAuthor2.EbookMonitorFuture, Is.False);
+                Assert.That(updatedAuthor2.EbookMonitorExisting, Is.EqualTo(0));
+                Assert.That(updatedAuthor2.Monitored, Is.False);
+            });
+        }
+
+        [Test]
+        public void should_not_override_a_tri_state_field_the_bulk_request_genuinely_changes()
+        {
+            var author = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = false, // stored value the bulk edit is about to genuinely change
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var controller = BuildController(authorServiceProxy);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = false,
+                AudiobookMonitorFuture = true // explicit bulk edit: turn audiobook future-monitoring ON, genuinely differs from the stored false
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.AudiobookMonitorFuture, Is.True, "client's genuine bulk edit to this field wins");
+                Assert.That(updatedAuthor.AudiobookMonitorExisting, Is.EqualTo(0), "untouched by the request, so the legacy flag cascades into it");
+                Assert.That(updatedAuthor.EbookMonitorFuture, Is.False, "not touched by the bulk edit at all, so the legacy flag cascades into it");
+                Assert.That(updatedAuthor.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_do_nothing_when_bulk_monitored_is_omitted()
+        {
+            var author = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var controller = BuildController(authorServiceProxy);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = null
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.AudiobookMonitorFuture, Is.True);
+                Assert.That(updatedAuthor.AudiobookMonitorExisting, Is.EqualTo(1));
+            });
+        }
+
+        [Test]
+        public void should_cascade_a_newly_added_root_folder_media_type_in_a_bulk_request()
+        {
+            // Mirrors the single-author "gained a root folder in this exact request" case, but through
+            // the real SaveAll loop: this is the one branch whose correctness depends on the cascade
+            // running AFTER this author's own root-folder writes in the loop, not before - a change
+            // that moved the cascade call earlier in the method would break this silently.
+            var author = new CoreAuthor
+            {
+                Id = 1
+                // no root folders configured at all yet
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var rootFolders = new List<RootFolder>
+            {
+                new RootFolder { Path = @"C:\ebooks", FolderType = FolderType.Ebook }
+            };
+            var controller = BuildController(authorServiceProxy, rootFolders);
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = false,
+                EbookRootFolderPath = @"C:\ebooks" // assigned by this same request
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.EbookRootFolderPath, Is.EqualTo(@"C:\ebooks"));
+                Assert.That(updatedAuthor.EbookMonitorFuture, Is.False);
+                Assert.That(updatedAuthor.EbookMonitorExisting, Is.EqualTo(0));
+            });
+        }
+
+        [Test]
+        public void should_not_cascade_under_readarr_facade_context()
+        {
+            // A Readarr-facade client (e.g. a media-type-scoped path like /audiobook/api/v1/author/editor)
+            // reaches this same endpoint. Unlike AuthorController.UpdateAuthor, this endpoint isn't
+            // media-type-scoped by its own resource shape, so nothing else stops a facade request's
+            // "monitored" from cascading into both media types - it has to be skipped explicitly.
+            var author = new CoreAuthor
+            {
+                Id = 1,
+                AudiobookRootFolderPath = @"C:\audiobooks",
+                AudiobookMonitorExisting = 1,
+                AudiobookMonitorFuture = true,
+                EbookRootFolderPath = @"C:\ebooks",
+                EbookMonitorExisting = 2,
+                EbookMonitorFuture = true
+            };
+
+            var authorServiceProxy = new AuthorServiceProxy { Authors = new List<CoreAuthor> { author } };
+            var controller = BuildController(authorServiceProxy);
+            controller.ControllerContext = new Microsoft.AspNetCore.Mvc.ControllerContext
+            {
+                HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext()
+            };
+            controller.HttpContext.Items[ReadarrFacadeContext.ItemKey] = new ReadarrFacadeContext("gr", "audiobook", "readarr");
+
+            controller.SaveAll(new AuthorEditorResource
+            {
+                AuthorIds = new List<int> { 1 },
+                Monitored = false
+            });
+
+            var updatedAuthor = authorServiceProxy.Authors.Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updatedAuthor.AudiobookMonitorFuture, Is.True, "facade context present - the cascade must not run at all here");
+                Assert.That(updatedAuthor.EbookMonitorFuture, Is.True);
+            });
+        }
+    }
+}

--- a/src/Chaptarr.Core.Test/Books/AuthorResourceMapperFixture.cs
+++ b/src/Chaptarr.Core.Test/Books/AuthorResourceMapperFixture.cs
@@ -284,6 +284,49 @@ namespace Chaptarr.Core.Test.Books
         }
 
         [Test]
+        public void should_default_facade_media_side_tri_state_to_false_when_monitored_is_omitted()
+        {
+            // AuthorResource.Monitored is bool? (changed from a non-nullable bool so a native PUT can
+            // tell "omitted" from "explicitly false" - see AuthorController.UpdateAuthor). This facade
+            // write path predates that distinction and never needs it - Monitored being unset here
+            // should still backfill the media-side tri-state fields to false, exactly as it did back
+            // when the field's own default (rather than an explicit null) meant "not sent".
+            var resource = new AuthorResource
+            {
+                ForeignAuthorId = "173491",
+                RootFolderPath = "/ebooks",
+                Monitored = null
+            };
+
+            var model = resource.ToModel(new ReadarrFacadeContext("gr", "ebook", "/readarr/gr/ebook"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.EbookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.EbookMonitorFuture, Is.False);
+            });
+        }
+
+        [Test]
+        public void should_default_facade_media_side_tri_state_to_false_when_monitored_is_explicitly_false()
+        {
+            var resource = new AuthorResource
+            {
+                ForeignAuthorId = "173491",
+                RootFolderPath = "/audiobooks",
+                Monitored = false
+            };
+
+            var model = resource.ToModel(new ReadarrFacadeContext("hc", "audiobook", "/readarr/hc/audiobook"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(model.AudiobookMonitorExisting, Is.EqualTo(0));
+                Assert.That(model.AudiobookMonitorFuture, Is.False);
+            });
+        }
+
+        [Test]
         public void should_preserve_sibling_and_omitted_fields_on_facade_author_update()
         {
             var existing = new NzbDrone.Core.Books.Author


### PR DESCRIPTION
## Summary
Fixes the "PUT monitored:false does not persist" sub-bug from #17. (The V5-matching / multi-pocket part of that issue is a metadata-server-side data quality problem, not something fixable client-side, and is left open.)

`AuthorService.UpdateAuthor`/`UpdateAuthors` recompute the legacy `Author.Monitored` flag from the per-media-type tri-state settings on every save (`author.Monitored = author.IsMonitoredFromMediaSettings()`), and separately fill any still-null tri-state field from the root folder's defaults before that recompute runs. So a PUT that only sets the top-level `monitored` field - without touching any of the four tri-state fields - has it silently discarded: whatever those fields already were (or get defaulted to) wins, and the recompute overwrites the requested value right back before it's ever persisted. `monitored:true` "works" only when it happens to already match the derived value; `monitored:false` never sticks once any tri-state field for a configured media type is already on.

(Note: `AuthorController`'s own validators require `Path` and at least one quality profile id on every PUT regardless of this fix, so the minimal request that actually reaches this code still has to carry those - it isn't as bare as `{id, monitored:false}`.)

## What changed

- **`AuthorResource.Monitored` is now `bool?`** instead of `bool` (matching the existing `bool?` on `AuthorEditorResource`), since a non-nullable bool can't distinguish "client omitted this field" from "client explicitly sent false." Every other read of the field preserves its old omitted-means-false behavior, so this isn't a behavior change for any existing caller, including the Readarr-facade write path (covered by two new tests).

- **`AuthorController.UpdateAuthor` cascades an explicit `Monitored` value into `MonitorFuture`/`MonitorExisting`** for whichever media types the author is configured for. A non-nullable bool alone isn't enough to know intent though: almost every real client - Chaptarr's own UI included, and any script that does GET → flip one field → PUT the whole object back - sends a full object on every PUT, so a stale `monitored` **and** stale (unchanged) tri-state field values both ride along on saves that have nothing to do with them. The cascade only treats a field as "touched" when its sent value actually *differs* from what was stored - by field, not by media type (see below) - so a same-value echo of either kind is always a no-op. The cascade fires per media type when the requested top-level value genuinely differs from what's already true for the author overall, or when that media type is gaining a root folder in this exact request (the one case where "nothing changed" isn't safe to skip).

- **The bulk author editor** (`PUT /api/v1/author/editor`, `AuthorEditorController.SaveAll`) has the identical underlying recompute bug (`AuthorService.UpdateAuthors`) and now gets the same cascade, skipped under a Readarr-facade request the same way the single-author path is. The shared cascade logic was refactored into a thin `AuthorResource`-shaped wrapper over a primitive-parameter core so both controllers share it without duplicating it.

- **Touched-detection is per FIELD, not per media type.** Chaptarr's own bulk editor UI always sends `MonitorExisting` when changing bulk monitoring but never `MonitorFuture` - an earlier version of this fix protected a whole media type from cascading the moment *either* field was present, which made it a no-op for that exact payload. Turning **off** always needs both fields cleared (`MonitorExisting > 0` alone keeps an author monitored even with `MonitorFuture` false); turning **on** only forces `MonitorFuture` when `MonitorExisting` (as the request leaves it) doesn't already satisfy "monitored" on its own - otherwise it would silently flip on "monitor new releases" for a preference nobody touched. This asymmetry was caught in review and is now covered by dedicated tests for both directions.

- Root folder paths, the four tri-state field values, and the author's overall derived-monitored status are all captured from the stored author - into one `StoredAuthorMonitoringState` value, in one line - **before** `ToModel`/`ApplyChanges` (or the bulk editor's own field writes) mutate that object in place.

- Also updates `openapi.json`'s `AuthorResource.monitored` schema to `nullable: true`.

## Known gaps, left out of this PR

- **A media type losing its root folder in the same request as an explicit `monitored:true` isn't guarded** (single-author path only - the bulk editor has no mechanism to clear a root folder at all). This is downstream of a broader, pre-existing issue: `Author.ApplyChanges` copies root folder paths unconditionally, including to `null` on simple omission, and that ambiguity is load-bearing elsewhere (`BookController`'s facade normalization relies on it). Filed separately as **#88**, since it's a real, independently-reachable bug beyond this PR's scope.
- **The bulk editor's media-type-scoped modes** (Audiobook only / Ebook only) build a different frontend payload that never includes `monitored` at all, so `monitored:false` still won't persist through those - a frontend gap, not something this backend fix can reach.
- **The cascade skips an unconfigured media type entirely, but the recompute (`IsMonitoredFromMediaSettings`) doesn't** - it reads all four tri-state fields regardless of whether either media type has a root folder. A stale `MonitorFuture=true` left on a never-configured media type (writable via the bulk editor's separate "Monitor New Items" action, which isn't root-folder-gated either) can still keep an author "monitored" after an explicit `monitored:false`. Pre-existing, not introduced here, and out of scope for the same reason as #88.
- **A Readarr-facade-scoped bulk request** still can't persist `monitored:false` - the facade guard makes that a deliberate no-op, since there's no per-media-type `ToModel` equivalent for this endpoint to fall back on.

## Test plan
- [x] `AuthorControllerMonitoredCascadeFixture` (15 cases): the reported bug, the GET-modify-PUT echo case, the UI-toggle stale-echo case, the newly-added-root-folder case, the turn-on-doesn't-force-future-when-existing-satisfies-it case, facade pass-through, and an end-to-end seam test through the real `ToModel` call
- [x] `AuthorEditorControllerMonitoredCascadeFixture` (7 cases), built against the real `AuthorEditorController.SaveAll` end to end (reusing this project's existing `AuthorServiceProxy`/`RootFolderServiceProxy`/`RecordingCommandQueue` test doubles, with a real `Monitored` recompute added so the tests assert on the actual outcome, not just the cascade's direct writes): the exact bulk-editor-UI payload shape for both monitored on and off, independent correctness across two authors with different prior states in one bulk request, a genuine per-field edit not being overridden, `monitored` omitted, a media type gaining a root folder in the same bulk request, and the Readarr-facade skip
- [x] Two new tests in `AuthorResourceMapperFixture` confirming the facade write path's omitted-`Monitored`-defaults-to-false behavior is unchanged
- [x] Full existing test suite passes unchanged (2875/2875)
