### PR TITLE
Calibre content server

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
@@ -180,6 +180,7 @@ class EditQualityProfileModalContent extends Component {
       upgradeAllowed,
       preferCustomFormatsOverQuality,
       convertToQualityId,
+      mergeMultiPartFiles,
       cutoff,
       minFormatScore,
       cutoffFormatScore,
@@ -190,6 +191,7 @@ class EditQualityProfileModalContent extends Component {
     const upgradeAllowedField = fieldWithDefault(upgradeAllowed, false);
     const preferCustomFormatsOverQualityField = fieldWithDefault(preferCustomFormatsOverQuality, false);
     const convertToQualityIdField = fieldWithDefault(convertToQualityId, 0);
+    const mergeMultiPartFilesField = fieldWithDefault(mergeMultiPartFiles, false);
     const cutoffField = fieldWithDefault(cutoff, 0);
     const minFormatScoreField = fieldWithDefault(minFormatScore, 0);
     const cutoffFormatScoreField = fieldWithDefault(cutoffFormatScore, 0);
@@ -335,6 +337,23 @@ class EditQualityProfileModalContent extends Component {
                                 translate('ConvertToQualityHelpText') :
                                 undefined}
                               onChange={onConvertToQualityChange}
+                            />
+                          </FormGroup>
+                      }
+
+                      {
+                        isAudiobookProfile && Number(convertToQualityIdField.value) > 0 &&
+                          <FormGroup size={sizes.EXTRA_SMALL}>
+                            <FormLabel size={sizes.SMALL}>
+                              {translate('MergeMultiPartFiles')}
+                            </FormLabel>
+
+                            <FormInputGroup
+                              type={inputTypes.CHECK}
+                              name="mergeMultiPartFiles"
+                              {...mergeMultiPartFilesField}
+                              helpText={translate('MergeMultiPartFilesHelpText')}
+                              onChange={onInputChange}
                             />
                           </FormGroup>
                       }

--- a/src/Chaptarr.Api.V1/Profiles/Quality/QualityProfileResource.cs
+++ b/src/Chaptarr.Api.V1/Profiles/Quality/QualityProfileResource.cs
@@ -17,6 +17,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; }
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public List<QualityProfileQualityItemResource> Items { get; set; }
         public int MinFormatScore { get; set; }
@@ -79,6 +80,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
                 PreferCustomFormatsOverQuality = model.ProfileType == ProfileType.Audiobook && model.PreferCustomFormatsOverQuality,
                 ConvertMp3ToM4b = model.ConvertMp3ToM4b,
                 ConvertToQualityId = convertToQualityId,
+                MergeMultiPartFiles = model.MergeMultiPartFiles,
                 Cutoff = cutoff,
                 Items = items.ConvertAll(ToResource),
                 MinFormatScore = model.MinFormatScore,
@@ -140,6 +142,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
                 // toggle. ConvertToQualityId is the canonical conversion target.
                 ConvertMp3ToM4b = convertToQualityId == NzbDrone.Core.Qualities.Quality.M4B.Id,
                 ConvertToQualityId = convertToQualityId,
+                MergeMultiPartFiles = resource.ProfileType == ProfileType.Audiobook && resource.MergeMultiPartFiles,
                 Cutoff = resource.Cutoff,
                 Items = (resource.Items ?? new List<QualityProfileQualityItemResource>()).ConvertAll(ToModel),
                 MinFormatScore = resource.MinFormatScore,

--- a/src/Chaptarr.Api.V1/openapi.json
+++ b/src/Chaptarr.Api.V1/openapi.json
@@ -18272,6 +18272,9 @@
             "format": "int32",
             "nullable": true
           },
+          "mergeMultiPartFiles": {
+            "type": "boolean"
+          },
           "cutoff": {
             "type": "integer",
             "format": "int32"

--- a/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupModels.cs
+++ b/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupModels.cs
@@ -222,6 +222,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; }
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupService.cs
+++ b/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupService.cs
@@ -626,6 +626,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
                 CutoffFormatScore = profile.CutoffFormatScore,
                 ConvertMp3ToM4b = profile.ConvertMp3ToM4b,
                 ConvertToQualityId = profile.ConvertToQualityId,
