### PR TITLE
Don't move ebook files when no colocated destination applies

### DIFF
--- a/src/Chaptarr.Core.Test/MediaFiles/BookFileMovingServiceFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/BookFileMovingServiceFixture.cs
@@ -291,6 +291,52 @@ namespace Chaptarr.Core.Test.MediaFiles
             Assert.That(plan.DestinationPath, Is.EqualTo(colocatedPath));
             Assert.That(plan.DestinationAuthorFolderPath, Is.EqualTo(sourceAuthorFolder));
             Assert.That(plan.ShouldUpdateStoredAuthorPath, Is.False);
+            Assert.That(plan.ColocationApplied, Is.True);
+        }
+
+        [Test]
+        public void should_not_flag_colocation_when_planner_declines()
+        {
+            var rootFolder = @"C:\ebooks".AsOsAgnostic();
+            var sourceAuthorFolder = Path.Combine(rootFolder, "George R. R. Martin");
+            var fileNameBuilder = DispatchProxy.Create<IBuildFileNames, BuildFileNamesProxy>();
+            var fileNameProxy = (BuildFileNamesProxy)(object)fileNameBuilder;
+            fileNameProxy.AuthorFolderFactory = (_, _) => "George R.R. Martin";
+            fileNameProxy.BookFileNameFactory = (_, _, _, _) => Path.Combine("Wild Cards", "file");
+            var namingConfigService = DispatchProxy.Create<INamingConfigService, NamingConfigServiceProxy>();
+            var colocationPlanner = DispatchProxy.Create<IEbookColocationPlanner, ColocatingPlannerProxy>();
+            ((ColocatingPlannerProxy)(object)colocationPlanner).PlanResult =
+                EbookColocationPlan.Skipped(EbookColocationSkipReason.RootNotMixedOrDisabled, cleanupReplicas: true);
+            var service = CreateService(
+                fileNameBuilder,
+                namingConfigService,
+                ebookColocationPlanner: colocationPlanner);
+            var author = new Author
+            {
+                Id = 1,
+                Name = "George R.R. Martin",
+                EbookRootFolderPath = rootFolder,
+                EbookPath = sourceAuthorFolder
+            };
+            var bookFile = new BookFile
+            {
+                Path = Path.Combine(sourceAuthorFolder, "Wild Cards", "original.epub"),
+                EditionId = 7,
+                Edition = new Edition
+                {
+                    Id = 7,
+                    BookId = 42,
+                    Book = new Book { Id = 42, AuthorId = author.Id }
+                },
+                Quality = new QualityModel(Quality.EPUB),
+                MediaType = "ebook"
+            };
+
+            var plan = service.GetOrganizeDestination(bookFile, author, false);
+
+            Assert.That(plan.CanOrganize, Is.True);
+            Assert.That(plan.ColocationApplied, Is.False);
+            Assert.That(plan.DestinationPath, Is.EqualTo(Path.Combine(sourceAuthorFolder, "Wild Cards", "file.epub")));
         }
 
         [Test]

--- a/src/Chaptarr.Core.Test/MediaFiles/EbookColocateOnAudiobookImportHandlerFixture.cs
+++ b/src/Chaptarr.Core.Test/MediaFiles/EbookColocateOnAudiobookImportHandlerFixture.cs
@@ -131,23 +131,31 @@ namespace Chaptarr.Core.Test.MediaFiles
         private sealed class StubBookFileMover : IMoveBookFiles
         {
             private readonly Func<BookFile, string> _destinationFactory;
+            private readonly bool _colocationApplied;
 
-            public StubBookFileMover(Func<BookFile, string> destinationFactory)
+            public StubBookFileMover(Func<BookFile, string> destinationFactory, bool colocationApplied = true)
             {
                 _destinationFactory = destinationFactory;
+                _colocationApplied = colocationApplied;
             }
+
+            public List<BookFile> Moved { get; } = new();
 
             public BookFileMovePlan GetOrganizeDestination(BookFile bookFile, Author author, bool moveToCanonicalAuthorFolder, RenameBatchContext renameBatchContext = null)
             {
+                // Mirror the real service in that ReplicaPaths is populated only when colocation applied.
                 return new BookFileMovePlan
                 {
                     CanOrganize = true,
+                    ColocationApplied = _colocationApplied,
+                    ReplicaPaths = _colocationApplied ? new List<string>() : null,
                     DestinationPath = _destinationFactory(bookFile)
                 };
             }
 
             public BookFile MoveBookFile(BookFile bookFile, Author author, BookFileMovePlan plan, RenameBatchContext renameBatchContext = null)
             {
+                Moved.Add(bookFile);
                 bookFile.Path = plan.DestinationPath;
                 return bookFile;
             }
@@ -232,7 +240,23 @@ namespace Chaptarr.Core.Test.MediaFiles
             Assert.That(context.Events.Events, Is.Empty);
         }
 
