### PR TITLE
Fix: approved imports silently delete higher-quality files of the same book

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/UpgradeMediaFileServiceFixture.cs
@@ -9,6 +9,8 @@ using NzbDrone.Core.Books;
 using NzbDrone.Core.Books.Calibre;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
 using NzbDrone.Core.RootFolders;
 
 namespace Chaptarr.Core.Test.MediaFiles
@@ -146,7 +148,8 @@ namespace Chaptarr.Core.Test.MediaFiles
                 DispatchProxy.Create<IDiskProvider, DiskProviderProxy>(),
                 DispatchProxy.Create<IRootFolderService, RootFolderServiceProxy>(),
                 DispatchProxy.Create<ICalibreProxy, ThrowingProxy<ICalibreProxy>>(),
-                LogManager.GetCurrentClassLogger());
+                LogManager.GetCurrentClassLogger(),
+                null);
 
             Assert.DoesNotThrow(() => subject.UpgradeBookFile(replacement, localBook));
 
@@ -157,5 +160,125 @@ namespace Chaptarr.Core.Test.MediaFiles
                 Assert.That(mover.Moved, Is.True);
             });
         }
+
+        private class QualityProfileServiceProxy : DispatchProxy
+        {
+            public static QualityProfile Profile { get; set; }
+
+            protected override object Invoke(MethodInfo targetMethod, object[] args)
+            {
+                if (targetMethod?.Name == "Get")
+                {
+                    return Profile;
+                }
+
+                throw new NotImplementedException($"Test proxy does not implement IQualityProfileService.{targetMethod?.Name}");
+            }
+        }
+
+        private static QualityProfile AudiobookProfile()
+        {
+            return new QualityProfile
+            {
+                Id = 7,
+                Name = "Audiobook",
+                UpgradeAllowed = true,
+                Cutoff = Quality.M4B.Id,
+                Items = new List<QualityProfileQualityItem>
+                {
+                    new QualityProfileQualityItem { Quality = Quality.MP3, Allowed = true },
+                    new QualityProfileQualityItem { Quality = Quality.M4B, Allowed = true }
+                }
+            };
+        }
+
+        private static (UpgradeMediaFileService subject, RecordingRecycleBinProvider bin, MediaFileServiceProxy media, StubBookFileMover mover) BuildGuardedSubject()
+        {
+            QualityProfileServiceProxy.Profile = AudiobookProfile();
+            var recycleBin = new RecordingRecycleBinProvider();
+            var mediaFileService = DispatchProxy.Create<IMediaFileService, MediaFileServiceProxy>();
+            var mediaProxy = (MediaFileServiceProxy)(object)mediaFileService;
+            var mover = new StubBookFileMover();
+            var subject = new UpgradeMediaFileService(
+                recycleBin,
+                mediaFileService,
+                DispatchProxy.Create<IMetadataTagService, NoOpProxy<IMetadataTagService>>(),
+                mover,
+                DispatchProxy.Create<IDiskProvider, DiskProviderProxy>(),
+                DispatchProxy.Create<IRootFolderService, RootFolderServiceProxy>(),
+                DispatchProxy.Create<ICalibreProxy, ThrowingProxy<ICalibreProxy>>(),
+                LogManager.GetCurrentClassLogger(),
+                DispatchProxy.Create<NzbDrone.Core.Profiles.Qualities.IQualityProfileService, QualityProfileServiceProxy>());
+            return (subject, recycleBin, mediaProxy, mover);
+        }
+
+        private static LocalBook BuildLocalBook(BookFile existing, string incomingPath)
+        {
+            var author = new Author { Id = 1, Path = "/books/Author", AudiobookQualityProfileId = 7 };
+            var book = new Book
+            {
+                Id = 2,
+                Author = author,
+                MediaType = BookMediaType.Audiobook,
+                BookFiles = new List<BookFile> { existing }
+            };
+            return new LocalBook { Author = author, Book = book, Path = incomingPath };
+        }
+
+        [Test]
+        public void should_refuse_to_delete_existing_file_that_outranks_the_incoming_file()
+        {
+            var existingM4b = new BookFile
+            {
+                Id = 1,
+                Path = "/books/Author/Book (2003)/Book.m4b",
+                Quality = new QualityModel(Quality.M4B)
+            };
+            var incomingMp3 = new BookFile
+            {
+                Id = 2,
+                Path = "/downloads/Book.mp3",
+                Quality = new QualityModel(Quality.MP3)
+            };
+            var localBook = BuildLocalBook(existingM4b, incomingMp3.Path);
+            var (subject, bin, media, mover) = BuildGuardedSubject();
+
+            Assert.Throws<InvalidOperationException>(() => subject.UpgradeBookFile(incomingMp3, localBook));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(bin.DeletedFiles, Is.Empty);
+                Assert.That(media.Deleted, Is.Empty);
+                Assert.That(mover.Moved, Is.False);
+            });
+        }
+
+        [Test]
+        public void should_still_replace_existing_file_when_incoming_file_is_an_upgrade()
+        {
+            var existingMp3 = new BookFile
+            {
+                Id = 1,
+                Path = "/books/Author/Book (2003)/Book.mp3",
+                Quality = new QualityModel(Quality.MP3)
+            };
+            var incomingM4b = new BookFile
+            {
+                Id = 2,
+                Path = "/downloads/Book.m4b",
+                Quality = new QualityModel(Quality.M4B)
+            };
+            var localBook = BuildLocalBook(existingMp3, incomingM4b.Path);
+            var (subject, bin, media, mover) = BuildGuardedSubject();
+
+            Assert.DoesNotThrow(() => subject.UpgradeBookFile(incomingM4b, localBook));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(media.Deleted, Is.EqualTo(new[] { existingMp3 }));
+                Assert.That(mover.Moved, Is.True);
+            });
+        }
+
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
+++ b/src/NzbDrone.Core/MediaFiles/UpgradeMediaFileService.cs
@@ -7,6 +7,8 @@ using NzbDrone.Common.Extensions;
 using NzbDrone.Core.Books.Calibre;
 using NzbDrone.Core.MediaFiles.BookImport;
 using NzbDrone.Core.Parser.Model;
