### PR TITLE
Merge multi-part M4B downloads into a single file

### DIFF
--- a/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
+++ b/frontend/src/Settings/Profiles/Quality/EditQualityProfileModalContent.js
@@ -180,6 +180,7 @@ class EditQualityProfileModalContent extends Component {
       upgradeAllowed,
       preferCustomFormatsOverQuality,
       convertToQualityId,
+      mergeMultiPartFiles,
       cutoff,
       minFormatScore,
       cutoffFormatScore,
@@ -190,6 +191,7 @@ class EditQualityProfileModalContent extends Component {
     const upgradeAllowedField = fieldWithDefault(upgradeAllowed, false);
     const preferCustomFormatsOverQualityField = fieldWithDefault(preferCustomFormatsOverQuality, false);
     const convertToQualityIdField = fieldWithDefault(convertToQualityId, 0);
+    const mergeMultiPartFilesField = fieldWithDefault(mergeMultiPartFiles, false);
     const cutoffField = fieldWithDefault(cutoff, 0);
     const minFormatScoreField = fieldWithDefault(minFormatScore, 0);
     const cutoffFormatScoreField = fieldWithDefault(cutoffFormatScore, 0);
@@ -335,6 +337,23 @@ class EditQualityProfileModalContent extends Component {
                                 translate('ConvertToQualityHelpText') :
                                 undefined}
                               onChange={onConvertToQualityChange}
+                            />
+                          </FormGroup>
+                      }
+
+                      {
+                        isAudiobookProfile && Number(convertToQualityIdField.value) > 0 &&
+                          <FormGroup size={sizes.EXTRA_SMALL}>
+                            <FormLabel size={sizes.SMALL}>
+                              {translate('MergeMultiPartFiles')}
+                            </FormLabel>
+
+                            <FormInputGroup
+                              type={inputTypes.CHECK}
+                              name="mergeMultiPartFiles"
+                              {...mergeMultiPartFilesField}
+                              helpText={translate('MergeMultiPartFilesHelpText')}
+                              onChange={onInputChange}
                             />
                           </FormGroup>
                       }

--- a/src/Chaptarr.Api.V1/Profiles/Quality/QualityProfileResource.cs
+++ b/src/Chaptarr.Api.V1/Profiles/Quality/QualityProfileResource.cs
@@ -17,6 +17,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; }
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public List<QualityProfileQualityItemResource> Items { get; set; }
         public int MinFormatScore { get; set; }
@@ -79,6 +80,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
                 PreferCustomFormatsOverQuality = model.ProfileType == ProfileType.Audiobook && model.PreferCustomFormatsOverQuality,
                 ConvertMp3ToM4b = model.ConvertMp3ToM4b,
                 ConvertToQualityId = convertToQualityId,
+                MergeMultiPartFiles = model.MergeMultiPartFiles,
                 Cutoff = cutoff,
                 Items = items.ConvertAll(ToResource),
                 MinFormatScore = model.MinFormatScore,
@@ -140,6 +142,7 @@ namespace Chaptarr.Api.V1.Profiles.Quality
                 // toggle. ConvertToQualityId is the canonical conversion target.
                 ConvertMp3ToM4b = convertToQualityId == NzbDrone.Core.Qualities.Quality.M4B.Id,
                 ConvertToQualityId = convertToQualityId,
+                MergeMultiPartFiles = resource.ProfileType == ProfileType.Audiobook && resource.MergeMultiPartFiles,
                 Cutoff = resource.Cutoff,
                 Items = (resource.Items ?? new List<QualityProfileQualityItemResource>()).ConvertAll(ToModel),
                 MinFormatScore = resource.MinFormatScore,

--- a/src/Chaptarr.Api.V1/openapi.json
+++ b/src/Chaptarr.Api.V1/openapi.json
@@ -18272,6 +18272,9 @@
             "format": "int32",
             "nullable": true
           },
+          "mergeMultiPartFiles": {
+            "type": "boolean"
+          },
           "cutoff": {
             "type": "integer",
             "format": "int32"

--- a/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupModels.cs
+++ b/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupModels.cs
@@ -222,6 +222,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; }
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupService.cs
+++ b/src/NzbDrone.Core/Configuration/SettingsBackups/SettingsBackupService.cs
@@ -626,6 +626,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
                 CutoffFormatScore = profile.CutoffFormatScore,
                 ConvertMp3ToM4b = profile.ConvertMp3ToM4b,
                 ConvertToQualityId = profile.ConvertToQualityId,