+                MergeMultiPartFiles = profile.MergeMultiPartFiles,
                 UpgradeAllowed = profile.UpgradeAllowed,
                 PreferCustomFormatsOverQuality = profile.ProfileType == ProfileType.Audiobook && profile.PreferCustomFormatsOverQuality,
                 FormatItems = (profile.FormatItems ?? new List<NzbDrone.Core.Profiles.ProfileFormatItem>())
@@ -1725,6 +1726,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
                 CutoffFormatScore = profile.CutoffFormatScore,
                 ConvertMp3ToM4b = profile.ConvertMp3ToM4b,
                 ConvertToQualityId = profile.ConvertToQualityId,
+                MergeMultiPartFiles = profile.MergeMultiPartFiles,
                 UpgradeAllowed = profile.UpgradeAllowed,
                 PreferCustomFormatsOverQuality = profile.ProfileType == ProfileType.Audiobook && profile.PreferCustomFormatsOverQuality,
                 FormatItems = new List<NzbDrone.Core.Profiles.ProfileFormatItem>()

--- a/src/NzbDrone.Core/Datastore/Migration/001_chaptarr_complete_schema.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/001_chaptarr_complete_schema.cs
@@ -816,7 +816,8 @@ namespace NzbDrone.Core.Datastore.Migration
                 .WithColumn("FormatItems").AsString().NotNullable()
                 .WithColumn("SearchCriteriaProfileId").AsInt32().Nullable()
                 .WithColumn("ConvertMp3ToM4b").AsBoolean().NotNullable().WithDefaultValue(false)
-                .WithColumn("ConvertToQualityId").AsInt32().Nullable();
+                .WithColumn("ConvertToQualityId").AsInt32().Nullable()
+                .WithColumn("MergeMultiPartFiles").AsBoolean().NotNullable().WithDefaultValue(false);
 
             // Metadata profiles
             Create.TableForModel("MetadataProfiles")

