### PR TITLE
Fix crash on supplementary-plane characters (emoji, astral CJK) in release/catalog titles

### DIFF
--- a/src/Chaptarr.Core.Test/Parser/ReleaseTitleMatchScorerFixture.cs
+++ b/src/Chaptarr.Core.Test/Parser/ReleaseTitleMatchScorerFixture.cs
@@ -29,6 +29,17 @@ namespace Chaptarr.Core.Test.Parser
         }
 
         [Test]
+        public void should_not_throw_on_release_titles_containing_supplementary_plane_characters()
+        {
+            // A release title carrying an emoji or other astral-plane character (a surrogate pair
+            // in .NET's UTF-16 strings) used to crash TokenizeWithSpans with
+            // "String contains invalid Unicode code points" - see Chaptarr/chaptarr#116.
+            var tokens = ReleaseTitleMatchScorer.Tokenize("Fourth Wing 🔥 Rebecca Yarros");
+
+            Assert.That(tokens, Is.EqualTo(new[] { "fourth", "wing", "rebecca", "yarros" }));
+        }
+
+        [Test]
         public void should_match_exact_monitored_title_with_author_series_and_noise()
         {
             var author = new Author { Name = "Brandon Sanderson" };

--- a/src/Chaptarr.Core.Test/Utilities/UnicodeComparisonNormalizerFixture.cs
+++ b/src/Chaptarr.Core.Test/Utilities/UnicodeComparisonNormalizerFixture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using NzbDrone.Core.Utilities;
 
@@ -25,6 +26,73 @@ namespace Chaptarr.Core.Test.Utilities
         {
             Assert.That(UnicodeComparisonNormalizer.NormalizeWords("Renée Ballard"), Is.EqualTo("renee ballard"));
             Assert.That(UnicodeComparisonNormalizer.NormalizeWords("村上 春樹"), Is.EqualTo("村上 春樹"));
+        }
+
+        [Test]
+        public void normalize_words_should_preserve_supplementary_plane_letters()
+        {
+            // U+20000 is a CJK Extension B ideograph - a real letter outside the Basic Multilingual Plane,
+            // represented in .NET as a surrogate pair (two UTF-16 code units).
+            Assert.That(UnicodeComparisonNormalizer.NormalizeWords("Title 𠀀 Word"), Is.EqualTo("title 𠀀 word"));
+        }
+
+        [Test]
+        public void normalize_words_should_not_throw_on_emoji()
+        {
+            Assert.That(UnicodeComparisonNormalizer.NormalizeWords("Fourth Wing 🔥 Rebecca Yarros"), Is.EqualTo("fourth wing rebecca yarros"));
+        }
+
+        [Test]
+        public void normalize_words_should_treat_a_symbol_outside_the_bmp_as_a_word_boundary()
+        {
+            // Before this fix, a supplementary-plane character sitting directly between two letters
+            // (no surrounding whitespace) was silently dropped without inserting a word boundary,
+            // e.g. "ab🔥cd" -> "abcd", because each half of its surrogate pair was individually
+            // classified as UnicodeCategory.Surrogate rather than as the symbol it actually represents.
+            // Classifying it correctly as a symbol now makes it act as a separator, like any other
+            // punctuation/symbol character.
+            Assert.That(UnicodeComparisonNormalizer.NormalizeWords("ab🔥cd"), Is.EqualTo("ab cd"));
+        }
+
+        [Test]
+        public void normalize_key_should_not_throw_on_unpaired_surrogate()
+        {
+            Assert.DoesNotThrow(() => UnicodeComparisonNormalizer.NormalizeKey("Broken \uD800 Title"));
+        }
+
+        [Test]
+        public void normalize_words_with_source_spans_should_merge_the_source_span_of_a_surrogate_pair()
+        {
+            var text = "ab🔥cd";
+            var sourceSpans = new List<(int Start, int End)>();
+            for (var i = 0; i < text.Length; i++)
+            {
+                sourceSpans.Add((i, i + 1));
+            }
+
+            var result = UnicodeComparisonNormalizer.NormalizeWordsWithSourceSpans(text, sourceSpans);
+
+            Assert.That(result.Text, Is.EqualTo("ab cd"));
+            Assert.That(result.SourceSpans, Has.Count.EqualTo(result.Text.Length));
+
+            // "ab" (0,1)(1,2), the synthetic separator space takes the emoji's merged (2,4) span, then "cd" (4,5)(5,6).
+            Assert.That(result.SourceSpans, Is.EqualTo(new List<(int Start, int End)>
+            {
+                (0, 1), (1, 2), (2, 4), (4, 5), (5, 6)
+            }));
+        }
+
+        [Test]
+        public void normalize_words_with_source_spans_should_not_throw_on_unpaired_surrogate()
+        {
+            var text = "Broken \uD800 Title";
+            var sourceSpans = new List<(int Start, int End)>();
+            for (var i = 0; i < text.Length; i++)
+            {
+                sourceSpans.Add((i, i + 1));
+            }
+
+            Assert.DoesNotThrow(() => UnicodeComparisonNormalizer.NormalizeWordsWithSourceSpans(text, sourceSpans));
         }
     }
 }

