### PR TITLE
UI: Fix input placeholder contrast and focus styling in dark mode

### DIFF
--- a/frontend/src/Author/Details/FilterSearchInput.css
+++ b/frontend/src/Author/Details/FilterSearchInput.css
@@ -21,16 +21,22 @@
   padding-left: 38px;
   padding-right: 30px;
   height: 35px;
-  border-radius: 20px;
   border: 1px solid var(--inputBorderColor);
+  border-radius: 20px;
   background-color: var(--inputBackgroundColor);
+  color: var(--textColor);
   transition: all 0.2s ease-in-out;
+
+  &::placeholder {
+    color: var(--gray);
+    opacity: 1;
+  }
 }
 
 .searchInput:focus {
+  outline: 0;
   border-color: var(--inputFocusBorderColor);
   box-shadow: 0 0 0 1px var(--inputFocusBorderColor);
-  background-color: var(--white);
 }
 
 .clearIcon {

--- a/frontend/src/Components/Form/Input.css
+++ b/frontend/src/Components/Form/Input.css
@@ -8,6 +8,11 @@
   box-shadow: inset 0 1px 1px var(--inputBoxShadowColor);
   color: var(--textColor);
 
+  &::placeholder {
+    color: var(--gray);
+    opacity: 1;
+  }
+
   &:focus {
     outline: 0;
     border-color: var(--inputFocusBorderColor);

--- a/frontend/src/Styles/scaffolding.css
+++ b/frontend/src/Styles/scaffolding.css
@@ -37,6 +37,12 @@ textarea {
   line-height: 1.528571429; /* 20/14 */
 }
 
+input::placeholder,
+textarea::placeholder {
+  color: var(--gray);
+  opacity: 1;
+}
+
 /* Better defaults for unordererd lists */
 
 ul {


### PR DESCRIPTION
## Problem
In dark mode, the author details filter search input rendered dark grey placeholder text on a `#333` dark grey background, causing poor contrast and making it difficult to read. It also abruptly flashed white when focused.

## Change summary
- Added placeholder styling (`color: var(--gray); opacity: 1;`) to `FilterSearchInput.css`, `Input.css`, and global `scaffolding.css`.
- Added `color: var(--textColor);` and removed `background-color: var(--white);` on focus in `FilterSearchInput.css`.

## Screenshots

### Original
<img width="647" height="61" alt="Screenshot 2026-09-04 at 7 17 04 pm" src="https://github.com/user-attachments/assets/a309d82b-870a-4e76-bf5e-086897121a38" />

<img width="649" height="68" alt="Screenshot 2026-09-04 at 7 25 09 pm" src="https://github.com/user-attachments/assets/068f4576-b77b-4fd8-b45f-37bb59bfba69" />

### Fixed
<img width="648" height="62" alt="Screenshot 2026-09-04 at 7 19 35 pm" src="https://github.com/user-attachments/assets/ca2cf58d-adb6-4ab3-90d7-8d07087744fb" />

<img width="645" height="64" alt="Screenshot 2026-09-04 at 7 24 33 pm" src="https://github.com/user-attachments/assets/60950a3d-8420-4da7-9d60-47822312c021" />

## Testing summary
- Built and tested frontend against live Chaptarr backend.
- Verified placeholder contrast and text input in both Dark and Light modes.
- Verified on Author Details page switching between Audiobook and eBook views.
- Verified that focusing the search input maintains the dark mode theme background.