-        private static TestContext CreateContext(Func<BookFile, string> destinationFactory, bool includeMobi = false)
+        [Test]
+        public void should_not_move_ebook_when_no_colocated_destination_applies()
+        {
+            // The planner declines to colocate (separate ebook-only root, or the feature disabled on that root),
+            // so the plan carries the plain naming destination. This handler must leave the file alone rather
+            // than re-organizing a file that was not part of the audiobook import.
+            var context = CreateContext(_ => "/library/Author/Series/Book/Book.epub", colocationApplied: false);
+
+            context.Handler.Handle(context.Event);
+
+            Assert.That(context.EbookFile.Path, Is.EqualTo("/library/Author/Book/Book.epub"));
+            Assert.That(context.BookFileMover.Moved, Is.Empty);
+            Assert.That(context.MediaFileService.Updated, Is.Empty);
+            Assert.That(context.Events.Events, Is.Empty);
+        }
+
+        private static TestContext CreateContext(Func<BookFile, string> destinationFactory, bool includeMobi = false, bool colocationApplied = true)
         {
             var author = new Author
             {
@@ -289,6 +313,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             mediaFileService.FilesByBook[ebookBook.Id] = ebookFiles;
 
             var events = new StubEventAggregator();
+            var bookFileMover = new StubBookFileMover(destinationFactory, colocationApplied);
 
             var handler = new EbookColocateOnAudiobookImportHandler(
                 new StubRootFolderService(new RootFolder
@@ -300,7 +325,7 @@ namespace Chaptarr.Core.Test.MediaFiles
                 }),
                 bookService,
                 mediaFileService,
-                new StubBookFileMover(destinationFactory),
+                bookFileMover,
                 DiskWith(ebookFiles.Select(f => f.Path).ToArray()),
                 events,
                 LogManager.GetCurrentClassLogger());
@@ -316,7 +341,8 @@ namespace Chaptarr.Core.Test.MediaFiles
                 ebookFile,
                 ebookFiles,
                 mediaFileService,
-                events);
+                events,
+                bookFileMover);
         }
 
         private static IDiskProvider DiskWith(params string[] existingFiles)
@@ -338,6 +364,7 @@ namespace Chaptarr.Core.Test.MediaFiles
             BookFile EbookFile,
             List<BookFile> EbookFiles,
             StubMediaFileService MediaFileService,
-            StubEventAggregator Events);
+            StubEventAggregator Events,
+            StubBookFileMover BookFileMover);
     }
 }

--- a/src/NzbDrone.Core/MediaFiles/BookFileMovingService.cs
+++ b/src/NzbDrone.Core/MediaFiles/BookFileMovingService.cs
@@ -39,6 +39,16 @@ namespace NzbDrone.Core.MediaFiles
         public bool ShouldCleanupReplicas { get; set; }
         public bool ShouldUpdateStoredAuthorPath { get; set; }
 
+        /// <summary>
+        /// True when the destination was chosen by the ebook colocation planner (i.e. the file is being
+        /// placed alongside an audiobook of the same work) rather than by the standard naming format.
+        /// This is the single source of truth for "this plan is a colocation": it selects the colocating
+        /// branch in <see cref="BookFileMovingService.MoveBookFile(BookFile, Author, BookFileMovePlan, RenameBatchContext)"/>,
+        /// and <see cref="ReplicaPaths"/> is populated only when it is set. Callers whose only mandate is
+        /// colocation must not move files when this is false.
+        /// </summary>
+        public bool ColocationApplied { get; set; }
+
         public static BookFileMovePlan Skipped(string reason)
         {
             return new BookFileMovePlan
@@ -166,7 +176,8 @@ namespace NzbDrone.Core.MediaFiles
                 DestinationPath = destinationPath,
                 ReplicaPaths = colocationPlan.Applies ? colocationPlan.ReplicaPaths : null,
                 ShouldCleanupReplicas = colocationPlan.ShouldCleanupReplicas,
-                ShouldUpdateStoredAuthorPath = moveToCanonicalAuthorFolder && !colocationPlan.Applies
+                ShouldUpdateStoredAuthorPath = moveToCanonicalAuthorFolder && !colocationPlan.Applies,
+                ColocationApplied = colocationPlan.Applies
             };
         }
 
@@ -184,7 +195,7 @@ namespace NzbDrone.Core.MediaFiles
                 throw new InvalidOperationException(plan.SkipReason);
             }
 
