### PR TITLE
Fix: Import button disabled by unselected invalid rows

### DIFF
--- a/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
+++ b/frontend/src/InteractiveImport/Interactive/InteractiveImportModalContent.js
@@ -321,6 +321,7 @@ class InteractiveImportModalContent extends Component {
     });
 
     const selectedIds = this.getSelectedIds();
+    const invalidSelectedIds = _.intersection(invalidRowsSelected, selectedIds);
     const selectedItem = selectedIds.length ? _.find(items, { id: selectedIds[0] }) : null;
     const importIdsByBook = _.chain(items).filter((x) => x.book).groupBy((x) => x.book.id).mapValues((x) => x.map((y) => y.id)).value();
     const editions = _.chain(items).filter((x) => x.book).keyBy((x) => x.book.id).mapValues((x) => ({ matchedEditionId: x.editionId, book: x.book })).values().value();
@@ -545,7 +546,7 @@ class InteractiveImportModalContent extends Component {
 
             <Button
               kind={kinds.SUCCESS}
-              isDisabled={isSaving || !selectedIds.length || !!invalidRowsSelected.length || inconsistentBookReleases}
+              isDisabled={isSaving || !selectedIds.length || !!invalidSelectedIds.length || inconsistentBookReleases}
               onPress={this.onImportSelectedPress}
             >
               {translate('Import')}


### PR DESCRIPTION
## What changed and why

The Import button in the Interactive Import dialog can be permanently disabled by rows the user never selected.

`onValidRowChange` is passed to every `InteractiveImportRow`, and each row reports its own validity on mount regardless of whether it is selected. Nothing in that handler filters by selection, so despite its name `invalidRowsSelected` accumulates **every** invalid row in the list.

The button then reads:

```js
isDisabled={isSaving || !selectedIds.length || !!invalidRowsSelected.length || inconsistentBookReleases}
```

So a single unresolvable row anywhere in the scanned folder disables Import, no matter what the user ticks.

On a large library this makes the dialog unusable. Scanning a folder produced a few thousand rows that could not be matched to an author. Those rows were never selected, but their presence meant the Import button could not be enabled at all, with no indication of why.

The fix intersects with the current selection at the point of use:

```js
const invalidSelectedIds = _.intersection(invalidRowsSelected, selectedIds);
```

This matches how `inconsistentBookReleases` already restricts itself to selected items in `componentDidUpdate`. No state restructuring, so rows keep reporting validity exactly as before, and behaviour is unchanged when the invalid rows *are* selected.

## Breaking changes

None. Selecting an invalid row still disables the button, exactly as before.

## Testing performed

- Reproduced on a large library where several thousand rows could not be matched to an author. Before the change the Import button was permanently disabled regardless of what was selected.
- Verified the fix by patching the equivalent expression into the running build, after which selecting only the matched rows enabled the button as expected.
- No frontend test runner exists in the repo, so this was verified against a running instance rather than in isolation.
