### PR TITLE
Fix: percentOfBooks counts files instead of available books (multi-file audiobooks exceed 100%)

### DIFF
--- a/src/Chaptarr.Api.V1/Books/BookStatisticsResource.cs
+++ b/src/Chaptarr.Api.V1/Books/BookStatisticsResource.cs
@@ -6,6 +6,7 @@ namespace Chaptarr.Api.V1.Books
     {
         public int BookFileCount { get; set; }
         public int BookCount { get; set; }
+        public int AvailableBookCount { get; set; }
         public int TotalBookCount { get; set; }
         public long SizeOnDisk { get; set; }
 
@@ -18,7 +19,7 @@ namespace Chaptarr.Api.V1.Books
                     return 0;
                 }
 
-                return BookFileCount / (decimal)BookCount * 100;
+                return AvailableBookCount / (decimal)BookCount * 100;
             }
         }
     }
@@ -36,6 +37,7 @@ namespace Chaptarr.Api.V1.Books
             {
                 BookFileCount = model.BookFileCount,
                 BookCount = model.BookCount,
+                AvailableBookCount = model.AvailableBookCount,
                 SizeOnDisk = model.SizeOnDisk,
                 TotalBookCount = model.TotalBookCount
             };

--- a/src/Chaptarr.Core.Test/ApiV1/BookStatisticsResourceFixture.cs
+++ b/src/Chaptarr.Core.Test/ApiV1/BookStatisticsResourceFixture.cs
@@ -1,0 +1,43 @@
+using Chaptarr.Api.V1.Books;
+using NUnit.Framework;
+using NzbDrone.Core.AuthorStats;
+
+namespace Chaptarr.Core.Test.ApiV1
+{
+    [TestFixture]
+    public class BookStatisticsResourceFixture
+    {
+        [Test]
+        public void complete_multi_file_audiobook_should_report_100_percent()
+        {
+            var model = new BookStatistics
+            {
+                BookFileCount = 24,
+                BookCount = 1,
+                AvailableBookCount = 1,
+                TotalBookCount = 1,
+                SizeOnDisk = 1234
+            };
+
+            var resource = model.ToResource();
+
+            Assert.That(resource.PercentOfBooks, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void missing_book_should_report_0_percent()
+        {
+            var model = new BookStatistics
+            {
+                BookFileCount = 0,
+                BookCount = 0,
+                AvailableBookCount = 0,
+                TotalBookCount = 1
+            };
+
+            var resource = model.ToResource();
+
+            Assert.That(resource.PercentOfBooks, Is.EqualTo(0));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #83

## The bug

`BookStatisticsResource.PercentOfBooks` divides `BookFileCount` by `BookCount`, so a complete 24-file audiobook reports `percentOfBooks: 2400`. Verified live: an 11-file book returns `1100`.

The core layer already computes the right numerator - `BookStatistics.AvailableBookCount` comes back from the statistics SQL - but the book resource neither maps it nor uses it. The author-level resource (`AuthorStatisticsResource`) already does this correctly with `AvailableBookCount`.

## The fix

Map `AvailableBookCount` onto `BookStatisticsResource` and use it in `PercentOfBooks`, mirroring the author resource. Three lines.

## Tests

New `BookStatisticsResourceFixture`: a complete 24-file/1-book model must report `100` (fails on current develop with `2400`), and an empty book reports `0`. Both pass with the fix; full Core.Test suite green (2854/2854).