--- a/src/NzbDrone.Core/Utilities/UnicodeComparisonNormalizer.cs
+++ b/src/NzbDrone.Core/Utilities/UnicodeComparisonNormalizer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Collections.Generic;
 using System.Text;
@@ -39,28 +40,47 @@ namespace NzbDrone.Core.Utilities
             if (sourceSpans == null || sourceSpans.Count != text.Length)
             {
                 var generatedSpans = new List<(int Start, int End)>(text.Length);
-                for (var i = 0; i < text.Length; i++)
+                for (var spanIndex = 0; spanIndex < text.Length; spanIndex++)
                 {
-                    generatedSpans.Add((i, i + 1));
+                    generatedSpans.Add((spanIndex, spanIndex + 1));
                 }
 
                 sourceSpans = generatedSpans;
             }
+
+            // Sanitize first so every remaining surrogate is part of a valid pair - this guarantees the
+            // per-scalar Normalize() call below can never throw (Chaptarr/chaptarr#116), without needing
+            // a try/catch on this hot RSS-matching path. Length-preserving, so `sourceSpans` (indexed by
+            // original UTF-16 code unit) stays valid against the sanitized text.
+            text = SanitizeUnpairedSurrogates(text);
 
             var builder = new StringBuilder(text.Length);
             var spans = new List<(int Start, int End)>();
             var pendingSeparator = false;
             (int Start, int End)? pendingSeparatorSpan = null;
 
-            for (var i = 0; i < text.Length; i++)
+            var i = 0;
+            while (i < text.Length)
             {
-                var sourceSpan = sourceSpans[i];
-                var decomposed = text[i].ToString().Normalize(NormalizationForm.FormD);
+                // Walk one Unicode scalar value at a time (not one UTF-16 code unit at a time) so that
+                // a surrogate pair - e.g. an emoji or a CJK Extension ideograph outside the Basic
+                // Multilingual Plane - is normalized as a whole character instead of being split into
+                // two lone surrogates, which String.Normalize() rejects with
+                // "String contains invalid Unicode code points" (Chaptarr/chaptarr#116).
+                var codePointLength = char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1])
+                    ? 2
+                    : 1;
+
+                var sourceSpan = codePointLength == 2
+                    ? (sourceSpans[i].Start, sourceSpans[i + 1].End)
+                    : sourceSpans[i];
+
+                var decomposed = text.Substring(i, codePointLength).Normalize(NormalizationForm.FormD);
                 var letterOrDigitSegment = new StringBuilder(decomposed.Length);
 
