### PR TITLE
Fix SearchForNewAuthor routing provider-prefixed IDs to the work endpoint

### DIFF
--- a/src/Chaptarr.Core.Test/MetadataSource/BookInfo/BookInfoProxyCanonicalLookupFixture.cs
+++ b/src/Chaptarr.Core.Test/MetadataSource/BookInfo/BookInfoProxyCanonicalLookupFixture.cs
@@ -152,6 +152,48 @@ namespace Chaptarr.Core.Test.MetadataSource.BookInfo
         }
 
         [Test]
+        public void should_route_provider_prefixed_author_search_to_the_author_endpoint()
+        {
+            // SearchForNewAuthor("hc:...") used to delegate to SearchForNewBook, which routes
+            // canonical provider ids to the V5 *work* endpoint - an author id searched as the
+            // wrong entity type. It must hit the author endpoint instead.
+            var httpClient = new RecordingHttpClient(req =>
+                new HttpResponse(req, new HttpHeader { ContentType = "application/json" }, "{}", HttpStatusCode.NotFound));
+
+            var proxy = CreateProxy(httpClient);
+
+            var results = proxy.SearchForNewAuthor("hc:252214");
+
+            var urls = httpClient.Requests.Select(r => Uri.UnescapeDataString(r.Url.ToString())).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(urls, Is.Not.Empty);
+                Assert.That(urls, Has.All.Contains("/api/v5/author"));
+                Assert.That(urls, Has.None.Contains("/api/v5/work"));
+                Assert.That(urls[0], Does.Contain("id=hc:252214"));
+                Assert.That(results, Is.Empty);
+            });
+        }
+
+        [Test]
+        public void should_still_text_search_authors_for_unprefixed_terms()
+        {
+            // Plain text terms keep the existing book-search-derived author flow: no direct
+            // author-endpoint call. With no search providers wired in this fixture the flow
+            // degrades to an empty result rather than touching the metadata server.
+            var httpClient = new RecordingHttpClient(_ =>
+                throw new AssertionException("Metadata server should not be called for a text term"));
+
+            var proxy = CreateProxy(httpClient);
+
+            var results = proxy.SearchForNewAuthor("Kentaro Miura");
+
+            Assert.That(results, Is.Empty);
+            Assert.That(httpClient.Requests, Is.Empty);
+        }
+
+        [Test]
         public void should_reject_a_bare_numeric_author_id_without_calling_the_metadata_server()
         {
             var httpClient = new RecordingHttpClient(_ =>

--- a/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
@@ -2454,6 +2454,35 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
 
         public List<Author> SearchForNewAuthor(string title)
         {
+            // A canonical provider-prefixed term (hc:/gr:/ol:/gb:/az:) is an identity, not a text
+            // query. Delegating it to SearchForNewBook would route it to the V5 *work* endpoint
+            // and confidently search the wrong entity type; the direct author fetch already
+            // handles these IDs.
+            var trimmed = title?.Trim();
+            if (!trimmed.IsNullOrWhiteSpace())
+            {
+                var firstColon = trimmed.IndexOf(':');
+                if (firstColon > 0 &&
+                    firstColon < trimmed.Length - 1 &&
+                    trimmed.IndexOf(':', firstColon + 1) == -1 &&
+                    ProviderIdHelper.IsCanonicalPrefix(trimmed.Substring(0, firstColon).Trim().ToLowerInvariant()))
+                {
+                    try
+                    {
+                        var author = GetAuthorInfo(ProviderIdHelper.Normalize(trimmed, defaultPrefix: null));
+                        return author != null ? new List<Author> { author } : new List<Author>();
+                    }
+                    catch (AuthorNotFoundException)
+                    {
+                        return new List<Author>();
+                    }
+                    catch (InvalidProviderIdException)
+                    {
+                        return new List<Author>();
+                    }
+                }
+            }
+
             var books = SearchForNewBook(title, null);
 
             return books


### PR DESCRIPTION
## Summary

`SearchForNewAuthor` delegates every term to `SearchForNewBook`, whose canonical-prefix branch sends `hc:`/`gr:` identifiers through `SearchByV5WorkId` — an author identity searched as the wrong entity type, so adding an author by provider ID returns nothing. The direct author-fetch path (`GetAuthorInfo`) already handles these IDs correctly.

Provider-prefixed terms in `SearchForNewAuthor` now route to `GetAuthorInfo`; author-not-found and invalid-ID degrade to empty results; plain-text terms keep the existing flow.

## Testing

- New regression test asserts `hc:252214` produces a request to `/api/v5/author` and never `/api/v5/work`; a companion test pins the unprefixed text-search path.
- `dotnet test` core suite green (only the known environment-dependent `should_stage_matched_provider_chapters_when_source_duration_matches` fails, same as on pristine develop).

Found while running a downstream fork; live-verified against api2 (returns Kentaro Miura for `hc:252214`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)