### PR TITLE
feature: calibre content server connector

### DIFF
--- a/frontend/src/Book/Details/BookDetails.js
+++ b/frontend/src/Book/Details/BookDetails.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import AuthorHistoryTable from 'Author/History/AuthorHistoryTable';
 import DeleteBookModal from 'Book/Delete/DeleteBookModal';
@@ -117,7 +117,10 @@ class BookDetails extends Component {
       nextBook,
       hasBookNavigation,
       isSearching,
+      isRePushing,
+      showRePush,
       onRefreshPress,
+      onRePushPress,
       onSearchPress,
       statistics = {}
     } = this.props;
@@ -171,6 +174,22 @@ class BookDetails extends Component {
             />
 
             <PageToolbarSeparator />
+
+            {
+              showRePush ?
+                <Fragment>
+                  <PageToolbarButton
+                    label={translate('ResendToCalibre')}
+                    title={translate('ResendToCalibreContentServerConnections')}
+                    iconName={icons.EXPORT}
+                    isSpinning={isRePushing}
+                    onPress={onRePushPress}
+                  />
+
+                  <PageToolbarSeparator />
+                </Fragment> :
+                null
+            }
 
             <PageToolbarButton
               label={translate('Edit')}
@@ -400,6 +419,8 @@ BookDetails.propTypes = {
   isSaving: PropTypes.bool.isRequired,
   isRefreshing: PropTypes.bool,
   isSearching: PropTypes.bool,
+  isRePushing: PropTypes.bool,
+  showRePush: PropTypes.bool,
   isFetching: PropTypes.bool,
   isPopulated: PropTypes.bool,
   bookFilesError: PropTypes.object,
@@ -413,6 +434,7 @@ BookDetails.propTypes = {
   isSmallScreen: PropTypes.bool.isRequired,
   onMonitorTogglePress: PropTypes.func.isRequired,
   onRefreshPress: PropTypes.func,
+  onRePushPress: PropTypes.func,
   onSearchPress: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Book/Details/BookDetails.js
+++ b/frontend/src/Book/Details/BookDetails.js
@@ -182,6 +182,7 @@ class BookDetails extends Component {
                     label={translate('ResendToCalibre')}
                     title={translate('ResendToCalibreContentServerConnections')}
                     iconName={icons.EXPORT}
+                    isDisabled={!hasBookFiles}
                     isSpinning={isRePushing}
                     onPress={onRePushPress}
                   />

--- a/frontend/src/Book/Details/BookDetailsConnector.js
+++ b/frontend/src/Book/Details/BookDetailsConnector.js
@@ -11,6 +11,7 @@ import { executeCommand } from 'Store/Actions/commandActions';
 import { clearEditions, fetchEditions } from 'Store/Actions/editionActions';
 import { clearQueueDetails, fetchQueueDetails } from 'Store/Actions/queueActions';
 import { cancelFetchReleases, clearReleases } from 'Store/Actions/releaseActions';
+import { fetchNotifications } from 'Store/Actions/settingsActions';
 import createAllAuthorSelector from 'Store/Selectors/createAllAuthorsSelector';
 import createCommandsSelector from 'Store/Selectors/createCommandsSelector';
 import createDimensionsSelector from 'Store/Selectors/createDimensionsSelector';
@@ -51,7 +52,8 @@ function createMapStateToProps() {
     createCommandsSelector(),
     createUISettingsSelector(),
     createDimensionsSelector(),
-    (bookId, bookFiles, books, editions, authors, commands, uiSettings, dimensions) => {
+    (state) => state.settings.notifications.items,
+    (bookId, bookFiles, books, editions, authors, commands, uiSettings, dimensions, notifications) => {
       try {
         const book = books.items.find((b) => b.id === bookId);
 
@@ -106,6 +108,13 @@ function createMapStateToProps() {
         isSearchingCommand.body.bookIds &&
         isSearchingCommand.body.bookIds.indexOf(book.id) > -1
         );
+        const rePushCommand = findCommand(commands, { name: commandNames.REPUSH_BOOK });
+        const isRePushing = !!(
+          rePushCommand &&
+        isCommandExecuting(rePushCommand) &&
+        rePushCommand.body &&
+        rePushCommand.body.bookId === book.id
+        );
         const isRenamingFiles = isCommandExecuting(findCommand(commands, { name: commandNames.RENAME_FILES, authorId: author.id }));
         const isRenamingAuthorCommand = findCommand(commands, { name: commandNames.RENAME_AUTHOR });
         const isRenamingAuthor = (
@@ -140,6 +149,8 @@ function createMapStateToProps() {
           author,
           isRefreshing,
           isSearching,
+          isRePushing,
+          showRePush: notifications.some((n) => n.implementation === 'CalibreContentServer'),
           isRenamingFiles,
           isRenamingAuthor,
           isFetching,
@@ -163,6 +174,7 @@ function createMapStateToProps() {
 
 const mapDispatchToProps = {
   executeCommand,
+  fetchNotifications,
   fetchBookFiles,
   clearBookFiles,
   fetchEditions,
@@ -228,6 +240,7 @@ class BookDetailsConnector extends Component {
     this.props.fetchBookFiles({ bookId });
     this.props.fetchEditions({ bookId });
     this.props.fetchQueueDetails({ bookIds: [bookId] });
+    this.props.fetchNotifications();
   };
 
   unpopulate = () => {
@@ -245,6 +258,13 @@ class BookDetailsConnector extends Component {
     this.props.toggleBooksMonitored({
       bookIds: [this.props.id],
       monitored
+    });
+  };
+
+  onRePushPress = () => {
+    this.props.executeCommand({
+      name: commandNames.REPUSH_BOOK,
+      bookId: this.props.id
     });
   };
 
@@ -271,6 +291,7 @@ class BookDetailsConnector extends Component {
         {...this.props}
         onMonitorTogglePress={this.onMonitorTogglePress}
         onRefreshPress={this.onRefreshPress}
+        onRePushPress={this.onRePushPress}
         onSearchPress={this.onSearchPress}
       />
     );
@@ -295,6 +316,7 @@ BookDetailsConnector.propTypes = {
   clearReleases: PropTypes.func.isRequired,
   cancelFetchReleases: PropTypes.func.isRequired,
   toggleBooksMonitored: PropTypes.func.isRequired,
+  fetchNotifications: PropTypes.func.isRequired,
   executeCommand: PropTypes.func.isRequired
 };
 

--- a/frontend/src/Book/Editor/BookEditorFooter.js
+++ b/frontend/src/Book/Editor/BookEditorFooter.js
@@ -1,9 +1,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import * as commandNames from 'Commands/commandNames';
 import SelectInput from 'Components/Form/SelectInput';
 import SpinnerButton from 'Components/Link/SpinnerButton';
 import PageContentFooter from 'Components/Page/PageContentFooter';
 import { kinds } from 'Helpers/Props';
+import { executeCommand } from 'Store/Actions/commandActions';
+import { fetchNotifications } from 'Store/Actions/settingsActions';
+import createCommandExecutingSelector from 'Store/Selectors/createCommandExecutingSelector';
 import translate from 'Utilities/String/translate';
 import BookEditorFooterLabel from './BookEditorFooterLabel';
 import DeleteBookModal from './Delete/DeleteBookModal';
@@ -28,6 +33,10 @@ class BookEditorFooter extends Component {
       isConfirmMoveModalOpen: false,
       destinationRootFolder: null
     };
+  }
+
+  componentDidMount() {
+    this.props.fetchNotifications();
   }
 
   componentDidUpdate(prevProps) {
@@ -64,6 +73,13 @@ class BookEditorFooter extends Component {
     }
   };
 
+  onResendToCalibrePress = () => {
+    this.props.executeCommand({
+      name: commandNames.REPUSH_BOOK,
+      bookIds: this.props.bookIds
+    });
+  };
+
   onDeleteSelectedPress = () => {
     this.setState({ isDeleteBookModalOpen: true });
   };
@@ -80,7 +96,9 @@ class BookEditorFooter extends Component {
       bookIds,
       selectedCount,
       isSaving,
-      isDeleting
+      isDeleting,
+      isResendingToCalibre,
+      showResendToCalibre
     } = this.props;
 
     const {
@@ -119,6 +137,20 @@ class BookEditorFooter extends Component {
             />
 
             <div className={styles.buttons}>
+              {
+                showResendToCalibre ?
+                  <SpinnerButton
+                    className={styles.organizeSelectedButton}
+                    kind={kinds.WARNING}
+                    isSpinning={isResendingToCalibre}
+                    isDisabled={!selectedCount || isResendingToCalibre}
+                    onPress={this.onResendToCalibrePress}
+                  >
+                    {translate('ResendToCalibre')}
+                  </SpinnerButton> :
+                  null
+              }
+
               <SpinnerButton
                 className={styles.deleteSelectedButton}
                 kind={kinds.DANGER}
@@ -144,6 +176,10 @@ class BookEditorFooter extends Component {
 }
 
 BookEditorFooter.propTypes = {
+  isResendingToCalibre: PropTypes.bool.isRequired,
+  showResendToCalibre: PropTypes.bool.isRequired,
+  executeCommand: PropTypes.func.isRequired,
+  fetchNotifications: PropTypes.func.isRequired,
   bookIds: PropTypes.arrayOf(PropTypes.number).isRequired,
   selectedCount: PropTypes.number.isRequired,
   isSaving: PropTypes.bool.isRequired,
@@ -153,4 +189,13 @@ BookEditorFooter.propTypes = {
   onSaveSelected: PropTypes.func.isRequired
 };
 
-export default BookEditorFooter;
+const selectIsResendingToCalibre = createCommandExecutingSelector(commandNames.REPUSH_BOOK);
+
+function mapStateToProps(state) {
+  return {
+    isResendingToCalibre: selectIsResendingToCalibre(state),
+    showResendToCalibre: state.settings.notifications.items.some((n) => n.implementation === 'CalibreContentServer')
+  };
+}
+
+export default connect(mapStateToProps, { executeCommand, fetchNotifications })(BookEditorFooter);

--- a/frontend/src/Commands/commandNames.js
+++ b/frontend/src/Commands/commandNames.js
@@ -12,6 +12,7 @@ export const DOWNLOADED_BOOKS_SCAN = 'DownloadedBooksScan';
 export const BOOK_SEARCH = 'BookSearch';
 export const INTERACTIVE_IMPORT = 'ManualImport';
 export const MISSING_BOOK_SEARCH = 'MissingBookSearch';
+export const REPUSH_BOOK = 'RePushBook';
 export const MOVE_AUTHOR = 'MoveAuthor';
 export const REFRESH_AUTHOR = 'RefreshAuthor';
 export const BULK_REFRESH_AUTHOR = 'BulkRefreshAuthor';

--- a/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
+++ b/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
@@ -25,7 +25,6 @@ namespace NzbDrone.Core.Books.Calibre
         public decimal Rating { get; set; }
         public Dictionary<string, string> Identifiers { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
-        // Omitted when null so a push cannot erase a series calibre-web learned on its own.
         public string Series { get; set; }
         [JsonProperty("series_index")]
         public double? SeriesIndex { get; set; }

--- a/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
+++ b/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Books.Calibre
         public decimal Rating { get; set; }
         public Dictionary<string, string> Identifiers { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        // Omitted when null so a push cannot erase a series calibre-web learned on its own.
         public string Series { get; set; }
         [JsonProperty("series_index")]
         public double? SeriesIndex { get; set; }

--- a/src/NzbDrone.Core/Localization/Core/en.json
+++ b/src/NzbDrone.Core/Localization/Core/en.json
@@ -1679,6 +1679,8 @@
   "RescanAfterRefreshHelpText": "Rescan the author folder after refreshing the author",
   "RescanAfterRefreshHelpTextWarning": "Chaptarr will not automatically detect changes to files when not set to 'Always",
   "RescanAuthorFolderAfterRefresh": "Rescan author folder after Refresh",
+  "ResendToCalibre": "Resend to Calibre",
+  "ResendToCalibreContentServerConnections": "Resend to Calibre Content Server Connections",
   "Reset": "Reset",
   "ResetAPIKey": "Reset API Key",
   "ResetAPIKeyMessageText": "Are you sure you want to reset your API Key?",

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -21,9 +21,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 {
     public class CalibreContentServer : NotificationBase<CalibreContentServerSettings>
     {
-        // BookFileAddedEvent also fires for tracked downloads, which push through
-        // OnReleaseImport on another handler thread; instances are transient, so the
-        // claim set is static and keyed per definition.
         private static readonly ConcurrentDictionary<string, DateTime> RecentlyPushedPaths = new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, (int MirrorId, DateTime Added)> RecentlyAddedMirrorIds = new ConcurrentDictionary<string, (int MirrorId, DateTime Added)>(StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan RecentPushWindow = TimeSpan.FromMinutes(5);
@@ -76,10 +73,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private void RemoveReplacedFormats(int calibreId, List<NzbDrone.Core.MediaFiles.BookFile> oldFiles, List<NzbDrone.Core.MediaFiles.BookFile> newFiles)
         {
-            // An upgrade must not delete and re-add the whole record - that would churn
-            // the calibre id and destroy whatever the server side attached to it. The
-            // new files overwrite their formats in place; only drop extensions the
-            // upgrade no longer provides.
             var newExtensions = newFiles
                 .Select(f => (Path.GetExtension(f?.Path) ?? string.Empty).TrimStart('.'))
                 .Where(e => e.IsNotNullOrWhiteSpace())
@@ -162,8 +155,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
             if (metadataOnly && mirrorBookId > 0)
             {
-                // Library edits only change the record; re-uploading every format on
-                // each refresh would send whole files for nothing.
                 SetCanonicalMetadata(mirrorBookId, book);
                 return true;
             }
@@ -204,8 +195,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
             try
             {
-                // Book id 0 never exists, so this exercises cdb write permissions
-                // without ever creating or touching a record.
+                // Book id 0 never exists, so this probes write permission without touching a record.
                 var request = BuildRequest("cdb/delete-books/0").Build();
                 var anonymousProbe = Settings.Username.IsNullOrWhiteSpace();
 
@@ -310,9 +300,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private int PushFile(int knownMirrorId, Book book, string path)
         {
-            // Formats of one book can arrive on different handler threads and adding is
-            // not idempotent, so resolving-or-adding the mirror record must be atomic
-            // per book and connection.
             lock (PushLocks[(uint)MirrorIdKey(book).GetHashCode() % PushLocks.Length])
             {
                 var mirrorId = knownMirrorId;
@@ -337,9 +324,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
                 if (added > 0)
                 {
-                    // A freshly added record carries the file's embedded metadata until the
-                    // canonical write lands, so a push in that window cannot find it by
-                    // author and title and would add the book again.
                     RecentlyAddedMirrorIds[MirrorIdKey(book)] = (added, DateTime.UtcNow);
                     SetCanonicalMetadata(added, book);
                 }
@@ -660,9 +644,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private static string[] TitleForms(string title)
         {
-            // A fully non-Latin title normalizes to an empty string; an empty form must
-            // never survive here, or every such title matches every other and the
-            // matches feed deletions.
+            // Empty forms must never survive; they would match every other non-Latin title.
             return new[] { Normalize(title), Normalize(Regex.Replace(title ?? string.Empty, @"\s*\([^)]*\)\s*$", "")) }
                 .Where(form => form.IsNotNullOrWhiteSpace())
                 .Distinct()
@@ -671,8 +653,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private static bool TitlesMatch(IEnumerable<string> bookForms, IEnumerable<string> recordForms)
         {
-            // Exact normalized equality only: suffix heuristics match sibling titles
-            // ("Foundation" vs "Second Foundation") and this result gates deletions.
+            // Exact equality only; this result gates deletions.
             return bookForms
                 .Where(form => form.IsNotNullOrWhiteSpace())
                 .Intersect(recordForms.Where(form => form.IsNotNullOrWhiteSpace()), StringComparer.Ordinal)

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -14,6 +14,7 @@ using NzbDrone.Common.Serializer;
 using NzbDrone.Core.Books;
 using NzbDrone.Core.Books.Calibre;
 using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Qualities;
 using NzbDrone.Core.RootFolders;
 
@@ -71,7 +72,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             }
         }
 
-        private void RemoveReplacedFormats(int calibreId, List<NzbDrone.Core.MediaFiles.BookFile> oldFiles, List<NzbDrone.Core.MediaFiles.BookFile> newFiles)
+        private void RemoveReplacedFormats(int calibreId, List<BookFile> oldFiles, List<BookFile> newFiles)
         {
             var newExtensions = newFiles
                 .Select(f => (Path.GetExtension(f?.Path) ?? string.Empty).TrimStart('.'))
@@ -125,7 +126,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             }
         }
 
-        public override void OnLibraryFileAdded(NzbDrone.Core.MediaFiles.BookFile bookFile, Book book)
+        public override void OnLibraryFileAdded(BookFile bookFile, Book book)
         {
             if (!QualityMediaTypeHelper.IsEbookFileQuality(bookFile.Quality.Quality))
             {
@@ -142,11 +143,9 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         public bool AcceptsExternalLibraryEdits => Settings.PushLibraryEdits;
 
-        // Applies an edit made in another library service (e.g. Grimmory) to the mirror
-        // record. Title and authors stay Chaptarr's - only the descriptive fields mirror the
-        // editing library, matching the calibre forwarder's identity rule. The changes dict is
-        // built by hand so absent fields are omitted rather than erased on the mirror.
-        public void PushExternalLibraryEdit(Book book, List<NzbDrone.Core.MediaFiles.BookFile> files, ExternalLibraryEditPayload payload)
+        // Title and authors stay Chaptarr's, matching the calibre forwarder's identity rule,
+        // and absent payload fields are left out so the mirror keeps what it already has.
+        public void PushExternalLibraryEdit(Book book, List<BookFile> files, ExternalLibraryEditPayload payload)
         {
             if (book == null || payload == null)
             {
@@ -233,7 +232,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             _logger.Debug("Forwarded external library edit of '{0}' to content server book {1}", book.Title, mirrorId);
         }
 
-        public bool RePush(Book book, List<NzbDrone.Core.MediaFiles.BookFile> files, bool metadataOnly = false)
+        public bool RePush(Book book, List<BookFile> files, bool metadataOnly = false)
         {
             try
             {
@@ -465,9 +464,21 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
                 var edition = book?.Editions?.FirstOrDefault(e => e.Monitored) ?? book?.Editions?.FirstOrDefault();
 
                 var identifiers = new Dictionary<string, string>();
-                if (edition?.Isbn13.IsNotNullOrWhiteSpace() == true) { identifiers["isbn"] = edition.Isbn13; }
-                if (edition?.Asin.IsNotNullOrWhiteSpace() == true) { identifiers["asin"] = edition.Asin; }
-                if (edition?.ForeignEditionId.IsNotNullOrWhiteSpace() == true) { identifiers["goodreads"] = edition.ForeignEditionId; }
+
+                if (edition?.Isbn13.IsNotNullOrWhiteSpace() == true)
+                {
+                    identifiers["isbn"] = edition.Isbn13;
+                }
+
+                if (edition?.Asin.IsNotNullOrWhiteSpace() == true)
+                {
+                    identifiers["asin"] = edition.Asin;
+                }
+
+                if (edition?.ForeignEditionId.IsNotNullOrWhiteSpace() == true)
+                {
+                    identifiers["goodreads"] = edition.ForeignEditionId;
+                }
 
                 var payload = new CalibreChangesPayload
                 {

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -19,7 +19,7 @@ using NzbDrone.Core.RootFolders;
 
 namespace NzbDrone.Core.Notifications.CalibreContentServer
 {
-    public class CalibreContentServer : NotificationBase<CalibreContentServerSettings>
+    public class CalibreContentServer : NotificationBase<CalibreContentServerSettings>, IExternalLibraryEditTarget
     {
         private static readonly ConcurrentDictionary<string, DateTime> RecentlyPushedPaths = new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, (int MirrorId, DateTime Added)> RecentlyAddedMirrorIds = new ConcurrentDictionary<string, (int MirrorId, DateTime Added)>(StringComparer.OrdinalIgnoreCase);
@@ -138,6 +138,99 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
             }
 
             PushFile(0, book, bookFile.Path);
+        }
+
+        public bool AcceptsExternalLibraryEdits => Settings.PushLibraryEdits;
+
+        // Applies an edit made in another library service (e.g. Grimmory) to the mirror
+        // record. Title and authors stay Chaptarr's - only the descriptive fields mirror the
+        // editing library, matching the calibre forwarder's identity rule. The changes dict is
+        // built by hand so absent fields are omitted rather than erased on the mirror.
+        public void PushExternalLibraryEdit(Book book, List<NzbDrone.Core.MediaFiles.BookFile> files, ExternalLibraryEditPayload payload)
+        {
+            if (book == null || payload == null)
+            {
+                return;
+            }
+
+            var mirrorId = RecentlyAddedMirrorId(book);
+
+            if (mirrorId == 0)
+            {
+                mirrorId = FindMirrorBookIds(book).Select(int.Parse).FirstOrDefault();
+            }
+
+            if (mirrorId == 0)
+            {
+                _logger.Debug("No content server record matches '{0}'; skipping external edit", book?.Title);
+                return;
+            }
+
+            var changes = new Dictionary<string, object>();
+
+            if (payload.Description.IsNotNullOrWhiteSpace())
+            {
+                changes["comments"] = payload.Description;
+            }
+
+            if (payload.Publisher.IsNotNullOrWhiteSpace())
+            {
+                changes["publisher"] = payload.Publisher;
+            }
+
+            if (payload.PublishedDate.HasValue)
+            {
+                changes["pubdate"] = payload.PublishedDate.Value;
+            }
+
+            if (payload.Languages?.Any() == true)
+            {
+                changes["languages"] = payload.Languages;
+            }
+
+            if (payload.Genres?.Any() == true)
+            {
+                changes["tags"] = payload.Genres;
+            }
+
+            if (payload.SeriesName.IsNotNullOrWhiteSpace())
+            {
+                changes["series"] = payload.SeriesName;
+
+                if (payload.SeriesPosition.HasValue)
+                {
+                    changes["series_index"] = payload.SeriesPosition.Value;
+                }
+            }
+
+            if (payload.Identifiers?.Any() == true)
+            {
+                changes["identifiers"] = payload.Identifiers;
+            }
+
+            if (payload.CoverBytes?.Length > 0 && CalibreImageValidator.IsValidImage(payload.CoverBytes))
+            {
+                changes["cover"] = Convert.ToBase64String(payload.CoverBytes);
+            }
+
+            if (!changes.Any())
+            {
+                return;
+            }
+
+            var body = new Dictionary<string, object>
+            {
+                { "changes", changes },
+                { "loaded_book_ids", new List<int> { mirrorId } }
+            };
+
+            var request = BuildRequest($"cdb/set-fields/{mirrorId}")
+                .SetHeader("Content-Type", "application/json")
+                .Build();
+            request.SetContent(body.ToJson());
+            _httpClient.Post(request);
+
+            _logger.Debug("Forwarded external library edit of '{0}' to content server book {1}", book.Title, mirrorId);
         }
 
         public bool RePush(Book book, List<NzbDrone.Core.MediaFiles.BookFile> files, bool metadataOnly = false)

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -27,6 +27,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
         private static readonly ConcurrentDictionary<string, DateTime> RecentlyPushedPaths = new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, (int MirrorId, DateTime Added)> RecentlyAddedMirrorIds = new ConcurrentDictionary<string, (int MirrorId, DateTime Added)>(StringComparer.OrdinalIgnoreCase);
         private static readonly TimeSpan RecentPushWindow = TimeSpan.FromMinutes(5);
+        private static readonly object[] PushLocks = Enumerable.Range(0, 16).Select(_ => new object()).ToArray();
 
         private readonly IHttpClient _httpClient;
         private readonly IRootFolderService _rootFolderService;
@@ -119,7 +120,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
         {
             if (Settings.SyncChanges)
             {
-                RecentlyAddedMirrorIds.TryRemove(MirrorIdKey(message.Book), out _);
                 DeleteBook(message.Book);
             }
         }
@@ -310,36 +310,42 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private int PushFile(int knownMirrorId, Book book, string path)
         {
-            var mirrorId = knownMirrorId;
-
-            if (mirrorId == 0)
+            // Formats of one book can arrive on different handler threads and adding is
+            // not idempotent, so resolving-or-adding the mirror record must be atomic
+            // per book and connection.
+            lock (PushLocks[(uint)MirrorIdKey(book).GetHashCode() % PushLocks.Length])
             {
-                mirrorId = RecentlyAddedMirrorId(book);
+                var mirrorId = knownMirrorId;
+
+                if (mirrorId == 0)
+                {
+                    mirrorId = RecentlyAddedMirrorId(book);
+                }
+
+                if (mirrorId == 0)
+                {
+                    mirrorId = FindMirrorBookIds(book).Select(int.Parse).FirstOrDefault();
+                }
+
+                if (mirrorId > 0)
+                {
+                    PushFormat(mirrorId, path);
+                    return mirrorId;
+                }
+
+                var added = AddBook(path);
+
+                if (added > 0)
+                {
+                    // A freshly added record carries the file's embedded metadata until the
+                    // canonical write lands, so a push in that window cannot find it by
+                    // author and title and would add the book again.
+                    RecentlyAddedMirrorIds[MirrorIdKey(book)] = (added, DateTime.UtcNow);
+                    SetCanonicalMetadata(added, book);
+                }
+
+                return added;
             }
-
-            if (mirrorId == 0)
-            {
-                mirrorId = FindMirrorBookIds(book).Select(int.Parse).FirstOrDefault();
-            }
-
-            if (mirrorId > 0)
-            {
-                PushFormat(mirrorId, path);
-                return mirrorId;
-            }
-
-            var added = AddBook(path);
-
-            if (added > 0)
-            {
-                // A freshly added record carries the file's embedded metadata until the
-                // canonical write lands, so a push in that window cannot find it by
-                // author and title and would add the book again.
-                RecentlyAddedMirrorIds[MirrorIdKey(book)] = (added, DateTime.UtcNow);
-                SetCanonicalMetadata(added, book);
-            }
-
-            return added;
         }
 
         private string MirrorIdKey(Book book)
@@ -497,6 +503,8 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         private void DeleteBook(Book book)
         {
+            RecentlyAddedMirrorIds.TryRemove(MirrorIdKey(book), out _);
+
             var matches = FindMirrorBookIds(book);
 
             if (matches.Any())
@@ -543,6 +551,7 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
                 }
                 else
                 {
+                    RecentlyAddedMirrorIds.TryRemove(MirrorIdKey(book), out _);
                     DeleteRecords(new List<string> { record.Key }, book.Title);
                 }
             }

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServer.cs
@@ -1,0 +1,709 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using FluentValidation.Results;
+using Newtonsoft.Json;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Common.Http;
+using NzbDrone.Common.Serializer;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.Books.Calibre;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.RootFolders;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class CalibreContentServer : NotificationBase<CalibreContentServerSettings>
+    {
+        // BookFileAddedEvent also fires for tracked downloads, which push through
+        // OnReleaseImport on another handler thread; instances are transient, so the
+        // claim set is static and keyed per definition.
+        private static readonly ConcurrentDictionary<string, DateTime> RecentlyPushedPaths = new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+        private static readonly ConcurrentDictionary<string, (int MirrorId, DateTime Added)> RecentlyAddedMirrorIds = new ConcurrentDictionary<string, (int MirrorId, DateTime Added)>(StringComparer.OrdinalIgnoreCase);
+        private static readonly TimeSpan RecentPushWindow = TimeSpan.FromMinutes(5);
+
+        private readonly IHttpClient _httpClient;
+        private readonly IRootFolderService _rootFolderService;
+        private readonly IMapCoversToLocal _coverMapper;
+        private readonly Logger _logger;
+
+        public CalibreContentServer(IHttpClient httpClient, IRootFolderService rootFolderService, IMapCoversToLocal coverMapper, Logger logger)
+        {
+            _httpClient = httpClient;
+            _rootFolderService = rootFolderService;
+            _coverMapper = coverMapper;
+            _logger = logger;
+        }
+
+        public override string Name => "Calibre Content Server";
+        public override string Link => "https://manual.calibre-ebook.com/server.html";
+
+        public override bool NotifyOnLibraryImports => Settings.PushLibraryImports;
+
+        public override void OnReleaseImport(BookDownloadMessage message)
+        {
+            var ebooks = message.BookFiles.Where(x => QualityMediaTypeHelper.IsEbookFileQuality(x.Quality.Quality)).ToList();
+
+            if (!ebooks.Any())
+            {
+                return;
+            }
+
+            var mirrorBookId = 0;
+
+            foreach (var file in ebooks)
+            {
+                if (!TryClaimPush(file.Path))
+                {
+                    continue;
+                }
+
+                mirrorBookId = PushFile(mirrorBookId, message.Book, file.Path);
+            }
+
+            if (Settings.SyncChanges && mirrorBookId > 0 && message.OldFiles?.Any() == true)
+            {
+                RemoveReplacedFormats(mirrorBookId, message.OldFiles, ebooks);
+            }
+        }
+
+        private void RemoveReplacedFormats(int calibreId, List<NzbDrone.Core.MediaFiles.BookFile> oldFiles, List<NzbDrone.Core.MediaFiles.BookFile> newFiles)
+        {
+            // An upgrade must not delete and re-add the whole record - that would churn
+            // the calibre id and destroy whatever the server side attached to it. The
+            // new files overwrite their formats in place; only drop extensions the
+            // upgrade no longer provides.
+            var newExtensions = newFiles
+                .Select(f => (Path.GetExtension(f?.Path) ?? string.Empty).TrimStart('.'))
+                .Where(e => e.IsNotNullOrWhiteSpace())
+                .ToList();
+
+            var staleExtensions = oldFiles
+                .Select(f => (Path.GetExtension(f?.Path) ?? string.Empty).TrimStart('.'))
+                .Where(e => e.IsNotNullOrWhiteSpace() && !newExtensions.Contains(e, StringComparer.OrdinalIgnoreCase))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach (var extension in staleExtensions)
+            {
+                try
+                {
+                    RemoveFormat(calibreId.ToString(), extension);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Unable to remove the stale {0} format from Calibre content server book {1}", extension, calibreId);
+                }
+            }
+        }
+
+        private bool TryClaimPush(string path)
+        {
+            var now = DateTime.UtcNow;
+
+            foreach (var stale in RecentlyPushedPaths.Where(p => now - p.Value > RecentPushWindow).Select(p => p.Key).ToList())
+            {
+                RecentlyPushedPaths.TryRemove(stale, out _);
+            }
+
+            return RecentlyPushedPaths.TryAdd($"{Definition.Id}:{path}", now);
+        }
+
+        public override void OnBookDelete(BookDeleteMessage message)
+        {
+            if (Settings.SyncChanges)
+            {
+                RecentlyAddedMirrorIds.TryRemove(MirrorIdKey(message.Book), out _);
+                DeleteBook(message.Book);
+            }
+        }
+
+        public override void OnBookFileDelete(BookFileDeleteMessage message)
+        {
+            if (Settings.SyncChanges && QualityMediaTypeHelper.IsEbookFileQuality(message.BookFile.Quality.Quality))
+            {
+                DeleteFormat(message.Book, message.BookFile.Path);
+            }
+        }
+
+        public override void OnLibraryFileAdded(NzbDrone.Core.MediaFiles.BookFile bookFile, Book book)
+        {
+            if (!QualityMediaTypeHelper.IsEbookFileQuality(bookFile.Quality.Quality))
+            {
+                return;
+            }
+
+            if (!TryClaimPush(bookFile.Path))
+            {
+                return;
+            }
+
+            PushFile(0, book, bookFile.Path);
+        }
+
+        public bool RePush(Book book, List<NzbDrone.Core.MediaFiles.BookFile> files, bool metadataOnly = false)
+        {
+            try
+            {
+                _coverMapper.EnsureBookCovers(book);
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Unable to reconcile the cover for {0} before resending", book?.Title);
+            }
+
+            var mirrorBookId = FindMirrorBookIds(book).Select(int.Parse).FirstOrDefault();
+
+            if (metadataOnly && mirrorBookId > 0)
+            {
+                // Library edits only change the record; re-uploading every format on
+                // each refresh would send whole files for nothing.
+                SetCanonicalMetadata(mirrorBookId, book);
+                return true;
+            }
+
+            foreach (var file in files)
+            {
+                mirrorBookId = PushFile(mirrorBookId, book, file.Path);
+            }
+
+            if (mirrorBookId > 0)
+            {
+                SetCanonicalMetadata(mirrorBookId, book);
+                return true;
+            }
+
+            return false;
+        }
+
+        public override void OnBookRetag(BookRetagMessage message)
+        {
+            if (Settings.SyncChanges && QualityMediaTypeHelper.IsEbookFileQuality(message.BookFile.Quality.Quality))
+            {
+                PushFile(0, message.Book, message.BookFile.Path);
+            }
+        }
+
+        public override ValidationResult Test()
+        {
+            var failures = new List<ValidationFailure>();
+
+            var conflictingRootFolder = FindSameServerRootFolder();
+
+            if (conflictingRootFolder != null)
+            {
+                failures.Add(new ValidationFailure("Url", $"This Calibre content server already backs the root folder '{conflictingRootFolder.Path}'. Chaptarr manages that library directly, so pushing to it again would create duplicates."));
+                return new ValidationResult(failures);
+            }
+
+            try
+            {
+                // Book id 0 never exists, so this exercises cdb write permissions
+                // without ever creating or touching a record.
+                var request = BuildRequest("cdb/delete-books/0").Build();
+                var anonymousProbe = Settings.Username.IsNullOrWhiteSpace();
+
+                if (anonymousProbe)
+                {
+                    request.Credentials = new NetworkCredential("chaptarr-connection-test", Guid.NewGuid().ToString("N"));
+                }
+
+                request.SuppressHttpError = true;
+                request.SetContent(Array.Empty<byte>());
+                var response = _httpClient.Post(request);
+
+                if (response.StatusCode == HttpStatusCode.Unauthorized)
+                {
+                    failures.Add(anonymousProbe
+                        ? new ValidationFailure("Username", "The content server requires authentication, enter a username and password")
+                        : new ValidationFailure("Username", "Authentication failed"));
+                }
+                else if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    failures.Add(new ValidationFailure("Username", "The content server does not accept anonymous changes, a username and password are required to push books"));
+                }
+                else if (response.StatusCode == HttpStatusCode.NotFound || ((int)response.StatusCode >= 300 && (int)response.StatusCode < 400))
+                {
+                    failures.Add(new ValidationFailure("Url", "Not a Calibre content server, check the URL"));
+                }
+                else if ((int)response.StatusCode >= 500)
+                {
+                    failures.Add(new ValidationFailure("Url", $"The content server returned {(int)response.StatusCode} to a Calibre API request"));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Unable to connect to Calibre content server");
+                failures.Add(new ValidationFailure("Url", "Unable to connect: " + ex.Message));
+            }
+
+            return new ValidationResult(failures);
+        }
+
+        private RootFolder FindSameServerRootFolder()
+        {
+            if (!Uri.TryCreate(Settings.Url, UriKind.Absolute, out var url))
+            {
+                return null;
+            }
+
+            var port = url.IsDefaultPort ? (url.Scheme == Uri.UriSchemeHttps ? 443 : 80) : url.Port;
+
+            return _rootFolderService.All()
+                .Where(f => f.IsCalibreLibrary && f.CalibreSettings != null && f.CalibreSettings.Host.IsNotNullOrWhiteSpace())
+                .FirstOrDefault(f => f.CalibreSettings.Port == port && HostsMatch(f.CalibreSettings.Host, url.Host));
+        }
+
+        private static bool HostsMatch(string a, string b)
+        {
+            if (a.Equals(b, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return IsLoopbackHost(a) && IsLoopbackHost(b);
+        }
+
+        private static bool IsLoopbackHost(string host)
+        {
+            if (host.IsNullOrWhiteSpace())
+            {
+                return false;
+            }
+
+            var trimmed = host.Trim().Trim('[', ']');
+
+            if (trimmed.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return IPAddress.TryParse(trimmed, out var ip) && IPAddress.IsLoopback(ip);
+        }
+
+        private int AddBook(string path)
+        {
+            var jobId = (int)(DateTime.UtcNow.Ticks % 1000000000);
+            var filename = Uri.EscapeDataString(Path.GetFileName(path));
+            var request = BuildRequest($"cdb/add-book/{jobId}/0/{filename}").Build();
+            request.SetContent(File.ReadAllBytes(path));
+
+            var response = _httpClient.Post<CalibreImportJob>(request).Resource;
+
+            if (response.Id == 0)
+            {
+                _logger.Info("Calibre content server reported {0} as a duplicate, skipped", path);
+            }
+            else
+            {
+                _logger.Debug("Pushed {0} to Calibre content server as book {1}", path, response.Id);
+            }
+
+            return response.Id;
+        }
+
+        private int PushFile(int knownMirrorId, Book book, string path)
+        {
+            var mirrorId = knownMirrorId;
+
+            if (mirrorId == 0)
+            {
+                mirrorId = RecentlyAddedMirrorId(book);
+            }
+
+            if (mirrorId == 0)
+            {
+                mirrorId = FindMirrorBookIds(book).Select(int.Parse).FirstOrDefault();
+            }
+
+            if (mirrorId > 0)
+            {
+                PushFormat(mirrorId, path);
+                return mirrorId;
+            }
+
+            var added = AddBook(path);
+
+            if (added > 0)
+            {
+                // A freshly added record carries the file's embedded metadata until the
+                // canonical write lands, so a push in that window cannot find it by
+                // author and title and would add the book again.
+                RecentlyAddedMirrorIds[MirrorIdKey(book)] = (added, DateTime.UtcNow);
+                SetCanonicalMetadata(added, book);
+            }
+
+            return added;
+        }
+
+        private string MirrorIdKey(Book book)
+        {
+            return $"{Definition.Id}:{book?.Id ?? 0}";
+        }
+
+        private int RecentlyAddedMirrorId(Book book)
+        {
+            var now = DateTime.UtcNow;
+
+            foreach (var stale in RecentlyAddedMirrorIds.Where(p => now - p.Value.Added > RecentPushWindow).Select(p => p.Key).ToList())
+            {
+                RecentlyAddedMirrorIds.TryRemove(stale, out _);
+            }
+
+            return RecentlyAddedMirrorIds.TryGetValue(MirrorIdKey(book), out var entry) ? entry.MirrorId : 0;
+        }
+
+        private void SetCanonicalMetadata(int calibreId, Book book)
+        {
+            var title = book?.Title;
+            var author = book?.Author?.Name;
+
+            if (title.IsNullOrWhiteSpace() && author.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            try
+            {
+                var serieslink = PickSeriesLink(book);
+                double? seriesIndex = null;
+
+                if (double.TryParse(serieslink?.Position, out var parsedIndex))
+                {
+                    seriesIndex = parsedIndex;
+                }
+
+                var edition = book?.Editions?.FirstOrDefault(e => e.Monitored) ?? book?.Editions?.FirstOrDefault();
+
+                var identifiers = new Dictionary<string, string>();
+                if (edition?.Isbn13.IsNotNullOrWhiteSpace() == true) { identifiers["isbn"] = edition.Isbn13; }
+                if (edition?.Asin.IsNotNullOrWhiteSpace() == true) { identifiers["asin"] = edition.Asin; }
+                if (edition?.ForeignEditionId.IsNotNullOrWhiteSpace() == true) { identifiers["goodreads"] = edition.ForeignEditionId; }
+
+                var payload = new CalibreChangesPayload
+                {
+                    LoadedBookIds = new List<int> { calibreId },
+                    Changes = new CalibreChanges
+                    {
+                        Title = title,
+                        Authors = author.IsNullOrWhiteSpace() ? null : new List<string> { author },
+                        Series = serieslink?.Series.Value.Title,
+                        SeriesIndex = seriesIndex,
+                        Cover = GetCanonicalCover(book),
+                        Comments = edition?.Overview,
+                        Publisher = edition?.Publisher,
+                        PubDate = book?.ReleaseDate,
+                        Tags = book?.Genres,
+                        Identifiers = identifiers.Any() ? identifiers : null
+                    }
+                };
+
+                var request = BuildRequest($"cdb/set-fields/{calibreId}")
+                    .SetHeader("Content-Type", "application/json")
+                    .Build();
+                request.SetContent(payload.ToJson());
+                _httpClient.Post(request);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warn(ex, "Unable to set canonical metadata on Calibre content server book {0}", calibreId);
+            }
+        }
+
+        private string GetCanonicalCover(Book book)
+        {
+            try
+            {
+                var edition = book?.Editions?.FirstOrDefault(e => e.Monitored) ?? book?.Editions?.FirstOrDefault();
+                var cover = edition?.Images?.FirstOrDefault(x => x.CoverType == MediaCoverTypes.Cover);
+
+                if (cover == null)
+                {
+                    return null;
+                }
+
+                var imageFile = _coverMapper.GetCoverPath(edition.BookId, MediaCoverEntity.Book, cover.CoverType, cover.Extension, null);
+
+                if (!File.Exists(imageFile))
+                {
+                    return null;
+                }
+
+                var imageData = File.ReadAllBytes(imageFile);
+
+                if (!CalibreImageValidator.IsValidImage(imageData))
+                {
+                    return null;
+                }
+
+                return Convert.ToBase64String(imageData);
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Unable to load canonical cover for {0}", book?.Title);
+                return null;
+            }
+        }
+
+        private static SeriesBookLink PickSeriesLink(Book book)
+        {
+            var links = book?.SeriesLinks?
+                .Where(x => x?.Series?.Value?.Title.IsNotNullOrWhiteSpace() == true)
+                .ToList();
+
+            if (links == null || links.Count == 0)
+            {
+                return null;
+            }
+
+            return links
+                .OrderBy(x => x.Series.Value.Title.Any(c => c > 127) ? 1 : 0)
+                .ThenByDescending(x => x.Series.Value.WorkCount)
+                .ThenBy(x => x.SeriesPosition)
+                .FirstOrDefault();
+        }
+
+        private void PushFormat(int calibreId, string path)
+        {
+            var payload = new CalibreChangesPayload
+            {
+                LoadedBookIds = new List<int> { calibreId },
+                Changes = new CalibreChanges
+                {
+                    AddedFormats = new List<CalibreAddFormat>
+                    {
+                        new CalibreAddFormat
+                        {
+                            Ext = Path.GetExtension(path),
+                            Data = Convert.ToBase64String(File.ReadAllBytes(path))
+                        }
+                    }
+                }
+            };
+
+            var request = BuildRequest($"cdb/set-fields/{calibreId}")
+                .SetHeader("Content-Type", "application/json")
+                .Build();
+            request.SetContent(payload.ToJson());
+            _httpClient.Post(request);
+            _logger.Debug("Pushed format {0} to Calibre content server book {1}", Path.GetExtension(path), calibreId);
+        }
+
+        private void DeleteBook(Book book)
+        {
+            var matches = FindMirrorBookIds(book);
+
+            if (matches.Any())
+            {
+                DeleteRecords(matches, book.Title);
+            }
+            else
+            {
+                _logger.Info("No matching book found on Calibre content server for {0}", book.Title);
+            }
+        }
+
+        private void DeleteFormat(Book book, string path)
+        {
+            var extension = (Path.GetExtension(path) ?? string.Empty).TrimStart('.');
+
+            if (extension.IsNullOrWhiteSpace())
+            {
+                return;
+            }
+
+            var records = FindMirrorBooks(book);
+
+            if (!records.Any())
+            {
+                _logger.Info("No matching book found on Calibre content server for {0}", book.Title);
+                return;
+            }
+
+            foreach (var record in records)
+            {
+                var formats = record.Value?.Formats?.Keys.ToList() ?? new List<string>();
+                var match = formats.FirstOrDefault(f => f.Equals(extension, StringComparison.OrdinalIgnoreCase));
+
+                if (match == null)
+                {
+                    _logger.Info("Calibre content server book {0} holds no {1} format, leaving it untouched", record.Key, extension);
+                    continue;
+                }
+
+                if (formats.Count > 1)
+                {
+                    RemoveFormat(record.Key, match);
+                }
+                else
+                {
+                    DeleteRecords(new List<string> { record.Key }, book.Title);
+                }
+            }
+        }
+
+        private void RemoveFormat(string calibreId, string extension)
+        {
+            if (!int.TryParse(calibreId, out var id))
+            {
+                return;
+            }
+
+            var payload = new CalibreChangesPayload
+            {
+                LoadedBookIds = new List<int> { id },
+                Changes = new CalibreChanges
+                {
+                    RemovedFormats = new List<string> { extension }
+                }
+            };
+
+            var request = BuildRequest($"cdb/set-fields/{id}")
+                .SetHeader("Content-Type", "application/json")
+                .Build();
+            request.SetContent(payload.ToJson());
+            _httpClient.Post(request);
+            _logger.Info("Removed the {0} format from Calibre content server book {1}", extension, id);
+        }
+
+        private void DeleteRecords(List<string> ids, string title)
+        {
+            _httpClient.Post(BuildRequest($"cdb/delete-books/{string.Join(",", ids)}").Build());
+            _logger.Info("Deleted book {0} from Calibre content server (calibre ids: {1})", title, string.Join(",", ids));
+        }
+
+        private List<string> FindMirrorBookIds(Book book)
+        {
+            return FindMirrorBooks(book).Select(x => x.Key).ToList();
+        }
+
+        private List<KeyValuePair<string, CalibreBookData>> FindMirrorBooks(Book book)
+        {
+            var author = book?.Author?.Name;
+
+            if (author.IsNullOrWhiteSpace() || book?.Title == null || book.Title.IsNullOrWhiteSpace())
+            {
+                return new List<KeyValuePair<string, CalibreBookData>>();
+            }
+
+            var query = Uri.EscapeDataString($"authors:\"={author.Replace("\"", "")}\"");
+            var searchRequest = BuildRequest($"ajax/search?query={query}").Build();
+            var ids = _httpClient.Get<CalibreSearchResult>(searchRequest).Resource.BookIds;
+
+            if (ids?.Any() != true)
+            {
+                _logger.Debug("No matching book found on Calibre content server for {0}", book.Title);
+                return new List<KeyValuePair<string, CalibreBookData>>();
+            }
+
+            var titles = TitleForms(book.Title);
+
+            if (titles.Length == 0)
+            {
+                _logger.Debug("Title '{0}' has no comparable normalized form, refusing to match by title", book.Title);
+                return new List<KeyValuePair<string, CalibreBookData>>();
+            }
+
+            var booksRequest = BuildRequest($"ajax/books?ids={string.Join(",", ids)}").Build();
+            var calibreBooks = _httpClient.Get<Dictionary<string, CalibreBookData>>(booksRequest).Resource;
+            var matches = calibreBooks.Where(x => x.Value != null && TitleForms(x.Value.Title).Intersect(titles).Any()).ToList();
+
+            if (!matches.Any())
+            {
+                matches = calibreBooks.Where(x => x.Value != null && TitlesMatch(titles, RecordTitleForms(x.Value))).ToList();
+            }
+
+            return matches;
+        }
+
+        private static IEnumerable<string> RecordTitleForms(CalibreBookData data)
+        {
+            var forms = new List<string>();
+
+            foreach (var title in new[] { data.Title, data.TitleSort })
+            {
+                if (title.IsNullOrWhiteSpace())
+                {
+                    continue;
+                }
+
+                forms.AddRange(TitleForms(title));
+
+                foreach (var segment in title.Split(new[] { " - " }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    var normalized = Normalize(segment);
+
+                    if (normalized.Length > 3 && !normalized.All(char.IsDigit))
+                    {
+                        forms.Add(normalized);
+                    }
+                }
+            }
+
+            return forms;
+        }
+
+        private static string[] TitleForms(string title)
+        {
+            // A fully non-Latin title normalizes to an empty string; an empty form must
+            // never survive here, or every such title matches every other and the
+            // matches feed deletions.
+            return new[] { Normalize(title), Normalize(Regex.Replace(title ?? string.Empty, @"\s*\([^)]*\)\s*$", "")) }
+                .Where(form => form.IsNotNullOrWhiteSpace())
+                .Distinct()
+                .ToArray();
+        }
+
+        private static bool TitlesMatch(IEnumerable<string> bookForms, IEnumerable<string> recordForms)
+        {
+            // Exact normalized equality only: suffix heuristics match sibling titles
+            // ("Foundation" vs "Second Foundation") and this result gates deletions.
+            return bookForms
+                .Where(form => form.IsNotNullOrWhiteSpace())
+                .Intersect(recordForms.Where(form => form.IsNotNullOrWhiteSpace()), StringComparer.Ordinal)
+                .Any();
+        }
+
+        private static string Normalize(string title)
+        {
+            return Regex.Replace(title?.ToLowerInvariant() ?? string.Empty, "[^a-z0-9]", "");
+        }
+
+        private HttpRequestBuilder BuildRequest(string relativePath)
+        {
+            var builder = new HttpRequestBuilder(HttpUri.CombinePath(Settings.Url, relativePath))
+                .Accept(HttpAccept.Json);
+
+            if (Settings.Username.IsNotNullOrWhiteSpace())
+            {
+                builder.NetworkCredential = new NetworkCredential(Settings.Username, Settings.Password);
+            }
+
+            return builder;
+        }
+
+        private class CalibreSearchResult
+        {
+            [JsonProperty("book_ids")]
+            public List<int> BookIds { get; set; }
+        }
+
+        private class CalibreBookData
+        {
+            [JsonProperty("title")]
+            public string Title { get; set; }
+
+            [JsonProperty("title_sort")]
+            public string TitleSort { get; set; }
+
+            [JsonProperty("format_metadata")]
+            public Dictionary<string, object> Formats { get; set; }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/CalibreContentServerSettings.cs
@@ -1,0 +1,47 @@
+using FluentValidation;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Annotations;
+using NzbDrone.Core.ThingiProvider;
+using NzbDrone.Core.Validation;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class CalibreContentServerSettingsValidator : AbstractValidator<CalibreContentServerSettings>
+    {
+        public CalibreContentServerSettingsValidator()
+        {
+            RuleFor(c => c.Url).NotEmpty().WithMessage("URL cannot be empty");
+            RuleFor(c => c.Url).IsValidUrl().When(c => c.Url.IsNotNullOrWhiteSpace());
+            RuleFor(c => c.Username).NotEmpty().When(c => c.Password.IsNotNullOrWhiteSpace());
+            RuleFor(c => c.Password).NotEmpty().When(c => c.Username.IsNotNullOrWhiteSpace());
+        }
+    }
+
+    public class CalibreContentServerSettings : IProviderConfig
+    {
+        private static readonly CalibreContentServerSettingsValidator Validator = new CalibreContentServerSettingsValidator();
+
+        [FieldDefinition(0, Label = "URL", HelpText = "Calibre content server URL, including http(s):// and port, e.g. http://localhost:8080", HelpTextWarning = "This connection functions as a one-way mirror: Chaptarr pushes books and its own deletions to this content server. Deleting a book on the content server itself is NOT reflected back into Chaptarr, and the book may be pushed to the server again later.")]
+        public string Url { get; set; }
+
+        [FieldDefinition(1, Label = "Username", Privacy = PrivacyLevel.UserName, HelpText = "Optional, only needed if the content server requires authentication")]
+        public string Username { get; set; }
+
+        [FieldDefinition(2, Label = "Password", Type = FieldType.Password, Privacy = PrivacyLevel.Password, HelpText = "Optional, only needed if the content server requires authentication")]
+        public string Password { get; set; }
+
+        [FieldDefinition(3, Label = "Allow Edits & Deletes", Type = FieldType.Checkbox, HelpText = "Allow Chaptarr to edit or delete matching books on the content server when books change in Chaptarr or are deleted from Chaptarr")]
+        public bool SyncChanges { get; set; }
+
+        [FieldDefinition(4, Label = "Push Library Scan Imports", Type = FieldType.Checkbox, HelpText = "Also push books that arrive via library scans, for example books added through calibre-web, to this content server")]
+        public bool PushLibraryImports { get; set; }
+
+        [FieldDefinition(5, Label = "Push Library Edits", Type = FieldType.Checkbox, HelpText = "When Chaptarr changes a book - a calibre push, a retag, or an edit - push the updated record to this content server")]
+        public bool PushLibraryEdits { get; set; }
+
+        public NzbDroneValidationResult Validate()
+        {
+            return new NzbDroneValidationResult(Validator.Validate(this));
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookCommand.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookCommand.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using NzbDrone.Core.Messaging.Commands;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class RePushBookCommand : Command
+    {
+        public int BookId { get; set; }
+
+        public List<int> BookIds { get; set; }
+
+        public bool FromLibraryEdit { get; set; }
+
+        public override bool SendUpdatesToClient => true;
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Messaging.Commands;
+using NzbDrone.Core.Qualities;
+using NzbDrone.Core.Messaging.Events;
+
+namespace NzbDrone.Core.Notifications.CalibreContentServer
+{
+    public class RePushBookService : IExecute<RePushBookCommand>, IHandle<MediaCoversUpdatedEvent>
+    {
+        private readonly IBookService _bookService;
+        private readonly IMediaFileService _mediaFileService;
+        private readonly INotificationFactory _notificationFactory;
+        private readonly IManageCommandQueue _commandQueueManager;
+        private readonly Logger _logger;
+
+        public RePushBookService(IBookService bookService,
+                                 IMediaFileService mediaFileService,
+                                 INotificationFactory notificationFactory,
+                                 IManageCommandQueue commandQueueManager,
+                                 Logger logger)
+        {
+            _bookService = bookService;
+            _mediaFileService = mediaFileService;
+            _notificationFactory = notificationFactory;
+            _commandQueueManager = commandQueueManager;
+            _logger = logger;
+        }
+
+        public void Handle(MediaCoversUpdatedEvent message)
+        {
+            // Check for a subscribed connector before queueing anything: this event fires
+            // after every author refresh and would otherwise fill the queue with no-ops.
+            if (!_notificationFactory.GetAvailableProviders()
+                    .OfType<CalibreContentServer>()
+                    .Any(c => ((CalibreContentServerSettings)c.Definition.Settings).PushLibraryEdits))
+            {
+                return;
+            }
+
+            if (message.Book != null && message.Book.Id > 0)
+            {
+                _commandQueueManager.Push(new RePushBookCommand { BookId = message.Book.Id, FromLibraryEdit = true });
+                return;
+            }
+
+            var author = message.Author;
+
+            if (author == null || author.Id <= 0)
+            {
+                return;
+            }
+
+            foreach (var book in _bookService.GetBooksByAuthor(author.Id))
+            {
+                if (book == null || book.Id <= 0)
+                {
+                    continue;
+                }
+
+                var hasEbookFiles = _mediaFileService.GetFilesByBook(book.Id)
+                    .Any(f => f.Path.IsNotNullOrWhiteSpace() && QualityMediaTypeHelper.IsEbookFileQuality(f.Quality.Quality));
+
+                if (hasEbookFiles)
+                {
+                    _commandQueueManager.Push(new RePushBookCommand { BookId = book.Id, FromLibraryEdit = true });
+                }
+            }
+        }
+
+        public void Execute(RePushBookCommand message)
+        {
+            var bookIds = message.BookIds != null && message.BookIds.Any()
+                ? message.BookIds.Where(id => id > 0).Distinct().ToList()
+                : new List<int> { message.BookId };
+
+            var connectors = _notificationFactory.GetAvailableProviders().OfType<CalibreContentServer>().ToList();
+
+            if (message.FromLibraryEdit)
+            {
+                connectors = connectors.Where(c => ((CalibreContentServerSettings)c.Definition.Settings).PushLibraryEdits).ToList();
+            }
+
+            if (!connectors.Any())
+            {
+                return;
+            }
+
+            foreach (var bookId in bookIds)
+            {
+                try
+                {
+                    RePushBook(bookId, connectors, message.FromLibraryEdit);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Unable to resend book {0} to the content server connections", bookId);
+                }
+            }
+        }
+
+        private void RePushBook(int bookId, List<CalibreContentServer> connectors, bool metadataOnly)
+        {
+            var book = _bookService.GetBook(bookId);
+
+            if (book == null)
+            {
+                return;
+            }
+
+            var files = _mediaFileService.GetFilesByBook(book.Id)
+                .Where(f => f.Path.IsNotNullOrWhiteSpace() && QualityMediaTypeHelper.IsEbookFileQuality(f.Quality.Quality))
+                .ToList();
+
+            if (!files.Any())
+            {
+                _logger.Info("No ebook files on disk for {0}, nothing to push", book.Title);
+                return;
+            }
+
+            var pushedConnectors = 0;
+
+            foreach (var connector in connectors)
+            {
+                if (connector.RePush(book, files, metadataOnly))
+                {
+                    pushedConnectors++;
+                }
+            }
+
+            if (pushedConnectors > 0)
+            {
+                _logger.Info("Re-pushed {0} to {1} of {2} content server connector(s)", book.Title, pushedConnectors, connectors.Count);
+            }
+            else
+            {
+                _logger.Info("No content server connector accepted {0}; nothing was matched or added", book.Title);
+            }
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
@@ -15,18 +15,21 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
     public class RePushBookService : IExecute<RePushBookCommand>, IHandle<MediaCoversUpdatedEvent>
     {
         private readonly IBookService _bookService;
+        private readonly IEditionService _editionService;
         private readonly IMediaFileService _mediaFileService;
         private readonly INotificationFactory _notificationFactory;
         private readonly IManageCommandQueue _commandQueueManager;
         private readonly Logger _logger;
 
         public RePushBookService(IBookService bookService,
+                                 IEditionService editionService,
                                  IMediaFileService mediaFileService,
                                  INotificationFactory notificationFactory,
                                  IManageCommandQueue commandQueueManager,
                                  Logger logger)
         {
             _bookService = bookService;
+            _editionService = editionService;
             _mediaFileService = mediaFileService;
             _notificationFactory = notificationFactory;
             _commandQueueManager = commandQueueManager;
@@ -123,6 +126,9 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
                 _logger.Info("No ebook files on disk for {0}, nothing to push", book.Title);
                 return;
             }
+
+            // EnsureBookCovers refuses to reconcile a cover without hydrated editions.
+            book.Editions = _editionService.GetEditionsByBook(book.Id);
 
             var pushedConnectors = 0;
 

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
@@ -7,8 +7,8 @@ using NzbDrone.Core.Books;
 using NzbDrone.Core.MediaCover;
 using NzbDrone.Core.MediaFiles;
 using NzbDrone.Core.Messaging.Commands;
-using NzbDrone.Core.Qualities;
 using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.Qualities;
 
 namespace NzbDrone.Core.Notifications.CalibreContentServer
 {

--- a/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
+++ b/src/NzbDrone.Core/Notifications/CalibreContentServer/RePushBookService.cs
@@ -38,8 +38,6 @@ namespace NzbDrone.Core.Notifications.CalibreContentServer
 
         public void Handle(MediaCoversUpdatedEvent message)
         {
-            // Check for a subscribed connector before queueing anything: this event fires
-            // after every author refresh and would otherwise fill the queue with no-ops.
             if (!_notificationFactory.GetAvailableProviders()
                     .OfType<CalibreContentServer>()
                     .Any(c => ((CalibreContentServerSettings)c.Definition.Settings).PushLibraryEdits))

--- a/src/NzbDrone.Core/Notifications/ExternalLibraryEdits.cs
+++ b/src/NzbDrone.Core/Notifications/ExternalLibraryEdits.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Notifications
+{
+    public class ExternalLibraryEditPayload
+    {
+        public string Title { get; set; }
+        public string Subtitle { get; set; }
+        public string Description { get; set; }
+        public string Publisher { get; set; }
+        public DateTime? PublishedDate { get; set; }
+        public string SeriesName { get; set; }
+        public double? SeriesPosition { get; set; }
+        public List<string> Languages { get; set; }
+        public List<string> Genres { get; set; }
+        public Dictionary<string, string> Identifiers { get; set; }
+        public string CoverUrl { get; set; }
+        public byte[] CoverBytes { get; set; }
+    }
+
+    // Seam between library-edit sources (e.g. the Grimmory forwarder) and connections able to
+    // mirror those edits outward. Sources discover targets via the notification factory, so a
+    // provider opts in simply by implementing this on top of NotificationBase; nothing here
+    // references a concrete provider, keeping each side independently mergeable.
+    public interface IExternalLibraryEditTarget
+    {
+        ProviderDefinition Definition { get; }
+        bool AcceptsExternalLibraryEdits { get; }
+        void PushExternalLibraryEdit(Book book, List<BookFile> files, ExternalLibraryEditPayload payload);
+    }
+}

--- a/src/NzbDrone.Core/Notifications/INotification.cs
+++ b/src/NzbDrone.Core/Notifications/INotification.cs
@@ -8,6 +8,7 @@ namespace NzbDrone.Core.Notifications
     public interface INotification : IProvider
     {
         string Link { get; }
+        bool NotifyOnLibraryImports { get; }
 
         void OnGrab(GrabMessage grabMessage);
         void OnReleaseImport(BookDownloadMessage message);
@@ -22,6 +23,7 @@ namespace NzbDrone.Core.Notifications
         void OnDownloadFailure(DownloadFailedMessage message);
         void OnImportFailure(BookDownloadMessage message);
         void OnBookRetag(BookRetagMessage message);
+        void OnLibraryFileAdded(BookFile bookFile, Book book);
         void ProcessQueue();
         bool HasPendingQueue { get; }
         bool SupportsOnGrab { get; }
@@ -39,5 +41,6 @@ namespace NzbDrone.Core.Notifications
         bool SupportsOnDownloadFailure { get; }
         bool SupportsOnImportFailure { get; }
         bool SupportsOnBookRetag { get; }
+        bool SupportsOnLibraryFileAdded { get; }
     }
 }

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -38,6 +38,8 @@ namespace NzbDrone.Core.Notifications
 
         public abstract string Name { get; }
 
+        public virtual bool NotifyOnLibraryImports => false;
+
         public Type ConfigContract => typeof(TSettings);
 
         public virtual ProviderMessage Message => null;
@@ -93,6 +95,10 @@ namespace NzbDrone.Core.Notifications
         {
         }
 
+        public virtual void OnLibraryFileAdded(NzbDrone.Core.MediaFiles.BookFile bookFile, NzbDrone.Core.Books.Book book)
+        {
+        }
+
         public virtual void OnBookRetag(BookRetagMessage message)
         {
         }
@@ -121,6 +127,7 @@ namespace NzbDrone.Core.Notifications
         public bool SupportsOnDownloadFailure => HasConcreteImplementation("OnDownloadFailure");
         public bool SupportsOnImportFailure => HasConcreteImplementation("OnImportFailure");
         public bool SupportsOnBookRetag => HasConcreteImplementation("OnBookRetag");
+        public bool SupportsOnLibraryFileAdded => HasConcreteImplementation("OnLibraryFileAdded");
         public bool SupportsOnApplicationUpdate => HasConcreteImplementation("OnApplicationUpdate");
 
         protected TSettings Settings => (TSettings)Definition.Settings;

--- a/src/NzbDrone.Core/Notifications/NotificationBase.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationBase.cs
@@ -95,7 +95,7 @@ namespace NzbDrone.Core.Notifications
         {
         }
 
-        public virtual void OnLibraryFileAdded(NzbDrone.Core.MediaFiles.BookFile bookFile, NzbDrone.Core.Books.Book book)
+        public virtual void OnLibraryFileAdded(BookFile bookFile, Book book)
         {
         }
 

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Notifications
           IHandle<AuthorDeletedEvent>,
           IHandle<BookDeletedEvent>,
           IHandle<BookFileDeletedEvent>,
+          IHandle<BookFileAddedEvent>,
           IHandle<HealthCheckFailedEvent>,
           IHandle<DownloadFailedEvent>,
           IHandle<BookImportIncompleteEvent>,
@@ -193,7 +194,9 @@ namespace NzbDrone.Core.Notifications
 
         public void Handle(BookImportedEvent message)
         {
-            if (!message.NewDownload)
+            var isLibraryImport = !message.NewDownload;
+
+            if (isLibraryImport && _notificationFactory.OnReleaseImportEnabled().All(n => !n.NotifyOnLibraryImports))
             {
                 _logger.Info("Skipping OnReleaseImport for '{0}' (BookId={1}): import was not from a tracked download",
                     message.Book?.Title ?? "<unknown>",
@@ -227,6 +230,11 @@ namespace NzbDrone.Core.Notifications
             {
                 try
                 {
+                    if (isLibraryImport && !notification.NotifyOnLibraryImports)
+                    {
+                        continue;
+                    }
+
                     if (ShouldHandleAuthor(notification.Definition, author))
                     {
                         if (downloadMessage.OldFiles.Empty() || ((NotificationDefinition)notification.Definition).OnUpgrade)
@@ -355,6 +363,72 @@ namespace NzbDrone.Core.Notifications
                 {
                     _notificationStatusService.RecordFailure(notification.Definition.Id);
                     _logger.Warn(ex, "Unable to send OnBookDelete notification to: " + notification.Definition.Name);
+                }
+            }
+        }
+
+        public void Handle(BookFileAddedEvent message)
+        {
+            var bookFile = message.BookFile;
+
+            if (bookFile?.Path == null || bookFile.EditionId <= 0)
+            {
+                return;
+            }
+
+            Book book = null;
+
+            try
+            {
+                book = bookFile.Edition?.Book;
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Unable to read the edition for {0}", bookFile.Path);
+            }
+
+            if (book == null)
+            {
+                book = _editionService.GetEdition(bookFile.EditionId)?.Book;
+            }
+
+            if (book == null)
+            {
+                return;
+            }
+
+            Author author = null;
+
+            try
+            {
+                author = book.Author ?? bookFile.Author;
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Unable to resolve the author for {0}", bookFile.Path);
+            }
+
+            foreach (var notification in _notificationFactory.OnReleaseImportEnabled())
+            {
+                if (!notification.NotifyOnLibraryImports)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (author != null && !ShouldHandleAuthor(notification.Definition, author))
+                    {
+                        continue;
+                    }
+
+                    notification.OnLibraryFileAdded(bookFile, book);
+                    _notificationStatusService.RecordSuccess(notification.Definition.Id);
+                }
+                catch (Exception ex)
+                {
+                    _notificationStatusService.RecordFailure(notification.Definition.Id);
+                    _logger.Warn(ex, "Unable to send library-file notification to: " + notification.Definition.Name);
                 }
             }
         }

--- a/src/NzbDrone.Core/Notifications/NotificationService.cs
+++ b/src/NzbDrone.Core/Notifications/NotificationService.cs
@@ -376,37 +376,14 @@ namespace NzbDrone.Core.Notifications
                 return;
             }
 
-            Book book = null;
-
-            try
-            {
-                book = bookFile.Edition?.Book;
-            }
-            catch (Exception ex)
-            {
-                _logger.Debug(ex, "Unable to read the edition for {0}", bookFile.Path);
-            }
-
-            if (book == null)
-            {
-                book = _editionService.GetEdition(bookFile.EditionId)?.Book;
-            }
+            var book = bookFile.Edition?.Book ?? _editionService.GetEdition(bookFile.EditionId)?.Book;
 
             if (book == null)
             {
                 return;
             }
 
-            Author author = null;
-
-            try
-            {
-                author = book.Author ?? bookFile.Author;
-            }
-            catch (Exception ex)
-            {
-                _logger.Debug(ex, "Unable to resolve the author for {0}", bookFile.Path);
-            }
+            var author = book.Author ?? bookFile.Author;
 
             foreach (var notification in _notificationFactory.OnReleaseImportEnabled())
             {


### PR DESCRIPTION
#### Description
Adds a Calibre Content Server notification connection that mirrors ebooks from Chaptarr to an external calibre content server. It's deliberately a one-way mirror: Chaptarr pushes books and its own deletions outward, but changes made on the content server are never pulled back, and a book deleted there may be pushed again later. The settings help text states this explicitly, since that asymmetry is the main thing a user needs to understand.

Fixes # — n/a (feature)

#### Related External PRs
CWA: https://github.com/crocodilestick/Calibre-Web-Automated/pull/1530
CWA-NG: https://github.com/new-usemame/Calibre-Web-NextGen/pull/2210

#### Database Migration
NO. Connection settings live in the notification definition's existing JSON settings blob; no schema change.

#### How was this tested?
Docker (linux/amd64) on an Ubuntu server host, image built with Dockerfile.build. The mirror target was a separate calibre Docker container running its content server, configured as a connection in Chaptarr.

Scenarios ran against the live setup:
1. Import → push
Added a book in Chaptarr and let it download; on import it was pushed into the calibre content server.
2. Book delete → mirrored
Deleting the book in Chaptarr removed the corresponding record from the content server.
3. File delete → mirrored
Deleting the pushed book file in Chaptarr likewise removed it from the content server.
4. Deletes gated
With Allow Edits & Deletes disabled, the record was left in place on the content server instead of being removed.
5. One-way mirror confirmed
Deleting the book directly in calibre did not remove it from Chaptarr — the book remained tracked, as documented.
6. Re-push re-adds
The Re-push action on the book page sent the book back into the content server after it had been removed there.
7. Re-push is idempotent
Running Re-push again on a book already present did not create a duplicate record — the existing record was matched and updated.


#### Screenshots (UI changes only)

<img width="720" height="1185" alt="image" src="https://github.com/user-attachments/assets/01cf7178-5c59-40ab-b59c-04511dd3a5f6" />

<img width="815" height="645" alt="image" src="https://github.com/user-attachments/assets/3e3a658a-b30e-469e-9505-84bdf164e321" />