-            if (plan.ReplicaPaths != null)
+            if (plan.ColocationApplied)
             {
                 EnsureBookFolder(bookFile, author, edition.Book, plan.DestinationPath, plan.DestinationAuthorFolderPath);
                 _logger.Debug("Colocating ebook file: {0} to {1}", bookFile, plan.DestinationPath);

--- a/src/NzbDrone.Core/MediaFiles/EbookColocateOnAudiobookImportHandler.cs
+++ b/src/NzbDrone.Core/MediaFiles/EbookColocateOnAudiobookImportHandler.cs
@@ -117,6 +117,17 @@ namespace NzbDrone.Core.MediaFiles
                             continue;
                         }
 
+                        // This handler exists solely to colocate ebooks with audiobooks. When the planner did not
+                        // produce a colocated destination (for example the ebook lives under a separate ebook-only
+                        // root, or that root has the feature disabled), the plan falls back to the plain naming
+                        // destination. Moving the file then would be a full re-organize of a file that was never
+                        // part of this import, so leave it where the user has it.
+                        if (!plan.ColocationApplied)
+                        {
+                            _logger.Debug("Skipping ebook colocation for {0}: no colocated destination applies for this file.", previousPath);
+                            continue;
+                        }
+
                         _bookFileMover.MoveBookFile(ebookFile, author, plan);
                         _mediaFileService.Update(ebookFile);
 


### PR DESCRIPTION
Fixes #126.

`EbookColocateOnAudiobookImportHandler` exists solely to place ebook files alongside a just-imported audiobook of the same work. It moved a file whenever `GetOrganizeDestination` returned `CanOrganize`, but that is true whether or not the colocation planner actually applied: when the planner declines, the plan still carries the plain naming destination, and the handler relocated the ebook to it. That is a full re-organize of a file that was never part of the triggering import.

The two gates disagree by construction. The handler resolves its root from the audiobook's quality, the planner resolves its root from the ebook's quality, and `Author.GetRootFolderForQuality` returns a different root per media type. `AuthorService.IsCompatibleRootFolder` allows an author to have a Mixed audiobook root and a separate ebook only root, and `RootFolderResource` forces `PlaceEbooksWithAudiobooks = false` on any non Mixed root, so that configuration is guaranteed to pass the handler's gate and fail the planner's. `NoAudiobookFolders` is reachable the same way.

In that state `MoveBookFile` also took its non colocation branch, whose unconditional `TransferFile` throws `SameFilenameException` for a file already at its canonical path. The handler's `try/catch` sits outside the per file loop and nothing on this path catches that exception, so one already correct ebook aborted the whole batch under the generic "Failed to colocate ebooks after audiobook import" warning.

## Change

Surface whether colocation was applied on `BookFileMovePlan` and skip the move when it was not.

`ColocationApplied` is also now the single source of truth for "this plan is a colocation" and selects the colocating branch in `MoveBookFile`, replacing the previous `plan.ReplicaPaths != null` check that encoded the same fact implicitly. Those two were provably equivalent for every plan reaching `MoveBookFile` in production (two construction sites, two callers, and the planner's single `Applies = true` site always assigns a non null list), so this is behavior preserving and removes an unsynchronized second encoding rather than adding one. The colocating branch is null tolerant either way, since `ReconcileReplicaFiles` null coalesces its argument.

`RenameBookFileService` is unaffected: it reads only `CanOrganize`, `DestinationPath`, `SkipReason`, the author folder paths and `ShouldUpdateStoredAuthorPath`.

## Tests

`should_not_move_ebook_when_no_colocated_destination_applies` hands the handler a plan where colocation did not apply and asserts no move, no `Update`, and no events. It fails on current develop and passes with the change.

`should_not_flag_colocation_when_planner_declines` pins the flag on the real `BookFileMovingService` with a declining planner, asserting `CanOrganize` stays true while `ColocationApplied` is false, so `RenameBookFileService`'s behavior is explicitly unchanged. The existing colocation test gained the positive assertion.

Full `Chaptarr.Core.Test` suite: 3010 passed, 0 failed.

## Known deferral

Because the handler now returns before `MoveBookFile`, it no longer triggers the `ShouldCleanupReplicas` path in the declined case, so an ebook carrying stale `ReplicaPaths` from an earlier colocation is no longer pruned opportunistically during an unrelated audiobook import. That cleanup still happens via `RenameBookFileService` and via `GetImportDestinationPath` on the next import of that file. This seemed like correct scoping for a handler whose mandate is colocation rather than general organizing, but happy to restore an explicit cleanup only path here if you would rather keep it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfnN7ewDrDq99e4LvzCzaW
