### PR TITLE
Fix off-by-one bound check in Quality.FindById

### DIFF
--- a/src/Chaptarr.Core.Test/Qualities/QualityFindByIdFixture.cs
+++ b/src/Chaptarr.Core.Test/Qualities/QualityFindByIdFixture.cs
@@ -1,0 +1,32 @@
+using System;
+using NUnit.Framework;
+using NzbDrone.Core.Qualities;
+
+namespace Chaptarr.Core.Test.Qualities
+{
+    [TestFixture]
+    public class QualityFindByIdFixture
+    {
+        [Test]
+        public void should_return_known_qualities_by_id()
+        {
+            Assert.That(Quality.FindById(0), Is.EqualTo(Quality.Unknown));
+            Assert.That(Quality.FindById(Quality.EPUB.Id), Is.EqualTo(Quality.EPUB));
+        }
+
+        [Test]
+        public void should_throw_argument_exception_for_id_just_past_the_lookup_bound()
+        {
+            // The guard must be inclusive: an id equal to the lookup length is out of
+            // bounds and previously surfaced as IndexOutOfRangeException instead of the
+            // intended ArgumentException.
+            Assert.Throws<ArgumentException>(() => Quality.FindById(Quality.AllLookup.Length));
+        }
+
+        [Test]
+        public void should_throw_argument_exception_for_id_far_past_the_lookup_bound()
+        {
+            Assert.Throws<ArgumentException>(() => Quality.FindById(Quality.AllLookup.Length + 100));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Qualities/Quality.cs
+++ b/src/NzbDrone.Core/Qualities/Quality.cs
@@ -133,7 +133,7 @@ namespace NzbDrone.Core.Qualities
             {
                 return Unknown;
             }
-            else if (id > AllLookup.Length)
+            else if (id >= AllLookup.Length)
             {
                 throw new ArgumentException("ID does not match a known quality", nameof(id));
             }


### PR DESCRIPTION
`FindById` guards with `id > AllLookup.Length`, so an id exactly equal to the array length passes the guard and indexes out of bounds — surfacing `IndexOutOfRangeException` instead of the intended `ArgumentException`. One-character fix (`>=`) plus boundary tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)