--- a/src/NzbDrone.Core/Datastore/Migration/103_add_quality_profile_merge_multi_part_files.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/103_add_quality_profile_merge_multi_part_files.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(103)]
+    public class add_quality_profile_merge_multi_part_files : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            if (!Schema.Table("QualityProfiles").Column("MergeMultiPartFiles").Exists())
+            {
+                Alter.Table("QualityProfiles")
+                    .AddColumn("MergeMultiPartFiles")
+                    .AsBoolean()
+                    .NotNullable()
+                    .WithDefaultValue(false);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/ImportLists/Goodreads/Bookshelf/GoodreadsBookshelf.cs
+++ b/src/NzbDrone.Core/ImportLists/Goodreads/Bookshelf/GoodreadsBookshelf.cs
@@ -63,7 +63,7 @@ namespace NzbDrone.Core.ImportLists.Goodreads
 
         public override string Name => "Goodreads Bookshelves";
         public override ImportListType ListType => ImportListType.Goodreads;
-        public override TimeSpan MinRefreshInterval => TimeSpan.FromHours(12);
+        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(15);
 
         public override IList<ImportListItemInfo> Fetch()
         {

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1115,7 +1115,7 @@
   "Medium": "Medium",
   "Member": "Member",
   "MergeMultiPartFiles": "Create Single File",
-  "MergeMultiPartFilesHelpText": "Also merge multi-part downloads that are already M4B into a single M4B file. Multi-part MP3 and other formats are always merged when converting.",
+  "MergeMultiPartFilesHelpText": "All multi-part downloads will be merged into a single M4B file",
   "Message": "Message",
   "Metadata": "Metadata",
   "MetadataConsumers": "Metadata Consumers",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1114,6 +1114,8 @@
   "MediaManagementSettingsSummary": "Naming, file management settings and root folders",
   "Medium": "Medium",
   "Member": "Member",
+  "MergeMultiPartFiles": "Create Single File",
+  "MergeMultiPartFilesHelpText": "Also merge multi-part downloads that are already M4B into a single M4B file. Multi-part MP3 and other formats are always merged when converting.",
   "Message": "Message",
   "Metadata": "Metadata",
   "MetadataConsumers": "Metadata Consumers",

--- a/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
@@ -1532,7 +1532,8 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 var sourceQuality = first?.Quality?.Quality ?? Qualities.Quality.Unknown;
                 var qualityProfile = author.GetQualityProfileForQuality(sourceQuality);
                 var targetQuality = QualityConversionHelper.GetPlannedConversionTarget(author, first?.Quality);
-                if (targetQuality != Qualities.Quality.M4B)
+                var mergeMultiPartM4b = QualityConversionHelper.ShouldMergeMultiPartM4b(qualityProfile, first?.Quality);
+                if (targetQuality != Qualities.Quality.M4B && !mergeMultiPartM4b)
                 {
                     return (bookDecisions, null, false, null);
                 }
@@ -1549,7 +1550,8 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                     return (bookDecisions, null, false, null);
                 }
 
-                if (inputFiles.All(p => Path.GetExtension(p).Equals(".m4b", StringComparison.OrdinalIgnoreCase)))
+                if (inputFiles.All(p => Path.GetExtension(p).Equals(".m4b", StringComparison.OrdinalIgnoreCase)) &&
+                    (inputFiles.Length == 1 || qualityProfile?.MergeMultiPartFiles != true))
                 {
                     return (bookDecisions, null, false, null);
                 }

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using FluentValidation.Results;
+using Newtonsoft.Json;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Books.Calibre;
+using NzbDrone.Core.Qualities;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class CalibreContentServer : NotificationBase<CalibreContentServerSettings>
+    {
+        private readonly IHttpClient _httpClient;
+        private readonly Logger _logger;
+
+        public CalibreContentServer(IHttpClient httpClient, Logger logger)
+        {
+            _httpClient = httpClient;
+            _logger = logger;
+        }
+
+        public override string Name => "Calibre Content Server";
+        public override string Link => "https://manual.calibre-ebook.com/server.html";
+
+        public override void OnReleaseImport(BookDownloadMessage message)
+        {
+            var ebooks = message.BookFiles.Where(x => QualityMediaTypeHelper.IsEbookFileQuality(x.Quality.Quality)).ToList();
+
+            if (!ebooks.Any())
+            {
+                return;
+            }
+
+            if (Settings.SyncChanges && message.OldFiles?.Any() == true)
+            {
+                DeleteBook(message.Book);
+            }
+
+            foreach (var file in ebooks)
+            {
+                AddBook(file.Path);
+            }
+        }
+
+        public override void OnBookDelete(BookDeleteMessage message)
+        {
+            if (Settings.SyncChanges)
+            {
+                DeleteBook(message.Book);
+            }
+        }
+
+        public override void OnBookFileDelete(BookFileDeleteMessage message)
+        {
+            if (Settings.SyncChanges && QualityMediaTypeHelper.IsEbookFileQuality(message.BookFile.Quality.Quality))
+            {
+                DeleteBook(message.Book);
+            }
+        }
+
+        public override void OnBookRetag(BookRetagMessage message)
+        {
+            if (Settings.SyncChanges && QualityMediaTypeHelper.IsEbookFileQuality(message.BookFile.Quality.Quality))
+            {
+                DeleteBook(message.Book);
+                AddBook(message.BookFile.Path);
+            }
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            try
+            {
+                var request = BuildRequest("ajax/library-info").Build();
+                _httpClient.Get(request);
+            }
+            catch (HttpException ex) when (ex.Response?.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                failures.Add(new ValidationFailure("Username", "Authentication failed"));
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unable to connect to Calibre content server");
+                failures.Add(new ValidationFailure("Url", "Unable to connect: " + ex.Message));
+            }
+
+            return new ValidationResult(failures);
+        }
+
+        private void AddBook(string path)
+        {
+            var jobId = (int)(DateTime.UtcNow.Ticks % 1000000000);
+            var filename = Uri.EscapeDataString(Path.GetFileName(path));
+            var request = BuildRequest($"cdb/add-book/{jobId}/0/{filename}").Build();
+            request.SetContent(File.ReadAllBytes(path));
+
+            var response = _httpClient.Post<CalibreImportJob>(request).Resource;
+
+            if (response.Id == 0)
+            {
+                _logger.Info("Calibre content server reported {0} as a duplicate, skipped", path);
+            }
+            else
+            {
+                _logger.Debug("Pushed {0} to Calibre content server as book {1}", path, response.Id);
+            }
+        }
+
+        private void DeleteBook(Book book)
+        {
+            var author = book?.Author?.Name;
+
+            if (author.IsNullOrWhiteSpace() || book.Title.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var query = Uri.EscapeDataString($"authors:\"={author.Replace("\"", "")}\"");
+            var searchRequest = BuildRequest($"ajax/search?query={query}").Build();
+            var ids = _httpClient.Get<CalibreSearchResult>(searchRequest).Resource.BookIds;
+
+            if (ids?.Any() != true)
+            {
+                _logger.Debug("No matching book found on Calibre content server for {0}", book.Title);
+                return;
+            }
+
+            var titles = new[] { Normalize(book.Title), Normalize(Regex.Replace(book.Title, @"\s*\([^)]*\)\s*$", "")) };
+            var booksRequest = BuildRequest($"ajax/books?ids={string.Join(",", ids)}").Build();
+            var calibreBooks = _httpClient.Get<Dictionary<string, CalibreBookData>>(booksRequest).Resource;
+            var matches = calibreBooks.Where(x => x.Value != null && titles.Contains(Normalize(x.Value.Title))).Select(x => x.Key).ToList();
+
+            if (matches.Any())
+            {
+                _httpClient.Post(BuildRequest($"cdb/delete-books/{string.Join(",", matches)}").Build());
+                _logger.Info("Deleted book {0} from Calibre content server (calibre ids: {1})", book.Title, string.Join(",", matches));
+            }
+            else
+            {
+                _logger.Debug("No matching book found on Calibre content server for {0}", book.Title);
+            }
+        }
+
+        private static string Normalize(string title)
+        {
+            return Regex.Replace(title?.ToLowerInvariant() ?? string.Empty, "[^a-z0-9]", "");
+        }
+
+        private HttpRequestBuilder BuildRequest(string relativePath)
+        {
+            var builder = new HttpRequestBuilder(HttpUri.CombinePath(Settings.Url, relativePath))
+                .Accept(HttpAccept.Json);
+
+            if (Settings.Username.IsNotNullOrWhiteSpace())
+            {
+                builder.NetworkCredential = new NetworkCredential(Settings.Username, Settings.Password);
+            }
+
+            return builder;
+        }
+
+        private class CalibreSearchResult
+        {
+            [JsonProperty("book_ids")]
+            public List<int> BookIds { get; set; }
+        }
+
+        private class CalibreBookData
+        {
+            [JsonProperty("title")]
+            public string Title { get; set; }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -134,10 +134,10 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
                 return;
             }
 
-            var titles = new[] { Normalize(book.Title), Normalize(Regex.Replace(book.Title, @"\s*\([^)]*\)\s*$", "")) };
+            var titles = TitleForms(book.Title);
             var booksRequest = BuildRequest($"ajax/books?ids={string.Join(",", ids)}").Build();
             var calibreBooks = _httpClient.Get<Dictionary<string, CalibreBookData>>(booksRequest).Resource;
-            var matches = calibreBooks.Where(x => x.Value != null && titles.Contains(Normalize(x.Value.Title))).Select(x => x.Key).ToList();
+            var matches = calibreBooks.Where(x => x.Value != null && TitleForms(x.Value.Title).Intersect(titles).Any()).Select(x => x.Key).ToList();
 
             if (matches.Any())
             {
@@ -146,8 +146,13 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             }
             else
             {
-                _logger.Debug("No matching book found on Calibre content server for {0}", book.Title);
+                _logger.Info("No matching book found on Calibre content server for {0}", book.Title);
             }
+        }
+
+        private static string[] TitleForms(string title)
+        {
+            return new[] { Normalize(title), Normalize(Regex.Replace(title ?? string.Empty, @"\s*\([^)]*\)\s*$", "")) };
         }
 
         private static string Normalize(string title)

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -80,12 +80,29 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
             try
             {
-                var request = BuildRequest("ajax/library-info").Build();
-                _httpClient.Get(request);
-            }
-            catch (HttpException ex) when (ex.Response?.StatusCode == HttpStatusCode.Unauthorized)
-            {
-                failures.Add(new ValidationFailure("Username", "Authentication failed"));
+                var request = BuildRequest("cdb/add-book/0/0/chaptarr-connection-test.epub").Build();
+
+                if (Settings.Username.IsNullOrWhiteSpace())
+                {
+                    request.Credentials = new NetworkCredential("chaptarr-connection-test", Guid.NewGuid().ToString("N"));
+                }
+
+                request.SuppressHttpError = true;
+                request.SetContent(Array.Empty<byte>());
+                var response = _httpClient.Post(request);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    failures.Add(new ValidationFailure("Username", "Authentication failed"));
+                }
+                else if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    failures.Add(new ValidationFailure("Username", "The content server does not accept anonymous changes, a username and password are required to push books"));
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound || ((int)response.StatusCode >= 300 && (int)response.StatusCode < 400))
+                {
+                    failures.Add(new ValidationFailure("Url", "Not a Calibre content server, check the URL"));
+                }
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
@@ -1,0 +1,39 @@
+using FluentValidation;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class CalibreContentServerSettingsValidator : AbstractValidator<CalibreContentServerSettings>
+    {
+        public CalibreContentServerSettingsValidator()
+        {
+            RuleFor(c => c.Url).IsValidUrl();
+            RuleFor(c => c.Username).NotEmpty().When(c => c.Password.IsNotNullOrWhiteSpace());
+        }
+    }
+
+    public class CalibreContentServerSettings : IProviderConfig
+    {
+        private static readonly CalibreContentServerSettingsValidator Validator = new CalibreContentServerSettingsValidator();
+
+        [FieldDefinition(0, Label = "URL", HelpText = "Calibre content server URL, including http(s):// and port, e.g. http://localhost:8080")]
+        public string Url { get; set; }
+
+        [FieldDefinition(1, Label = "Username", Privacy = PrivacyLevel.UserName, HelpText = "Optional, only needed if the content server requires authentication")]
+        public string Username { get; set; }
+
+        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password, HelpText = "Optional, only needed if the content server requires authentication")]
+        public string Password { get; set; }
+
+        [FieldDefinition(3, Label = "Allow Edits & Deletes", Type = FieldType.Checkbox, HelpText = "Allow Chaptarr to edit or delete matching books on the content server when books change in Chaptarr or are deleted from Chaptarr")]
+        public bool SyncChanges { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
@@ -10,7 +10,8 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
     {
         public CalibreContentServerSettingsValidator()
         {
-            RuleFor(c => c.Url).IsValidUrl();
+            RuleFor(c => c.Url).NotEmpty().WithMessage("URL cannot be empty");
+            RuleFor(c => c.Url).IsValidUrl().When(c => c.Url.IsNotNullOrWhiteSpace());
             RuleFor(c => c.Username).NotEmpty().When(c => c.Password.IsNotNullOrWhiteSpace());
         }
     }

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
@@ -13,6 +13,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             RuleFor(c => c.Url).NotEmpty().WithMessage("URL cannot be empty");
             RuleFor(c => c.Url).IsValidUrl().When(c => c.Url.IsNotNullOrWhiteSpace());
             RuleFor(c => c.Username).NotEmpty().When(c => c.Password.IsNotNullOrWhiteSpace());
+            RuleFor(c => c.Password).NotEmpty().When(c => c.Username.IsNotNullOrWhiteSpace());
         }
     }
 

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; } // Only applies to audiobook profiles
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; } // Only applies when converting to M4B
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; } // Only applies to audiobook profiles
         public int? ConvertToQualityId { get; set; }
