### PR TITLE
fix(api): preserve media type for scoped book lookup

### DIFF
--- a/src/Chaptarr.Api.V1/Books/BookLookupController.cs
+++ b/src/Chaptarr.Api.V1/Books/BookLookupController.cs
@@ -80,7 +80,7 @@ namespace Chaptarr.Api.V1.Books
             }
 
             // 2) Fall back to existing remote search path if nothing local
-            var searchResults = localMatches ?? _searchProxy.SearchForNewBook(term, null);
+            var searchResults = localMatches ?? _searchProxy.SearchForNewBook(term, null, mediaType: requestedMediaType);
 
             // Apply mediaType filter to remote results
             if (requestedMediaType.HasValue)

--- a/src/Chaptarr.Core.Test/Api/BookLookupControllerProviderLookupFixture.cs
+++ b/src/Chaptarr.Core.Test/Api/BookLookupControllerProviderLookupFixture.cs
@@ -52,6 +52,44 @@ namespace Chaptarr.Core.Test.Api
             public byte[] GetImage(string hash) => throw new NotImplementedException();
         }
 
+        private sealed class SearchProxyStub : ISearchForNewBook
+        {
+            public BookMediaType? RequestedMediaType { get; private set; }
+
+            public List<Book> SearchForNewBook(string title, string author, bool getAllEditions = true, BookMediaType? mediaType = null)
+            {
+                RequestedMediaType = mediaType;
+
+                return new List<Book>
+                {
+                    new Book
+                    {
+                        Title = title,
+                        MediaType = mediaType ?? BookMediaType.Audiobook,
+                        GoodreadsWorkId = "gr:123",
+                        Author = new Author
+                        {
+                            Name = "Test Author",
+                            GoodreadsAuthorId = "gr:456"
+                        },
+                        Editions = new List<Edition>
+                        {
+                            new Edition
+                            {
+                                ForeignEditionId = "gr:789",
+                                Title = title,
+                                Monitored = true
+                            }
+                        }
+                    }
+                };
+            }
+
+            public List<Book> SearchByIsbn(string isbn) => throw new NotImplementedException();
+            public List<Book> SearchByAsin(string asin) => throw new NotImplementedException();
+            public List<Book> SearchByGoodreadsBookId(int goodreadsId, bool getAllEditions) => throw new NotImplementedException();
+        }
+
         private class BookServiceProxy : DispatchProxy
         {
             public readonly List<(string Provider, string ProviderId, BookMediaType MediaType)> FindAllCalls = new();
@@ -143,6 +181,29 @@ namespace Chaptarr.Core.Test.Api
             var result = controller.Search("work:123");
 
             Assert.That(result.Result, Is.TypeOf<BadRequestObjectResult>());
+        }
+
+        [Test]
+        public void should_pass_requested_media_type_to_remote_lookup()
+        {
+            var searchProxy = new SearchProxyStub();
+            var controller = new BookLookupController(
+                searchProxy: searchProxy,
+                coverMapper: new CoverMapperStub(),
+                bookService: null,
+                editionService: null,
+                mediaFileService: null,
+                mediaCoverProxy: new MediaCoverProxyStub(),
+                providerAliasService: null);
+
+            var result = controller.Search("dune", "ebook");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(searchProxy.RequestedMediaType, Is.EqualTo(BookMediaType.Ebook));
+                Assert.That(result.Value, Has.Count.EqualTo(1));
+                Assert.That(result.Value.Single().MediaType, Is.EqualTo("ebook"));
+            });
         }
 
         [Test]

--- a/src/Chaptarr.Core.Test/MetadataSource/BookInfo/BookInfoProxyCanonicalLookupFixture.cs
+++ b/src/Chaptarr.Core.Test/MetadataSource/BookInfo/BookInfoProxyCanonicalLookupFixture.cs
@@ -21,6 +21,18 @@ namespace Chaptarr.Core.Test.MetadataSource.BookInfo
     [TestFixture]
     public class BookInfoProxyCanonicalLookupFixture
     {
+        private sealed class GoodreadsSearchProxyStub : IGoodreadsSearchProxy
+        {
+            private readonly List<SearchJsonResource> _results;
+
+            public GoodreadsSearchProxyStub(List<SearchJsonResource> results)
+            {
+                _results = results;
+            }
+
+            public List<SearchJsonResource> Search(string query) => _results;
+        }
+
         private class RecordingHttpClient : IHttpClient
         {
             private readonly Func<HttpRequest, HttpResponse> _handler;
@@ -74,14 +86,14 @@ namespace Chaptarr.Core.Test.MetadataSource.BookInfo
             return new MetadataServerHealthGate(configService, new MetadataServerHealthService(logger), logger);
         }
 
-        private static BookInfoProxy CreateProxy(IHttpClient httpClient)
+        private static BookInfoProxy CreateProxy(IHttpClient httpClient, IGoodreadsSearchProxy goodreadsSearchProxy = null)
         {
             var configService = DispatchProxy.Create<IConfigService, ConfigServiceProxy>();
             var requestBuilder = new MetadataRequestBuilder(configService);
 
             return new BookInfoProxy(httpClient,
                 cachedHttpClient: null,
-                goodreadsSearchProxy: null,
+                goodreadsSearchProxy: goodreadsSearchProxy,
                 hardcoverSearchClient: null,
                 audibleCatalogProxy: null,
                 authorService: null,
@@ -107,7 +119,8 @@ namespace Chaptarr.Core.Test.MetadataSource.BookInfo
                     WorkId = 22733728,
                     Title = "The Long Way to a Small, Angry Planet",
                     Author = new AuthorJsonResource { Id = 1306980, Name = "Becky Chambers" }
-                }
+                },
+                null
             });
 
             var resource = book.ToResource();