+                MergeMultiPartFiles = profile.MergeMultiPartFiles,
                 UpgradeAllowed = profile.UpgradeAllowed,
                 PreferCustomFormatsOverQuality = profile.ProfileType == ProfileType.Audiobook && profile.PreferCustomFormatsOverQuality,
                 FormatItems = (profile.FormatItems ?? new List<NzbDrone.Core.Profiles.ProfileFormatItem>())
@@ -1725,6 +1726,7 @@ namespace NzbDrone.Core.Configuration.SettingsBackups
                 CutoffFormatScore = profile.CutoffFormatScore,
                 ConvertMp3ToM4b = profile.ConvertMp3ToM4b,
                 ConvertToQualityId = profile.ConvertToQualityId,
+                MergeMultiPartFiles = profile.MergeMultiPartFiles,
                 UpgradeAllowed = profile.UpgradeAllowed,
                 PreferCustomFormatsOverQuality = profile.ProfileType == ProfileType.Audiobook && profile.PreferCustomFormatsOverQuality,
                 FormatItems = new List<NzbDrone.Core.Profiles.ProfileFormatItem>()

--- a/src/NzbDrone.Core/Datastore/Migration/001_chaptarr_complete_schema.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/001_chaptarr_complete_schema.cs
@@ -816,7 +816,8 @@ namespace NzbDrone.Core.Datastore.Migration
                 .WithColumn("FormatItems").AsString().NotNullable()
                 .WithColumn("SearchCriteriaProfileId").AsInt32().Nullable()
                 .WithColumn("ConvertMp3ToM4b").AsBoolean().NotNullable().WithDefaultValue(false)
-                .WithColumn("ConvertToQualityId").AsInt32().Nullable();
+                .WithColumn("ConvertToQualityId").AsInt32().Nullable()
+                .WithColumn("MergeMultiPartFiles").AsBoolean().NotNullable().WithDefaultValue(false);
 
             // Metadata profiles
             Create.TableForModel("MetadataProfiles")