-        public bool MergeMultiPartFiles { get; set; } // Only applies when converting to M4B
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Qualities/QualityConversionHelper.cs
+++ b/src/NzbDrone.Core/Qualities/QualityConversionHelper.cs
@@ -68,6 +68,21 @@ namespace NzbDrone.Core.Qualities
             return null;
         }
 
+        public static bool ShouldMergeMultiPartM4b(QualityProfile profile, QualityModel sourceQuality)
+        {
+            if (profile == null || !profile.MergeMultiPartFiles || profile.ProfileType != ProfileType.Audiobook)
+            {
+                return false;
+            }
+
+            if (GetConversionTargetQualityId(profile) != Quality.M4B.Id)
+            {
+                return false;
+            }
+
+            return (sourceQuality?.Quality ?? Quality.Unknown) == Quality.M4B;
+        }
+
         private static int? GetConversionTargetQualityId(QualityProfile profile)
         {
             if (profile.ConvertToQualityId.HasValue && profile.ConvertToQualityId.Value > 0)


### PR DESCRIPTION
#### Description
Adds a connect notification for the "Calibre Content Server":

- URL (required), username and password (optional, only needed if the server has auth), and an
  "Allow Edits & Deletes" checkbox that's off by default.
- On import every ebook file in the release is POSTed to `cdb/add-book`, sequentially — the
  content server would rather take them one at a time. Audiobook files are skipped.
- Adds go up with `add_duplicates=0`, so a book the library already has is skipped and logged
  instead of duplicated.
- With edits and deletes enabled, deleting a book or a book file in Chaptarr deletes the
  matching book on the server, and a retag or an upgrade replaces it. With it off none of those
  handlers do anything, so the integration stays add-only until you opt in.

**Quick note on "edits and deletes":**
Edits and deletes have to find the book in the calibre db first. That match is by author, then by title, with case and punctuation removed and a trailing parenthetical stripped from both sides. calibre takes its title from inside the epub, and those usually carry decorations the Chaptarr title doesn't — "Out of Spite, Out of Mind (Magic 2.0 Book 5)" where Chaptarr has plain "Out of Spite, Out of Mind" — so comparing the two literally matches nothing, quietly. Normalising keeps it an equality test rather than a fuzzy one, so it can't wander onto a neighbouring book in the same series, and a delete that comes up empty logs that instead of reporting success. 

## Validation

- The connection test POSTs an empty body to `cdb/add-book`, the same endpoint pushes use.
  calibre checks auth and the write permission before it looks for a body, so a server that
  would accept books answers `400` ("A request body containing the file data must be
  specified") and one that wouldn't answers `401` or `403`. Nothing is added — checked against
  a live library by count.
- With the credential fields empty the test sends throwaway sentinel credentials, so the shared
  credential cache can't answer the challenge on its behalf.
- A username without a password is rejected before any request goes out, since calibre's `400`
  for that case is indistinguishable from the "authenticated, no body" `400` the test wants.
- An empty URL says so, instead of `Invalid Url: '{url}'` with the placeholder unfilled.
- `401` reports authentication failed, `403` reports that the server doesn't accept anonymous
  changes and needs credentials, `404` and redirects report that the URL isn't a content server
  — pointing at Calibre-Web's web UI instead of the content server port lands here.

## Related PRs

Calibre-Web can't run calibre's content server itself, which is the other half of this. PRs are
up for Calibre-Web and both forks:

- Calibre-Web: https://github.com/janeczku/calibre-web/pull/3694
- Calibre-Web-Automated: https://github.com/crocodilestick/Calibre-Web-Automated/pull/1507
- Calibre-Web-NextGen: https://github.com/new-usemame/Calibre-Web-NextGen/pull/1911

#### Database Migration
NO.

#### How was this tested?

- Tested against Calibre-Web-Automated running its bundled content server: imports from a
  tracked download push and show up in the library, re-imports skip as duplicates, a delete
  with the option off leaves the server alone and with it on removes the right book, and each
  of the failing test cases above against both an authenticated and an anonymous server.
- Setup: Docker / Docker Compose for Chaptarr and CW / CWA



#### Screenshots - Not really a change but this is how it looks

<img width="800" height="961" alt="add-connection-form" src="https://github.com/user-attachments/assets/b2e7393b-6d8f-40b2-9141-2ea8de0576d6" />
<img width="800" height="322" alt="connection-tile" src="https://github.com/user-attachments/assets/05468a46-bf8c-4f85-bda0-e10e853c89b4" />