+using NzbDrone.Core.Profiles.Qualities;
+using NzbDrone.Core.Qualities;
 using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.MediaFiles
@@ -26,6 +28,7 @@ namespace NzbDrone.Core.MediaFiles
         private readonly IRootFolderService _rootFolderService;
         private readonly ICalibreProxy _calibre;
         private readonly Logger _logger;
+        private readonly IQualityProfileService _qualityProfileService;
 
         public UpgradeMediaFileService(IRecycleBinProvider recycleBinProvider,
                                        IMediaFileService mediaFileService,
@@ -34,7 +37,8 @@ namespace NzbDrone.Core.MediaFiles
                                        IDiskProvider diskProvider,
                                        IRootFolderService rootFolderService,
                                        ICalibreProxy calibre,
-                                       Logger logger)
+                                       Logger logger,
+                                       IQualityProfileService qualityProfileService)
         {
             _recycleBinProvider = recycleBinProvider;
             _mediaFileService = mediaFileService;
@@ -44,6 +48,7 @@ namespace NzbDrone.Core.MediaFiles
             _rootFolderService = rootFolderService;
             _calibre = calibre;
             _logger = logger;
+            _qualityProfileService = qualityProfileService;
         }
 
         public BookFileMoveResult UpgradeBookFile(BookFile bookFile, LocalBook localBook, bool copyOnly = false)
@@ -52,6 +57,28 @@ namespace NzbDrone.Core.MediaFiles
 
             // Ensure BookFiles collection is loaded
             var existingFiles = localBook.Book.BookFiles ?? new List<BookFile>();
+
+            // Last-line quality guard: an approved import (e.g. an edition
+            // switch) must never destroy files that outrank the incoming one
+            // in the author's profile. Decision specs compare within an
+            // edition; this is the only place that sees the actual deletion.
+            var guardProfileId = localBook.Book?.MediaType == Books.BookMediaType.Ebook
+                ? localBook.Author?.EbookQualityProfileId
+                : localBook.Author?.AudiobookQualityProfileId;
+            if (guardProfileId > 0 && bookFile.Quality != null && _qualityProfileService != null)
+            {
+                var guardProfile = _qualityProfileService.Get(guardProfileId.Value);
+                if (guardProfile != null)
+                {
+                    var comparer = new QualityModelComparer(guardProfile);
+                    var betterExisting = existingFiles.FirstOrDefault(f => f.Quality != null && comparer.Compare(f.Quality, bookFile.Quality) > 0);
+                    if (betterExisting != null)
+                    {
+                        throw new System.InvalidOperationException(
+                            $"Refusing to replace '{betterExisting.Path}' ({betterExisting.Quality}) with lower-ranked '{localBook.Path}' ({bookFile.Quality})");
+                    }
+                }
+            }
 
             // Handle cases where author path might not be set (e.g., for downloads)
             string rootFolderPath;


### PR DESCRIPTION
## The bug

Every quality protection lives in the grab-side decision engine (`UpgradeDiskSpecification`, `QueueSpecification`, `HistorySpecification`) - they stop worse *releases* being grabbed. The import side has no quality comparison at all: once a file is matched and approved for import (a completed download matching a different edition, a manual import, a retry pass), `UpgradeMediaFileService.UpgradeBookFile` unconditionally deletes **every existing file of the book** before moving the new one in.

The edition-switch path makes this destructive in practice: an incoming MP3 that matches a *different edition* of a book than the one whose M4B you hold sails past the grab-side specs (they compared within the grabbed edition), reaches `UpgradeBookFile`, and the M4B is deleted with reason "Upgrade". With no recycle bin configured (the default), the file is gone permanently.

I verified the behaviour on pristine develop with a probe test - existing `M4B`-quality file on the book, incoming `MP3` - and it deletes the M4B without any comparison. On my install a batch of MP3-edition downloads destroyed a run of M4B files this way (recovered most from still-seeding source data; the rest were permanent losses).

## The fix

A last-line guard in `UpgradeBookFile`: before deleting existing files, compare each against the incoming file using `QualityModelComparer` over the author's per-media quality profile. If any existing file outranks the incoming one, throw instead of deleting - the import surfaces as a visible failure rather than a silent downgrade. Genuine upgrades (MP3 -> M4B) and same-rank replacements behave exactly as before; grab-side selection logic is untouched.

A dedicated decision-layer fix (comparing quality across editions before approving the switch) might be the nicer long-term shape - happy to rework in that direction if you prefer; this guard is the minimal stop-the-data-loss version and is running in production on my install.

## Tests

Two new tests in `UpgradeMediaFileServiceFixture`: refuse-downgrade (M4B on disk, MP3 incoming -> throws, nothing deleted) and upgrade-still-works (MP3 on disk, M4B incoming -> replaced as before). A literal fails-first run isn't possible for the refusal test since it needs the widened constructor (new `IQualityProfileService` dependency) - the pristine destructive behaviour was verified with a separate probe test instead, as described above. Full Core.Test suite green: 2854/2854.