--- a/src/NzbDrone.Core/Datastore/Migration/103_add_quality_profile_merge_multi_part_files.cs
+++ b/src/NzbDrone.Core/Datastore/Migration/103_add_quality_profile_merge_multi_part_files.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using NzbDrone.Core.Datastore.Migration.Framework;
+
+namespace NzbDrone.Core.Datastore.Migration
+{
+    [Migration(103)]
+    public class add_quality_profile_merge_multi_part_files : NzbDroneMigrationBase
+    {
+        protected override void MainDbUpgrade()
+        {
+            if (!Schema.Table("QualityProfiles").Column("MergeMultiPartFiles").Exists())
+            {
+                Alter.Table("QualityProfiles")
+                    .AddColumn("MergeMultiPartFiles")
+                    .AsBoolean()
+                    .NotNullable()
+                    .WithDefaultValue(false);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1115,7 +1115,7 @@
   "Medium": "Medium",
   "Member": "Member",
   "MergeMultiPartFiles": "Create Single File",
-  "MergeMultiPartFilesHelpText": "Also merge multi-part downloads that are already M4B into a single M4B file. Multi-part MP3 and other formats are always merged when converting.",
+  "MergeMultiPartFilesHelpText": "All multi-part downloads will be merged into a single M4B file",
   "Message": "Message",
   "Metadata": "Metadata",
   "MetadataConsumers": "Metadata Consumers",

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1114,6 +1114,8 @@
   "MediaManagementSettingsSummary": "Naming, file management settings and root folders",
   "Medium": "Medium",
   "Member": "Member",
+  "MergeMultiPartFiles": "Create Single File",
+  "MergeMultiPartFilesHelpText": "Also merge multi-part downloads that are already M4B into a single M4B file. Multi-part MP3 and other formats are always merged when converting.",
   "Message": "Message",
   "Metadata": "Metadata",
   "MetadataConsumers": "Metadata Consumers",

--- a/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookImport/ImportApprovedBooks.cs
@@ -1532,7 +1532,8 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                 var sourceQuality = first?.Quality?.Quality ?? Qualities.Quality.Unknown;
                 var qualityProfile = author.GetQualityProfileForQuality(sourceQuality);
                 var targetQuality = QualityConversionHelper.GetPlannedConversionTarget(author, first?.Quality);
-                if (targetQuality != Qualities.Quality.M4B)
+                var mergeMultiPartM4b = QualityConversionHelper.ShouldMergeMultiPartM4b(qualityProfile, first?.Quality);
+                if (targetQuality != Qualities.Quality.M4B && !mergeMultiPartM4b)
                 {
                     return (bookDecisions, null, false, null);
                 }
@@ -1549,7 +1550,8 @@ namespace NzbDrone.Core.MediaFiles.BookImport
                     return (bookDecisions, null, false, null);
                 }
 
-                if (inputFiles.All(p => Path.GetExtension(p).Equals(".m4b", StringComparison.OrdinalIgnoreCase)))
+                if (inputFiles.All(p => Path.GetExtension(p).Equals(".m4b", StringComparison.OrdinalIgnoreCase)) &&
+                    (inputFiles.Length == 1 || qualityProfile?.MergeMultiPartFiles != true))
                 {
                     return (bookDecisions, null, false, null);
                 }

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; } // Only applies to audiobook profiles
         public int? ConvertToQualityId { get; set; }
+        public bool MergeMultiPartFiles { get; set; } // Only applies when converting to M4B
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
+++ b/src/NzbDrone.Core/Profiles/Qualities/QualityProfile.cs
@@ -27,7 +27,7 @@ namespace NzbDrone.Core.Profiles.Qualities
         public bool PreferCustomFormatsOverQuality { get; set; }
         public bool ConvertMp3ToM4b { get; set; } // Only applies to audiobook profiles
         public int? ConvertToQualityId { get; set; }
-        public bool MergeMultiPartFiles { get; set; } // Only applies when converting to M4B
+        public bool MergeMultiPartFiles { get; set; }
         public int Cutoff { get; set; }
         public int MinFormatScore { get; set; }
         public int CutoffFormatScore { get; set; }

--- a/src/NzbDrone.Core/Qualities/QualityConversionHelper.cs
+++ b/src/NzbDrone.Core/Qualities/QualityConversionHelper.cs
@@ -68,6 +68,21 @@ namespace NzbDrone.Core.Qualities
             return null;
         }
 
+        public static bool ShouldMergeMultiPartM4b(QualityProfile profile, QualityModel sourceQuality)
+        {
+            if (profile == null || !profile.MergeMultiPartFiles || profile.ProfileType != ProfileType.Audiobook)
+            {
+                return false;
+            }
+
+            if (GetConversionTargetQualityId(profile) != Quality.M4B.Id)
+            {
+                return false;
+            }
+
+            return (sourceQuality?.Quality ?? Quality.Unknown) == Quality.M4B;
+        }
+
         private static int? GetConversionTargetQualityId(QualityProfile profile)
         {
             if (profile.ConvertToQualityId.HasValue && profile.ConvertToQualityId.Value > 0)


### PR DESCRIPTION
#### Description

Multi-part downloads that already consist of M4B files were the one case the M4B conversion pipeline did not create 1 m4b file. There was a guard in `ImportApprovedBooks` which skipped conversion entirely, so a 10-part M4B audiobook imported as 10 separate files while multi-part MP3/M4A/FLAC merged into one. This was obviously intentional but for some setups a single m4b file works better. 

This adds an opt-in per-quality-profile setting, `MergeMultiPartFiles`, exposed as a **"Create Single File"** checkbox below **Convert To** in the quality profile editor. When enabled, multi-part all-M4B downloads are routed through the existing `m4b-tool merge` pipeline like any other format.

- Single-file M4B downloads are still imported untouched to avoid a pointless re-encode.
- `GetPlannedConversionTarget` is unchanged, so queue display and decision-engine effective-quality comparisons behave exactly as before; the new `ShouldMergeMultiPartM4b` helper gates the import path only.
- The flag round-trips through the API resource, `openapi.json`, and settings backups.

#### Database Migration

YES. 
Migration 103 adds a `MergeMultiPartFiles` boolean column (NOT NULL, default false) to `QualityProfiles`, with an existence check Migration 001 complete-schema migration gains the same column for fresh installs.

#### How was this tested?

Built with `docker build -f Dockerfile.build` on Ubuntu and deployed over a live SQLite install (v0.9.936.0) that previously ran the base branch. Verified on startup:

- Migration 103 applied cleanly to the existing database and the app started without errors.
- `GET /api/v1/qualityprofile` returns `mergeMultiPartFiles` on existing profiles (defaulting to false).
- The checkbox renders and persists in the profile editor.


#### Screenshots (UI changes only)
<img width="1263" height="1086" alt="image" src="https://github.com/user-attachments/assets/e3c6e464-f13f-4ebe-8565-370d91088505" />