-                foreach (var ch in decomposed)
+                foreach (var rune in decomposed.EnumerateRunes())
                 {
-                    var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+                    var category = Rune.GetUnicodeCategory(rune);
 
                     if (stripDiacritics &&
                         (category == UnicodeCategory.NonSpacingMark ||
@@ -70,7 +90,7 @@ namespace NzbDrone.Core.Utilities
                         continue;
                     }
 
-                    if (ch == '\uFFFD')
+                    if (rune.Value == '\uFFFD')
                     {
                         if (builder.Length > 0)
                         {
@@ -81,13 +101,13 @@ namespace NzbDrone.Core.Utilities
                         continue;
                     }
 
-                    if (char.IsLetterOrDigit(ch))
+                    if (Rune.IsLetterOrDigit(rune))
                     {
-                        letterOrDigitSegment.Append(char.ToLowerInvariant(ch));
+                        letterOrDigitSegment.Append(Rune.ToLowerInvariant(rune).ToString());
                         continue;
                     }
 
-                    if (IsSeparator(ch, category) && builder.Length > 0)
+                    if (IsSeparator(rune, category) && builder.Length > 0)
                     {
                         pendingSeparator = true;
                         pendingSeparatorSpan ??= sourceSpan;
@@ -96,6 +116,7 @@ namespace NzbDrone.Core.Utilities
 
                 if (letterOrDigitSegment.Length == 0)
                 {
+                    i += codePointLength;
                     continue;
                 }
 
@@ -114,6 +135,7 @@ namespace NzbDrone.Core.Utilities
 
                 pendingSeparator = false;
                 pendingSeparatorSpan = null;
+                i += codePointLength;
             }
 
             return new NormalizedMappedText
@@ -130,13 +152,26 @@ namespace NzbDrone.Core.Utilities
                 return string.Empty;
             }
 
-            var normalized = text.Normalize(NormalizationForm.FormD);
+            string normalized;
+            try
+            {
+                normalized = text.Normalize(NormalizationForm.FormD);
+            }
+            catch (ArgumentException)
+            {
+                // An unpaired surrogate anywhere in the text makes it ill-formed UTF-16, which
+                // String.Normalize() rejects outright (Chaptarr/chaptarr#116). Replace any such code
+                // unit with U+FFFD - handled the same as the existing replacement-character case below -
+                // and retry once on the now well-formed text.
+                normalized = SanitizeUnpairedSurrogates(text).Normalize(NormalizationForm.FormD);
+            }
+
             var builder = new StringBuilder(normalized.Length);
             var pendingSeparator = false;
 
-            foreach (var ch in normalized)
+            foreach (var rune in normalized.EnumerateRunes())
             {
-                var category = CharUnicodeInfo.GetUnicodeCategory(ch);
+                var category = Rune.GetUnicodeCategory(rune);
 
                 if (stripDiacritics &&
                     (category == UnicodeCategory.NonSpacingMark ||
@@ -146,7 +181,7 @@ namespace NzbDrone.Core.Utilities
                     continue;
                 }
 
-                if (ch == '\uFFFD')
+                if (rune.Value == '\uFFFD')
                 {
                     if (preserveWhitespace && builder.Length > 0)
                     {
@@ -156,19 +191,19 @@ namespace NzbDrone.Core.Utilities
                     continue;
                 }
 
-                if (char.IsLetterOrDigit(ch))
+                if (Rune.IsLetterOrDigit(rune))
                 {
                     if (preserveWhitespace && pendingSeparator && builder.Length > 0 && builder[builder.Length - 1] != ' ')
                     {
                         builder.Append(' ');
                     }
 
-                    builder.Append(char.ToLowerInvariant(ch));
+                    builder.Append(Rune.ToLowerInvariant(rune).ToString());
                     pendingSeparator = false;
                     continue;
                 }
 
-                if (preserveWhitespace && IsSeparator(ch, category) && builder.Length > 0)
+                if (preserveWhitespace && IsSeparator(rune, category) && builder.Length > 0)
                 {
                     pendingSeparator = true;
                 }
@@ -184,9 +219,37 @@ namespace NzbDrone.Core.Utilities
             return CollapseWhitespaceRegex.Replace(result, " ").Trim();
         }
 
-        private static bool IsSeparator(char ch, UnicodeCategory category)
+        // Replaces any UTF-16 code unit that isn't part of a valid surrogate pair with U+FFFD, so that
+        // callers can safely pass the result to String.Normalize() without it throwing on ill-formed
+        // input (Chaptarr/chaptarr#116). Leaves well-formed text (including valid surrogate pairs)
+        // completely untouched.
+        private static string SanitizeUnpairedSurrogates(string text)
         {
-            if (char.IsWhiteSpace(ch))
+            StringBuilder sanitized = null;
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                var ch = text[i];
+                var isWellFormed = char.IsHighSurrogate(ch)
+                    ? i + 1 < text.Length && char.IsLowSurrogate(text[i + 1])
+                    : !char.IsLowSurrogate(ch) || (i > 0 && char.IsHighSurrogate(text[i - 1]));
+
+                if (isWellFormed)
+                {
+                    sanitized?.Append(ch);
+                    continue;
+                }
+
+                sanitized ??= new StringBuilder(text, 0, i, text.Length);
+                sanitized.Append('\uFFFD');
+            }
+
+            return sanitized?.ToString() ?? text;
+        }
+
+        private static bool IsSeparator(Rune rune, UnicodeCategory category)
+        {
+            if (Rune.IsWhiteSpace(rune))
             {
                 return true;
             }


### PR DESCRIPTION
## What

Fixes #116. `UnicodeComparisonNormalizer.NormalizeWordsWithSourceSpans` iterated a string one UTF-16 code unit at a time and called `.Normalize(NormalizationForm.FormD)` on each unit alone. Any character outside the Basic Multilingual Plane (an emoji, or a character like a CJK Extension B ideograph) is a surrogate pair in .NET strings — normalizing one half in isolation throws `ArgumentException: String contains invalid Unicode code points`, since a lone surrogate isn't well-formed UTF-16 on its own. This is a real, valid character being torn in half by the per-code-unit loop, not malformed input.

This crashes `ReleaseTitleMatchScorer.TokenizeWithSpans`, which `DownloadDecisionMaker` calls per report while matching RSS releases (`BuildContradictoryVariants` tokenizes both the release title and the matched author's full catalog titles). The per-report `catch` in `GetBookDecisions` turns the crash into a permanent, non-bypassable rejection (`"Unexpected error processing release"`), so any release whose title — or a title in the author's catalog it gets compared against — contains such a character can never be grabbed, silently. (I initially thought this could abort matching for the whole RSS batch; that was wrong, see the correction comment on #116 — it's scoped to the one report.)

## Fix

- Walk the input by Unicode scalar value (consuming full surrogate pairs via `char.IsHighSurrogate`/`char.IsLowSurrogate`) instead of by UTF-16 code unit, so a supplementary-plane character normalizes as a whole instead of being split. Source-span tracking (used to map normalized tokens back to original release-title offsets) merges the two spans of a pair into one.
- Switched character classification from `char`/`CharUnicodeInfo` to `System.Text.Rune` (`Rune.IsLetterOrDigit`, `Rune.GetUnicodeCategory`, `Rune.ToLowerInvariant`) so a supplementary-plane letter is recognized as a letter instead of being silently dropped (a lone surrogate half is never `IsLetterOrDigit`). One side effect worth calling out: a supplementary-plane *symbol* (e.g. an emoji) sitting directly between two letters with no surrounding whitespace is now correctly treated as a word boundary — previously it vanished without inserting one (`"ab🔥cd"` → `"abcd"` before, `"ab cd"` now). Covered by a new test.
- A genuinely unpaired/lone surrogate (actual ill-formed input, not a valid character) is sanitized to `U+FFFD` via a new `SanitizeUnpairedSurrogates` helper — reusing the method's existing replacement-character handling — instead of crashing. `NormalizeWordsWithSourceSpans` sanitizes up front (it's length-preserving, so the source-span indices stay valid); `NormalizeInternal` (backing `NormalizeKey`/`NormalizeWords`) had the same latent whole-string-`Normalize()` bug and gets a try/sanitize-and-retry fallback instead, since that path isn't on the RSS-matching hot loop and the common case shouldn't pay for a sanitize scan it doesn't need.

## Known limitation, not fixed here

`ReleaseTitleMatchScorer`'s `TokenRegex` (`[\p{L}\p{Nd}]+`) matches per UTF-16 code unit, and .NET regex doesn't recognize a surrogate pair as `\p{L}` even when it's a real letter — so a supplementary-plane *letter* embedded in a release title still won't survive tokenization as part of a token (e.g. `Tokenize("abc𠀀def")` still splits into two tokens rather than one). It no longer crashes, which is the actual reported bug, but full round-trip fidelity for supplementary-plane letters through the regex tokenizer would need a separate change to the tokenizer itself. Flagging so it isn't mistaken for solved by this PR.

## Testing

Added regression tests in `UnicodeComparisonNormalizerFixture` and `ReleaseTitleMatchScorerFixture` covering: an emoji no longer crashing (`NormalizeWords`, `NormalizeWordsWithSourceSpans`, and end-to-end `ReleaseTitleMatchScorer.Tokenize`), a genuinely unpaired surrogate no longer crashing, a real supplementary-plane letter (U+20000) being preserved through `NormalizeWords`, the word-boundary behavior change for an adjacent symbol called out above, and the source-span merging for a surrogate pair (asserted by value, not just "doesn't throw").

Full suite: `dotnet test src/Chaptarr.Core.Test/Chaptarr.Core.Test.csproj` → 2859 passed, 0 failed, 1 skipped (pre-existing, unrelated).

Independently reviewed (fresh-context Opus pass) before opening this PR — findings incorporated: removed the per-scalar try/catch on the RSS-matching hot path in favor of sanitizing once up front (same fix, one code path, no exception-as-control-flow); added value-asserting tests in place of `DoesNotThrow`-only ones; corrected the issue's understanding of blast radius (see comment on #116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNX9Y1DFRRTsVFXG6aYoHH
