### PR TITLE
Release matching: don't fuse numbers with dotted scene years; match zero-padded numbers by value

### DIFF
--- a/src/Chaptarr.Core.Test/Parser/ReleaseTitleMatchScorerNumericTokenFixture.cs
+++ b/src/Chaptarr.Core.Test/Parser/ReleaseTitleMatchScorerNumericTokenFixture.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Parser;
+
+namespace Chaptarr.Core.Test.Parser
+{
+    [TestFixture]
+    public class ReleaseTitleMatchScorerNumericTokenFixture
+    {
+        [Test]
+        public void should_not_fuse_a_number_with_a_following_dotted_scene_year()
+        {
+            var tokens = ReleaseTitleMatchScorer.Tokenize("Fahrenheit.451.2018.RETAIL.EPUB");
+
+            Assert.That(tokens, Does.Contain("451"));
+            Assert.That(tokens, Does.Contain("2018"));
+            Assert.That(tokens, Does.Not.Contain("451.2018"));
+        }
+
+        [Test]
+        public void should_keep_genuine_decimal_positions_fused()
+        {
+            var tokens = ReleaseTitleMatchScorer.Tokenize("Series Book 13.5 Novella");
+
+            Assert.That(tokens, Does.Contain("13.5"));
+        }
+
+        [Test]
+        public void should_match_zero_padded_dotted_release_against_unpadded_catalog_title()
+        {
+            var author = new Author { Name = "Jane Doe" };
+            var book = new Book
+            {
+                Title = "Example Saga, Vol. 1",
+                Author = author,
+                Editions = new List<Edition>
+                {
+                    new Edition { Id = 1, Title = "Example Saga, Vol. 1", Monitored = true }
+                }
+            };
+
+            var result = ReleaseTitleMatchScorer.FindBestMatch(
+                "Jane.Doe.Example.Saga.Vol.01.2019.RETAIL.EPUB",
+                "Jane Doe",
+                new[] { book },
+                null,
+                new[] { book });
+
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result.IsMatch, Is.True);
+        }
+
+        [Test]
+        public void should_not_equate_different_numbers()
+        {
+            var author = new Author { Name = "Jane Doe" };
+            var book = new Book
+            {
+                Title = "Example Saga, Vol. 5",
+                Author = author,
+                Editions = new List<Edition>
+                {
+                    new Edition { Id = 1, Title = "Example Saga, Vol. 5", Monitored = true }
+                }
+            };
+
+            var result = ReleaseTitleMatchScorer.FindBestMatch(
+                "Jane.Doe.Example.Saga.Vol.03.2019.RETAIL.EPUB",
+                "Jane Doe",
+                new[] { book },
+                null,
+                new[] { book });
+
+            Assert.That(result == null || !result.IsMatch, Is.True);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Parser/ReleaseTitleMatchScorer.cs
+++ b/src/NzbDrone.Core/Parser/ReleaseTitleMatchScorer.cs
@@ -74,7 +74,10 @@ namespace NzbDrone.Core.Parser
 
         private static readonly Regex TokenRegex = new Regex(@"\p{Nd}+(?:\.\p{Nd}+)+|[\p{L}\p{Nd}]+", RegexOptions.Compiled);
         private static readonly Regex PossessiveRegex = new Regex(@"['\u2018\u2019]s\b", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex DecimalPointBetweenDigitsRegex = new Regex(@"(?<=\p{Nd})\.(?=\p{Nd})", RegexOptions.Compiled);
+        // A dot between digits marks a decimal ("13.5") - except when what follows is a
+        // four-digit year, which is dotted scene punctuation ("Vol.01.2016", "451.2018"),
+        // not a fraction; fusing them makes the number token unmatchable.
+        private static readonly Regex DecimalPointBetweenDigitsRegex = new Regex(@"(?<=\p{Nd})\.(?=\p{Nd})(?!(?:19|20)\d{2}(?!\p{Nd}))", RegexOptions.Compiled);
         private static readonly Regex OptionalQualifierSegmentRegex = new Regex(@"\s*[\(\[](?<label>[^\)\]]+)[\)\]]\s*", RegexOptions.Compiled);
         private static readonly Regex SubtitleLeadingArticleRegex = new Regex(@"(?<prefix>[:;\-\u2013\u2014]\s+)(?<article>a|an|the)\s+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex SubtitleArticleInsertionPointRegex = new Regex(@"(?<prefix>[:;\-\u2013\u2014]\s+)(?<head>[\p{L}\p{Nd}])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -829,7 +832,22 @@ namespace NzbDrone.Core.Parser
 
         internal static bool TokensMatch(string left, string right)
         {
-            return string.Equals(left, right, StringComparison.OrdinalIgnoreCase) || TokenSynonyms.AreSynonyms(left, right);
+            return string.Equals(left, right, StringComparison.OrdinalIgnoreCase) ||
+                   TokenSynonyms.AreSynonyms(left, right) ||
+                   NumericTokensEquivalent(left, right);
+        }
+
+        private static readonly Regex ShortNumericTokenRegex = new Regex(@"^\d{1,4}(?:\.\d{1,4})?$", RegexOptions.Compiled);
+
+        // Releases zero-pad freely ("Vol.01" for volume 1); the values are what must agree.
+        // Capped at 4 integer digits so identifier fragments never collapse into each other.
+        private static bool NumericTokensEquivalent(string left, string right)
+        {
+            return left != null && right != null &&
+                   ShortNumericTokenRegex.IsMatch(left) && ShortNumericTokenRegex.IsMatch(right) &&
+                   decimal.TryParse(left, NumberStyles.Number, CultureInfo.InvariantCulture, out var leftValue) &&
+                   decimal.TryParse(right, NumberStyles.Number, CultureInfo.InvariantCulture, out var rightValue) &&
+                   leftValue == rightValue;
         }
 
         private static TitleMatchResult ChooseBetterResult(TitleMatchResult current, TitleMatchResult candidate)


### PR DESCRIPTION
## Summary

Two related gaps that make dotted scene releases unmatchable:

1. **Number/year fusion.** The decimal-preservation regex treats any `digit.digit` as a fraction, so `Fahrenheit.451.2018.RETAIL.EPUB` tokenizes with `451.2018` as a single token and the title can never align. A dot followed by a four-digit year is scene punctuation, not a decimal; genuine decimals (`13.5`) still fuse.

2. **Zero padding.** `TokensMatch` requires ordinal equality, so a catalog title containing `Vol. 1` never aligns with a release's `Vol 01` — and scene releases pad essentially always. Numeric tokens now compare by value, capped at 4 integer digits so identifier fragments can't collapse into each other.

## Testing

New fixture covers: no fusion before years, decimals preserved, `Vol. 1` catalog title matching a `Vol.01.2019` dotted release, and different numbers still refusing to match. Full core suite green (only the known environment-dependent conversion-staging failure, same as pristine develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)