@@ -125,6 +138,28 @@ namespace Chaptarr.Core.Test.MetadataSource.BookInfo
                 Assert.That(resource.Editions.Single().ForeignEditionId, Is.EqualTo("gr:22733729"));
                 Assert.That(prefixFailures, Is.Empty);
             });
+        }
+
+        [Test]
+        public void should_preserve_requested_media_type_on_goodreads_text_search()
+        {
+            var proxy = CreateProxy(
+                new RecordingHttpClient(_ => throw new AssertionException("HTTP should not be called")),
+                new GoodreadsSearchProxyStub(new List<SearchJsonResource>
+                {
+                    new SearchJsonResource
+                    {
+                        BookId = 22733729,
+                        WorkId = 22733728,
+                        Title = "The Long Way to a Small, Angry Planet",
+                        Author = new AuthorJsonResource { Id = 1306980, Name = "Becky Chambers" }
+                    }
+                }));
+
+            var results = proxy.SearchForNewBook("dune", author: null, mediaType: BookMediaType.Ebook);
+
+            Assert.That(results, Has.Count.EqualTo(1));
+            Assert.That(results.Single().MediaType, Is.EqualTo(BookMediaType.Ebook));
         }
 
         [Test]

--- a/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
+++ b/src/NzbDrone.Core/MetadataSource/BookInfo/BookInfoProxy.cs
@@ -2462,7 +2462,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
                 .ToList();
         }
 
-            public List<Book> SearchForNewBook(string title, string author, bool getAllEditions = true)
+            public List<Book> SearchForNewBook(string title, string author, bool getAllEditions = true, BookMediaType? mediaType = null)
             {
                 var q = title.ToLower().Trim();
                 if (author != null)
@@ -2540,7 +2540,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
                     q = slug;
                 }
 
-                return Search(q, getAllEditions);
+                return Search(q, getAllEditions, mediaType);
             }
             catch (HttpException ex)
             {
@@ -2577,7 +2577,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
             return Search(asin, true);
         }
 
-        private List<Book> Search(string query, bool getAllEditions)
+        private List<Book> Search(string query, bool getAllEditions, BookMediaType? mediaType = null)
         {
             List<SearchJsonResource> result;
             try
@@ -2599,7 +2599,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
 
             foreach (var searchResult in result)
             {
-                var book = CreateBookFromSearchResult(searchResult);
+                var book = CreateBookFromSearchResult(searchResult, mediaType);
                 if (book != null)
                 {
                     books.Add(book);
@@ -3754,7 +3754,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
             return false;
         }
 
-        private Book CreateBookFromSearchResult(SearchJsonResource searchResult)
+        private Book CreateBookFromSearchResult(SearchJsonResource searchResult, BookMediaType? mediaType = null)
         {
             if (searchResult == null || searchResult.Author == null)
             {
@@ -3783,6 +3783,7 @@ namespace NzbDrone.Core.MetadataSource.BookInfo
                 AudiobookMonitored = false,
                 EbookMonitored = false,
                 AnyEditionOk = true,
+                MediaType = mediaType ?? BookMediaType.Audiobook,
                 Author = author,
                 Ratings = new Ratings
                 {

--- a/src/NzbDrone.Core/MetadataSource/ISearchForNewBook.cs
+++ b/src/NzbDrone.Core/MetadataSource/ISearchForNewBook.cs
@@ -5,7 +5,7 @@ namespace NzbDrone.Core.MetadataSource
 {
     public interface ISearchForNewBook
     {
-        List<Book> SearchForNewBook(string title, string author, bool getAllEditions = true);
+        List<Book> SearchForNewBook(string title, string author, bool getAllEditions = true, BookMediaType? mediaType = null);
         List<Book> SearchByIsbn(string isbn);
         List<Book> SearchByAsin(string asin);
         List<Book> SearchByGoodreadsBookId(int goodreadsId, bool getAllEditions);


### PR DESCRIPTION
Fixes #67

Book lookup already accepts a `mediaType` query parameter and filters remote results with it, but the remote text-search path was not given that value. Goodreads autocomplete results therefore kept the default `Audiobook` media type, so an ebook lookup filtered every result out.

This passes the requested `BookMediaType` from `BookLookupController` through `ISearchForNewBook` and `BookInfoProxy`. Calls without a scope keep the existing behavior.

I added regression coverage for both the controller forwarding the requested type and Goodreads text results retaining it.

Testing:

- `dotnet build src/Chaptarr.sln --configuration Release --no-restore`
- `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj --configuration Release --no-restore`
- 2,854 tests passed