### PR TITLE
UI: Adjust "Add New" search bar layout and provider dropdown caret styling

### DIFF
--- a/frontend/src/Search/AddNewItem.css
+++ b/frontend/src/Search/AddNewItem.css
@@ -19,30 +19,53 @@
 .searchInput {
   composes: input from '~Components/Form/TextInput.css';
 
-  height: 46px;
-  border-radius: 0;
-  font-size: 18px;
   flex: 1;
-}
 
-.providerSelect {
   height: 46px;
-  width: 140px;
-  margin-left: 10px;
-  font-size: 18px;
-  border: 1px solid var(--inputBorderColor);
   border-radius: 0;
-  background-color: var(--inputBackgroundColor);
-  color: var(--textColor);
-  padding: 0 16px;
+  font-size: 18px;
 }
 
 .clearLookupButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 46px;
+  height: 46px;
   border: 1px solid var(--inputBorderColor);
   border-left: none;
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  border-radius: 4px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  box-shadow: inset 0 1px 1px var(--inputBoxShadowColor);
+}
+
+.providerSelectContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-left: 10px;
+}
+
+.providerSelect {
+  composes: input from '~Components/Form/Input.css';
+
+  padding-right: 40px;
+  padding-left: 16px;
+  width: auto;
+  height: 46px;
+  font-size: 18px;
+  cursor: pointer;
+  appearance: none;
+}
+
+.providerSelectIcon {
+  position: absolute;
+  right: 16px;
+  color: var(--textColor);
+  font-size: 14px;
+  pointer-events: none;
 }
 
 .message {
@@ -69,25 +92,25 @@
 
 .filterButtons {
   display: flex;
-  gap: 10px;
+  justify-content: center;
   margin-top: 20px;
   margin-bottom: 20px;
-  justify-content: center;
+  gap: 10px;
 }
 
 .filterButtons button {
   padding: 8px 16px;
   border: 1px solid var(--inputBorderColor);
-  background-color: var(--inputBackgroundColor);
   border-radius: 4px;
+  background-color: var(--inputBackgroundColor);
   font-size: 14px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .filterButtons button:hover:not(:disabled) {
-  background-color: var(--inputHoverBackgroundColor);
   border-color: var(--themeLightColor);
+  background-color: var(--inputHoverBackgroundColor);
 }
 
 .filterButtons button:disabled {
@@ -96,7 +119,7 @@
 }
 
 .activeFilter {
+  border-color: var(--themeLightColor) !important;
   background-color: var(--themeLightColor) !important;
   color: var(--white) !important;
-  border-color: var(--themeLightColor) !important;
 }

--- a/frontend/src/Search/AddNewItem.css.d.ts
+++ b/frontend/src/Search/AddNewItem.css.d.ts
@@ -8,6 +8,8 @@ interface CssExports {
   'message': string;
   'noResults': string;
   'providerSelect': string;
+  'providerSelectContainer': string;
+  'providerSelectIcon': string;
   'searchContainer': string;
   'searchIconContainer': string;
   'searchInput': string;

--- a/frontend/src/Search/AddNewItem.js
+++ b/frontend/src/Search/AddNewItem.js
@@ -220,14 +220,6 @@ class AddNewItem extends Component {
               onKeyPress={this.onSearchKeyPress}
             />
 
-            <SelectInput
-              className={styles.providerSelect}
-              name="provider"
-              value={selectedProvider}
-              values={metadataProviders}
-              onChange={this.onProviderChange}
-            />
-
             <Button
               className={styles.clearLookupButton}
               onPress={this.onClearSearchPress}
@@ -237,6 +229,20 @@ class AddNewItem extends Component {
                 size={20}
               />
             </Button>
+
+            <div className={styles.providerSelectContainer}>
+              <SelectInput
+                className={styles.providerSelect}
+                name="provider"
+                value={selectedProvider}
+                values={metadataProviders}
+                onChange={this.onProviderChange}
+              />
+              <Icon
+                className={styles.providerSelectIcon}
+                name={icons.CARET_DOWN}
+              />
+            </div>
           </div>
 
           {


### PR DESCRIPTION
## Problem
On the Add New screen in the UI, the search bar elements were awkwardly arranged:
- The search text box clear button ("X") was placed after the metadata provider dropdown (Goodreads / Audiobooks / Hardcover) rather than directly attached to the search input it clears.
- The provider dropdown was sandwiched between the search input and the clear button instead of appearing as a separate filter control to the right.
- The provider dropdown caret (arrow) was positioned right up against the right border of the box due to native select rendering and fixed width constraints, leaving awkward spacing.

## Change summary
- **Reordered search input controls**: Moved the clear button (`.clearLookupButton`) to attach directly to the right side of the search text input (`.searchInput`), forming a cohesive search box group with the search icon.
- **Separated provider dropdown**: Positioned the metadata provider dropdown (`.providerSelect`) to the right of the search input group with standard spacing and full border radius.
- **Customized dropdown caret**:
  - Replaced native select arrow with a styled FontAwesome caret down icon (`icons.CARET_DOWN`) with `pointer-events: none`.
  - Set `appearance: none` on the select input to hide the browser-default menulist arrow.
  - Positioned the caret 16px from the right edge with generous right padding (`padding-right: 40px`) to prevent text overlap and balance with the 16px left padding.
  - Allowed dynamic width sizing (`width: auto`) instead of a fixed width.

## Screenshots

### Before
<img width="1284" height="70" alt="Screenshot 2026-09-04 at 7 38 50 pm" src="https://github.com/user-attachments/assets/61459558-8668-4e05-a7de-61188d2dbb65" />

### After
<img width="1288" height="69" alt="Screenshot 2026-09-04 at 7 54 00 pm" src="https://github.com/user-attachments/assets/a5cd60cf-4312-42a3-b6bd-02b88dc59c1f" />

## Test summary
- Built production frontend bundle with Webpack (`yarn build`) and ran TypeScript typecheck (`yarn typecheck`).
- Deployed and tested UI changes live on a local Chaptarr container instance.
- Verified search input, typing, enter/submit, clear button ("X") functionality, provider selection dropdown, and visual layout/caret alignment across themes.