### PR TITLE
feature: abs propagation

### DIFF
--- a/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
+++ b/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
@@ -18,6 +18,81 @@ namespace Chaptarr.Core.Test.Notifications.AudioBookShelf
     public class AudioBookShelfTargetedUpdatesFixture
     {
         [Test]
+        public void cover_event_push_should_not_overwrite_item_metadata()
+        {
+            var proxy = BuildPushProxy();
+            var subject = CreatePushSubject(proxy);
+
+            subject.PushBooksCovers(BuildPushableBook());
+
+            Assert.That(proxy.MetadataUpdates, Is.Empty);
+        }
+
+        [Test]
+        public void library_edit_push_should_still_send_item_metadata()
+        {
+            var proxy = BuildPushProxy();
+            var subject = CreatePushSubject(proxy);
+
+            subject.PushBooksMetadata(BuildPushableBook());
+
+            Assert.That(proxy.MetadataUpdates, Is.EqualTo(new[] { "item-1" }));
+        }
+
+        private static FakeAudioBookShelfProxy BuildPushProxy()
+        {
+            return new FakeAudioBookShelfProxy
+            {
+                Libraries = new List<AudioBookShelfLibrary>
+                {
+                    BuildLibrary("library-audio", "folder-audio", "/abs/audio", disableWatcher: false)
+                },
+                Items = new List<AudioBookShelfLibraryItemSummary>
+                {
+                    new AudioBookShelfLibraryItemSummary
+                    {
+                        Id = "item-1",
+                        RelPath = "Joe Abercrombie/The Blade Itself"
+                    }
+                }
+            };
+        }
+
+        private static NzbDrone.Core.Notifications.AudioBookShelf.AudioBookShelf CreatePushSubject(FakeAudioBookShelfProxy proxy)
+        {
+            return CreateSubject(proxy, new List<RootFolder>
+            {
+                new RootFolder { Id = 1, Path = "/audiobooks", FolderType = FolderType.Audiobook }
+            }, new List<AudioBookShelfLibraryMapping>
+            {
+                new AudioBookShelfLibraryMapping
+                {
+                    RootFolderId = 1,
+                    MediaType = "audiobook",
+                    LibraryId = "library-audio",
+                    LibraryFolderId = "folder-audio",
+                    LibraryFolderPath = "/abs/audio"
+                }
+            });
+        }
+
+        private static List<(Book Book, List<BookFile> Files)> BuildPushableBook()
+        {
+            return new List<(Book Book, List<BookFile> Files)>
+            {
+                (new Book { Title = "The Blade Itself", MediaType = BookMediaType.Audiobook },
+                 new List<BookFile>
+                 {
+                     new BookFile
+                     {
+                         Path = "/audiobooks/Joe Abercrombie/The Blade Itself/The Blade Itself.m4b",
+                         MediaType = "audiobook"
+                     }
+                 })
+            };
+        }
+
+        [Test]
         public void should_send_targeted_add_for_mapped_import()
         {
             var proxy = new FakeAudioBookShelfProxy
@@ -404,9 +479,15 @@ namespace Chaptarr.Core.Test.Notifications.AudioBookShelf
                 return Libraries;
             }
 
-            public List<AudioBookShelfLibraryItemSummary> GetLibraryItems(AudioBookShelfSettings settings, string libraryId) => new List<AudioBookShelfLibraryItemSummary>();
+            public List<AudioBookShelfLibraryItemSummary> Items { get; set; } = new List<AudioBookShelfLibraryItemSummary>();
+            public List<string> MetadataUpdates { get; } = new List<string>();
+
+            public List<AudioBookShelfLibraryItemSummary> GetLibraryItems(AudioBookShelfSettings settings, string libraryId) => Items;
             public void ScanItem(AudioBookShelfSettings settings, string itemId) { }
-            public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata) { }
+            public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata)
+            {
+                MetadataUpdates.Add(itemId);
+            }
             public void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath) { }
             public void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName) { }
             public void PurgeCoverCache(AudioBookShelfSettings settings) { }

--- a/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
+++ b/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
@@ -409,6 +409,7 @@ namespace Chaptarr.Core.Test.Notifications.AudioBookShelf
             public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata) { }
             public void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath) { }
             public void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName) { }
+            public void PurgeCoverCache(AudioBookShelfSettings settings) { }
             public void RemoveItemsWithIssues(AudioBookShelfSettings settings, string libraryId) { }
         }
 

--- a/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
+++ b/src/Chaptarr.Core.Test/Notifications/AudioBookShelf/AudioBookShelfTargetedUpdatesFixture.cs
@@ -324,6 +324,8 @@ namespace Chaptarr.Core.Test.Notifications.AudioBookShelf
                 pendingProviderSecretService: new PendingProviderSecretService(new CacheManager()),
                 cacheManager: new CacheManager(),
                 rootFolderService: new FakeRootFolderService(rootFolders),
+                bookService: null,
+                editionService: null,
                 logger: LogManager.GetLogger("AudioBookShelfTargetedUpdatesFixture"))
             {
                 Definition = new NotificationDefinition
@@ -401,6 +403,13 @@ namespace Chaptarr.Core.Test.Notifications.AudioBookShelf
                 GetLibrariesCallCount++;
                 return Libraries;
             }
+
+            public List<AudioBookShelfLibraryItemSummary> GetLibraryItems(AudioBookShelfSettings settings, string libraryId) => new List<AudioBookShelfLibraryItemSummary>();
+            public void ScanItem(AudioBookShelfSettings settings, string itemId) { }
+            public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata) { }
+            public void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath) { }
+            public void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName) { }
+            public void RemoveItemsWithIssues(AudioBookShelfSettings settings, string libraryId) { }
         }
 
         private class FakeRootFolderService : IRootFolderService

--- a/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
+++ b/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
@@ -25,7 +25,6 @@ namespace NzbDrone.Core.Books.Calibre
         public decimal Rating { get; set; }
         public Dictionary<string, string> Identifiers { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
-        // Omitted when null so a push cannot erase a series calibre-web learned on its own.
         public string Series { get; set; }
         [JsonProperty("series_index")]
         public double? SeriesIndex { get; set; }

--- a/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
+++ b/src/NzbDrone.Core/Books/Calibre/Resources/CalibreChanges.cs
@@ -25,6 +25,7 @@ namespace NzbDrone.Core.Books.Calibre
         public decimal Rating { get; set; }
         public Dictionary<string, string> Identifiers { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Include)]
+        // Omitted when null so a push cannot erase a series calibre-web learned on its own.
         public string Series { get; set; }
         [JsonProperty("series_index")]
         public double? SeriesIndex { get; set; }

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -24,7 +24,7 @@ using NzbDrone.Core.ThingiProvider;
 
 namespace NzbDrone.Core.Notifications.AudioBookShelf
 {
-    public class AudioBookShelf : NotificationBase<AudioBookShelfSettings>, IResolveProviderPendingSecrets
+    public class AudioBookShelf : NotificationBase<AudioBookShelfSettings>, IResolveProviderPendingSecrets, IExternalLibraryEditTarget
     {
         private readonly IAudioBookShelfProxy _proxy;
         private readonly IHttpClient _httpClient;
@@ -298,6 +298,87 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 SeriesPosition = book.SeriesPosition,
                 Genres = book.Genres ?? new List<string>()
             };
+        }
+
+        public bool AcceptsExternalLibraryEdits => Settings.PushLibraryEdits;
+
+        // Applies an edit made in another library service (e.g. Grimmory) to the matching
+        // items. Title stays Chaptarr's, mirroring the calibre forwarder's identity rule.
+        public void PushExternalLibraryEdit(Book book, List<BookFile> files, ExternalLibraryEditPayload payload)
+        {
+            if (book == null || payload == null || files == null || files.Count == 0)
+            {
+                return;
+            }
+
+            var mappings = Settings.GetLibraryMappings();
+
+            if (mappings.Count == 0)
+            {
+                return;
+            }
+
+            var metadata = new AudioBookShelfItemMetadata
+            {
+                Title = book.Title,
+                Description = payload.Description,
+                Publisher = payload.Publisher,
+                SeriesName = payload.SeriesName,
+                SeriesPosition = payload.SeriesPosition?.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture),
+                Genres = payload.Genres
+            };
+
+            foreach (var libraryId in MappedLibraryIds(mappings))
+            {
+                List<AudioBookShelfLibraryItemSummary> items;
+
+                try
+                {
+                    items = _proxy.GetLibraryItems(Settings, libraryId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug(ex, "AudioBookShelf: unable to list items for library '{0}'", libraryId);
+                    continue;
+                }
+
+                foreach (var folder in DistinctFolders(files))
+                {
+                    var resolved = ResolveLibraryRelativePath(folder);
+
+                    if (resolved == null)
+                    {
+                        continue;
+                    }
+
+                    var item = items.FirstOrDefault(i => string.Equals(i.RelPath, resolved.Value.RelativePath, StringComparison.OrdinalIgnoreCase));
+
+                    if (item == null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        _proxy.UpdateItemMetadata(Settings, item.Id, metadata);
+
+                        if (payload.CoverBytes?.Length > 0)
+                        {
+                            _proxy.UploadItemCover(Settings, item.Id, payload.CoverBytes, "cover.jpg");
+                        }
+                        else if (payload.CoverUrl.IsNotNullOrWhiteSpace())
+                        {
+                            _proxy.UpdateItemCover(Settings, item.Id, payload.CoverUrl);
+                        }
+
+                        _logger.Debug("AudioBookShelf: forwarded external edit for '{0}'", resolved.Value.RelativePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Debug(ex, "AudioBookShelf: external edit push failed for '{0}'", resolved.Value.RelativePath);
+                    }
+                }
+            }
         }
 
         public void PushBooksMetadata(List<(Book Book, List<BookFile> Files)> books)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -40,8 +40,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
         private static readonly TimeSpan PurgeDelay = TimeSpan.FromSeconds(30);
         private static readonly TimeSpan RescanDelay = TimeSpan.FromSeconds(45);
 
-        // Notification instances are transient, so the pending set is static: a burst of
-        // delete events (one per file of a bulk delete) collapses into one sweep per library.
         private static readonly ConcurrentDictionary<string, byte> PendingPurges = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 
         public AudioBookShelf(IAudioBookShelfProxy proxy,
@@ -128,8 +126,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
             SendLibraryScans(libraryScans);
 
-            // A rename retires the old folder identity; sweep whatever the move left
-            // flagged so canonicalization renames do not strand ghost items.
             SchedulePurgeForDelete(libraryScans);
             ScheduleItemRescans(renamedFiles);
         }
@@ -306,10 +302,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void PushBooksMetadata(List<(Book Book, List<BookFile> Files)> books)
         {
-            // Changing a book's metadata never renames its files, so no rename ever
-            // reaches AudioBookShelf and the items keep whatever they were first scanned
-            // with. Send the current values straight to the items, listing each library
-            // once however many books changed.
             var pushable = (books ?? new List<(Book, List<BookFile>)>())
                 .Where(x => x.Book != null && x.Files != null && x.Files.Count > 0)
                 .ToList();
@@ -453,8 +445,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         private void ScheduleItemRescans(List<RenamedBookFile> renamedFiles)
         {
-            // A tracked move keeps the item's old metadata; ask AudioBookShelf to
-            // rescan the affected items so it re-reads the canonical OPF.
             if (renamedFiles == null || renamedFiles.Count == 0)
             {
                 return;
@@ -532,10 +522,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                                 continue;
                             }
 
-                            // Ask AudioBookShelf to re-read the folder FIRST. A scan
-                            // overwrites item metadata from the files, so pushing before
-                            // it means the canonical values are immediately discarded and
-                            // the item visibly flips back to whatever the file carries.
+                            // Scan first; metadata pushed before it is overwritten from the files.
                             _proxy.ScanItem(settings, item.Id);
                             _logger.Debug("AudioBookShelf: requested item rescan for '{0}'", rel);
 
@@ -558,9 +545,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         private void SchedulePurgeForDelete(ISet<string> libraryScans)
         {
-            // Mapped deletes are handled with watcher updates and never enter the scan
-            // loop, so purge scheduling must not live there: sweep every library this
-            // connection covers, whichever notification path ran.
             if (!Settings.RemoveMissingItems)
             {
                 return;
@@ -597,9 +581,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 return;
             }
 
-            // The scan triggered alongside this purge flags freshly deleted files as
-            // missing asynchronously; wait it out before sweeping, or the sweep runs
-            // before anything is flagged and the ghost item survives.
+            // The scan flags deleted files as missing asynchronously; sweep after it.
             Task.Delay(PurgeDelay).ContinueWith(task =>
             {
                 PendingPurges.TryRemove(purgeKey, out _);

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using FluentValidation;
 using FluentValidation.Results;
 using NLog;
@@ -30,15 +32,25 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
         private readonly ICached<AudioBookShelfOidcPendingAuth> _oidcPendingAuthCache;
         private readonly ICached<List<AudioBookShelfLibrary>> _libraryCache;
         private readonly IRootFolderService _rootFolderService;
+        private readonly IBookService _bookService;
+        private readonly IEditionService _editionService;
         private readonly Logger _logger;
 
         private static readonly TimeSpan LibraryCacheDuration = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan PurgeDelay = TimeSpan.FromSeconds(30);
+        private static readonly TimeSpan RescanDelay = TimeSpan.FromSeconds(45);
+
+        // Notification instances are transient, so the pending set is static: a burst of
+        // delete events (one per file of a bulk delete) collapses into one sweep per library.
+        private static readonly ConcurrentDictionary<string, byte> PendingPurges = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 
         public AudioBookShelf(IAudioBookShelfProxy proxy,
                               IHttpClient httpClient,
                               IPendingProviderSecretService pendingProviderSecretService,
                               ICacheManager cacheManager,
                               IRootFolderService rootFolderService,
+                              IBookService bookService,
+                              IEditionService editionService,
                               Logger logger)
         {
             _proxy = proxy;
@@ -47,6 +59,8 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             _oidcPendingAuthCache = cacheManager.GetCache<AudioBookShelfOidcPendingAuth>(GetType());
             _libraryCache = cacheManager.GetCache<List<AudioBookShelfLibrary>>(GetType(), "libraries");
             _rootFolderService = rootFolderService;
+            _bookService = bookService;
+            _editionService = editionService;
             _logger = logger;
         }
 
@@ -113,6 +127,11 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             }
 
             SendLibraryScans(libraryScans);
+
+            // A rename retires the old folder identity; sweep whatever the move left
+            // flagged so canonicalization renames do not strand ghost items.
+            SchedulePurgeForDelete(libraryScans);
+            ScheduleItemRescans(renamedFiles);
         }
 
         public override void OnBookFileDelete(BookFileDeleteMessage deleteMessage)
@@ -140,6 +159,56 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             }
 
             SendLibraryScans(libraryScans);
+            SchedulePurgeForDelete(libraryScans);
+        }
+
+        public override void OnBookDelete(BookDeleteMessage deleteMessage)
+        {
+            if (!deleteMessage.DeletedFiles)
+            {
+                return;
+            }
+
+            var author = deleteMessage.Book?.Author;
+            var mediaType = GetMediaType(deleteMessage.Book, null);
+
+            var libraryScans = NewLibraryScanSet();
+
+            if (Settings.HasConfiguredLibraryMappings())
+            {
+                SendMappedDelete(author, null, mediaType, libraryScans);
+            }
+            else
+            {
+                AddLegacyLibraryScans(author, null, mediaType, libraryScans);
+            }
+
+            SendLibraryScans(libraryScans);
+            SchedulePurgeForDelete(libraryScans);
+        }
+
+        public override void OnAuthorDelete(AuthorDeleteMessage deleteMessage)
+        {
+            if (!deleteMessage.DeletedFiles)
+            {
+                return;
+            }
+
+            var author = deleteMessage.Author;
+            var libraryScans = NewLibraryScanSet();
+
+            if (Settings.HasConfiguredLibraryMappings())
+            {
+                SendMappedDelete(author, null, "audiobook", libraryScans);
+                SendMappedDelete(author, null, "ebook", libraryScans);
+            }
+            else
+            {
+                AddLegacyLibraryScans(author, null, null, libraryScans);
+            }
+
+            SendLibraryScans(libraryScans);
+            SchedulePurgeForDelete(libraryScans);
         }
 
         // Watcher updates and scan fallbacks are sent at event time (fire and forget). Notification
@@ -220,6 +289,330 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 _logger.Debug(ex, "Failed to send AudioBookShelf watcher update for library '{0}', falling back to full scan", target.LibraryId);
                 libraryScans.Add(target.LibraryId);
             }
+        }
+
+        private AudioBookShelfItemMetadata BuildItemMetadata(Book book)
+        {
+            return new AudioBookShelfItemMetadata
+            {
+                Title = book.Title,
+                Description = book.Overview,
+                Publisher = book.Publisher,
+                SeriesName = book.SeriesName,
+                SeriesPosition = book.SeriesPosition,
+                Genres = book.Genres ?? new List<string>()
+            };
+        }
+
+        public void PushBooksMetadata(List<(Book Book, List<BookFile> Files)> books)
+        {
+            // Changing a book's metadata never renames its files, so no rename ever
+            // reaches AudioBookShelf and the items keep whatever they were first scanned
+            // with. Send the current values straight to the items, listing each library
+            // once however many books changed.
+            var pushable = (books ?? new List<(Book, List<BookFile>)>())
+                .Where(x => x.Book != null && x.Files != null && x.Files.Count > 0)
+                .ToList();
+
+            if (pushable.Count == 0)
+            {
+                return;
+            }
+
+            var mappings = Settings.GetLibraryMappings();
+
+            if (mappings.Count == 0)
+            {
+                _logger.Debug("AudioBookShelf: no library mappings configured, metadata pushes need mapped root folders");
+                return;
+            }
+
+            foreach (var libraryId in MappedLibraryIds(mappings))
+            {
+                List<AudioBookShelfLibraryItemSummary> items;
+
+                try
+                {
+                    items = _proxy.GetLibraryItems(Settings, libraryId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug(ex, "AudioBookShelf: unable to list items for library '{0}'", libraryId);
+                    continue;
+                }
+
+                foreach (var (book, files) in pushable)
+                {
+                    var payload = BuildItemMetadata(book);
+
+                    foreach (var folder in DistinctFolders(files))
+                    {
+                        var resolved = ResolveLibraryRelativePath(folder);
+
+                        if (resolved == null)
+                        {
+                            continue;
+                        }
+
+                        var item = items.FirstOrDefault(i => string.Equals(i.RelPath, resolved.Value.RelativePath, StringComparison.OrdinalIgnoreCase));
+
+                        if (item == null)
+                        {
+                            continue;
+                        }
+
+                        try
+                        {
+                            _proxy.UpdateItemMetadata(Settings, item.Id, payload);
+                            _logger.Debug("AudioBookShelf: pushed metadata for '{0}' ({1} genre(s))", resolved.Value.RelativePath, payload.Genres?.Count ?? 0);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.Debug(ex, "AudioBookShelf: metadata push failed for '{0}'", resolved.Value.RelativePath);
+                        }
+
+                        PushItemCover(Settings, mappings, resolved.Value.RootFolder.Id, libraryId, item.Id, folder, resolved.Value.RelativePath);
+                    }
+                }
+            }
+        }
+
+        private static List<string> DistinctFolders(List<BookFile> files)
+        {
+            return files
+                .Select(f => f?.Path)
+                .Where(path => path.IsNotNullOrWhiteSpace())
+                .Select(Path.GetDirectoryName)
+                .Where(folder => folder.IsNotNullOrWhiteSpace())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+
+        private static IEnumerable<string> MappedLibraryIds(List<AudioBookShelfLibraryMapping> mappings)
+        {
+            return mappings
+                .Select(m => m?.LibraryId)
+                .Where(id => id.IsNotNullOrWhiteSpace())
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private (RootFolder RootFolder, string RelativePath)? ResolveLibraryRelativePath(string folder)
+        {
+            RootFolder rootFolder;
+
+            try
+            {
+                rootFolder = _rootFolderService.GetBestRootFolder(folder);
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "Unable to resolve root folder for {0}", folder);
+                return null;
+            }
+
+            if (rootFolder?.Path == null || !TryGetRelativePath(rootFolder.Path, folder, out var relativePath))
+            {
+                return null;
+            }
+
+            return (rootFolder, relativePath);
+        }
+
+        private void PushItemCover(AudioBookShelfSettings settings, List<AudioBookShelfLibraryMapping> mappings, int rootFolderId, string libraryId, string itemId, string folder, string rel)
+        {
+            var localCover = Path.Combine(folder, "cover.jpg");
+
+            if (!File.Exists(localCover))
+            {
+                return;
+            }
+
+            var mapping = mappings.FirstOrDefault(m =>
+                m != null &&
+                m.RootFolderId == rootFolderId &&
+                string.Equals(m.LibraryId, libraryId, StringComparison.OrdinalIgnoreCase) &&
+                m.LibraryFolderPath.IsNotNullOrWhiteSpace());
+
+            if (mapping == null)
+            {
+                return;
+            }
+
+            var remoteCover = mapping.LibraryFolderPath.TrimEnd('/') + "/" + rel + "/cover.jpg";
+
+            try
+            {
+                _proxy.UpdateItemCover(settings, itemId, remoteCover);
+                _logger.Debug("AudioBookShelf: set item cover from '{0}'", remoteCover);
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "AudioBookShelf: cover update failed for '{0}'", rel);
+            }
+        }
+
+        private void ScheduleItemRescans(List<RenamedBookFile> renamedFiles)
+        {
+            // A tracked move keeps the item's old metadata; ask AudioBookShelf to
+            // rescan the affected items so it re-reads the canonical OPF.
+            if (renamedFiles == null || renamedFiles.Count == 0)
+            {
+                return;
+            }
+
+            var folderBooks = new Dictionary<string, Book>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var renamed in renamedFiles)
+            {
+                var path = renamed?.BookFile?.Path;
+
+                if (path.IsNullOrWhiteSpace())
+                {
+                    continue;
+                }
+
+                var folder = Path.GetDirectoryName(path);
+
+                if (folder.IsNullOrWhiteSpace() || folderBooks.ContainsKey(folder))
+                {
+                    continue;
+                }
+
+                Book book = null;
+
+                try
+                {
+                    var editionId = renamed.BookFile.EditionId;
+                    var edition = editionId > 0 ? _editionService.GetEdition(editionId) : null;
+
+                    if (edition != null && edition.BookId > 0)
+                    {
+                        book = _bookService.GetBook(edition.BookId);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug(ex, "Unable to resolve the book for {0}", path);
+                }
+
+                folderBooks[folder] = book;
+            }
+
+            var mappings = Settings.GetLibraryMappings();
+
+            if (folderBooks.Count == 0 || mappings.Count == 0)
+            {
+                return;
+            }
+
+            var settings = Settings;
+
+            Task.Delay(RescanDelay).ContinueWith(_ =>
+            {
+                try
+                {
+                    foreach (var libraryId in MappedLibraryIds(mappings))
+                    {
+                        var items = _proxy.GetLibraryItems(settings, libraryId);
+
+                        foreach (var pair in folderBooks)
+                        {
+                            var resolved = ResolveLibraryRelativePath(pair.Key);
+
+                            if (resolved == null)
+                            {
+                                continue;
+                            }
+
+                            var rel = resolved.Value.RelativePath;
+                            var item = items.FirstOrDefault(i => string.Equals(i.RelPath, rel, StringComparison.OrdinalIgnoreCase));
+
+                            if (item == null)
+                            {
+                                continue;
+                            }
+
+                            // Ask AudioBookShelf to re-read the folder FIRST. A scan
+                            // overwrites item metadata from the files, so pushing before
+                            // it means the canonical values are immediately discarded and
+                            // the item visibly flips back to whatever the file carries.
+                            _proxy.ScanItem(settings, item.Id);
+                            _logger.Debug("AudioBookShelf: requested item rescan for '{0}'", rel);
+
+                            if (pair.Value != null)
+                            {
+                                _proxy.UpdateItemMetadata(settings, item.Id, BuildItemMetadata(pair.Value));
+                                _logger.Debug("AudioBookShelf: set item metadata for '{0}'", rel);
+                            }
+
+                            PushItemCover(settings, mappings, resolved.Value.RootFolder.Id, libraryId, item.Id, pair.Key, rel);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "AudioBookShelf: item rescan after rename failed");
+                }
+            });
+        }
+
+        private void SchedulePurgeForDelete(ISet<string> libraryScans)
+        {
+            // Mapped deletes are handled with watcher updates and never enter the scan
+            // loop, so purge scheduling must not live there: sweep every library this
+            // connection covers, whichever notification path ran.
+            if (!Settings.RemoveMissingItems)
+            {
+                return;
+            }
+
+            var libraryIds = new HashSet<string>(libraryScans ?? new HashSet<string>(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var mapping in Settings.GetLibraryMappings())
+            {
+                if (mapping?.LibraryId.IsNotNullOrWhiteSpace() == true)
+                {
+                    libraryIds.Add(mapping.LibraryId);
+                }
+            }
+
+            if (Settings.LibraryId.IsNotNullOrWhiteSpace())
+            {
+                libraryIds.Add(Settings.LibraryId);
+            }
+
+            foreach (var libraryId in libraryIds)
+            {
+                SchedulePurgeMissing(libraryId);
+            }
+        }
+
+        private void SchedulePurgeMissing(string libraryId)
+        {
+            var settings = Settings;
+            var purgeKey = $"{settings.UseSsl}:{settings.Host}:{settings.Port}:{settings.UrlBase}:{libraryId}";
+
+            if (!PendingPurges.TryAdd(purgeKey, 0))
+            {
+                return;
+            }
+
+            // The scan triggered alongside this purge flags freshly deleted files as
+            // missing asynchronously; wait it out before sweeping, or the sweep runs
+            // before anything is flagged and the ghost item survives.
+            Task.Delay(PurgeDelay).ContinueWith(task =>
+            {
+                PendingPurges.TryRemove(purgeKey, out _);
+
+                try
+                {
+                    _proxy.RemoveItemsWithIssues(settings, libraryId);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warn(ex, "Failed to remove missing items for library: {0}", libraryId);
+                }
+            });
         }
 
         private void SendLibraryScans(ISet<string> libraryIds)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -302,8 +303,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public bool AcceptsExternalLibraryEdits => Settings.PushLibraryEdits;
 
-        // Applies an edit made in another library service (e.g. Grimmory) to the matching
-        // items. Title stays Chaptarr's, mirroring the calibre forwarder's identity rule.
+        // Title stays Chaptarr's, matching the calibre forwarder's identity rule.
         public void PushExternalLibraryEdit(Book book, List<BookFile> files, ExternalLibraryEditPayload payload)
         {
             if (book == null || payload == null || files == null || files.Count == 0)
@@ -324,7 +324,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 Description = payload.Description,
                 Publisher = payload.Publisher,
                 SeriesName = payload.SeriesName,
-                SeriesPosition = payload.SeriesPosition?.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture),
+                SeriesPosition = payload.SeriesPosition?.ToString("0.##", CultureInfo.InvariantCulture),
                 Genres = payload.Genres
             };
 
@@ -386,16 +386,13 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
             if (pushedCover)
             {
-                // Regenerate resized thumbnails from the refreshed covers.
                 _proxy.PurgeCoverCache(Settings);
             }
         }
 
         public void PushBooksMetadata(List<(Book Book, List<BookFile> Files)> books)
         {
-            var pushable = (books ?? new List<(Book, List<BookFile>)>())
-                .Where(x => x.Book != null && x.Files != null && x.Files.Count > 0)
-                .ToList();
+            var pushable = books.Where(x => x.Files.Count > 0).ToList();
 
             if (pushable.Count == 0)
             {
@@ -527,8 +524,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             {
                 _proxy.UpdateItemCover(settings, itemId, remoteCover);
                 _logger.Debug("AudioBookShelf: set item cover from '{0}'", remoteCover);
-
-                // Regenerate resized thumbnails from the refreshed cover.
                 _proxy.PurgeCoverCache(settings);
             }
             catch (Exception ex)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -328,6 +328,8 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 Genres = payload.Genres
             };
 
+            var pushedCover = false;
+
             foreach (var libraryId in MappedLibraryIds(mappings))
             {
                 List<AudioBookShelfLibraryItemSummary> items;
@@ -365,10 +367,12 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                         if (payload.CoverBytes?.Length > 0)
                         {
                             _proxy.UploadItemCover(Settings, item.Id, payload.CoverBytes, "cover.jpg");
+                            pushedCover = true;
                         }
                         else if (payload.CoverUrl.IsNotNullOrWhiteSpace())
                         {
                             _proxy.UpdateItemCover(Settings, item.Id, payload.CoverUrl);
+                            pushedCover = true;
                         }
 
                         _logger.Debug("AudioBookShelf: forwarded external edit for '{0}'", resolved.Value.RelativePath);
@@ -378,6 +382,12 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                         _logger.Debug(ex, "AudioBookShelf: external edit push failed for '{0}'", resolved.Value.RelativePath);
                     }
                 }
+            }
+
+            if (pushedCover)
+            {
+                // Regenerate resized thumbnails from the refreshed covers.
+                _proxy.PurgeCoverCache(Settings);
             }
         }
 
@@ -517,6 +527,9 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             {
                 _proxy.UpdateItemCover(settings, itemId, remoteCover);
                 _logger.Debug("AudioBookShelf: set item cover from '{0}'", remoteCover);
+
+                // Regenerate resized thumbnails from the refreshed cover.
+                _proxy.PurgeCoverCache(settings);
             }
             catch (Exception ex)
             {

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelf.cs
@@ -392,6 +392,23 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void PushBooksMetadata(List<(Book Book, List<BookFile> Files)> books)
         {
+            PushBooks(books, includeMetadata: true);
+        }
+
+        // A cover refresh is not a library edit. MediaCoversUpdatedEvent is raised by
+        // routine work - an author refresh, the daily cover repair, the deferred cover
+        // flush after every import - and carries no information about metadata having
+        // changed. Re-sending the whole block from Chaptarr's database on that signal
+        // silently overwrote whatever the AudioBookShelf item held, genres included.
+        // Covers are the one thing the event actually knows about, so that is all it
+        // sends; real edits still reach AudioBookShelf through PushExternalLibraryEdit.
+        public void PushBooksCovers(List<(Book Book, List<BookFile> Files)> books)
+        {
+            PushBooks(books, includeMetadata: false);
+        }
+
+        private void PushBooks(List<(Book Book, List<BookFile> Files)> books, bool includeMetadata)
+        {
             var pushable = books.Where(x => x.Files.Count > 0).ToList();
 
             if (pushable.Count == 0)
@@ -423,8 +440,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
                 foreach (var (book, files) in pushable)
                 {
-                    var payload = BuildItemMetadata(book);
-
                     foreach (var folder in DistinctFolders(files))
                     {
                         var resolved = ResolveLibraryRelativePath(folder);
@@ -441,14 +456,19 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                             continue;
                         }
 
-                        try
+                        if (includeMetadata)
                         {
-                            _proxy.UpdateItemMetadata(Settings, item.Id, payload);
-                            _logger.Debug("AudioBookShelf: pushed metadata for '{0}' ({1} genre(s))", resolved.Value.RelativePath, payload.Genres?.Count ?? 0);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.Debug(ex, "AudioBookShelf: metadata push failed for '{0}'", resolved.Value.RelativePath);
+                            var payload = BuildItemMetadata(book);
+
+                            try
+                            {
+                                _proxy.UpdateItemMetadata(Settings, item.Id, payload);
+                                _logger.Debug("AudioBookShelf: pushed metadata for '{0}' ({1} genre(s))", resolved.Value.RelativePath, payload.Genres?.Count ?? 0);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.Debug(ex, "AudioBookShelf: metadata push failed for '{0}'", resolved.Value.RelativePath);
+                            }
                         }
 
                         PushItemCover(Settings, mappings, resolved.Value.RootFolder.Id, libraryId, item.Id, folder, resolved.Value.RelativePath);

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NLog;
+using NzbDrone.Common.Extensions;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.MediaCover;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.Messaging.Events;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Notifications.AudioBookShelf
+{
+    public class AudioBookShelfLibraryEditService : IHandle<MediaCoversUpdatedEvent>
+    {
+        private readonly IBookService _bookService;
+        private readonly IMediaFileService _mediaFileService;
+        private readonly INotificationFactory _notificationFactory;
+        private readonly INotificationStatusService _notificationStatusService;
+        private readonly Logger _logger;
+
+        public AudioBookShelfLibraryEditService(IBookService bookService,
+                                                IMediaFileService mediaFileService,
+                                                INotificationFactory notificationFactory,
+                                                INotificationStatusService notificationStatusService,
+                                                Logger logger)
+        {
+            _bookService = bookService;
+            _mediaFileService = mediaFileService;
+            _notificationFactory = notificationFactory;
+            _notificationStatusService = notificationStatusService;
+            _logger = logger;
+        }
+
+        public void Handle(MediaCoversUpdatedEvent message)
+        {
+            // AudioBookShelf keeps its own copy of an item's metadata and only re-reads
+            // it on a rename, so a change Chaptarr makes to a book would otherwise never
+            // show up there.
+            Author author = message.Author;
+
+            if (author == null && message.Book != null)
+            {
+                author = message.Book.Author;
+            }
+
+            var blockedProviders = new HashSet<int>(_notificationStatusService.GetBlockedProviders().Select(v => v.ProviderId));
+
+            var shelves = _notificationFactory.GetAvailableProviders()
+                .OfType<AudioBookShelf>()
+                .Where(s => ((AudioBookShelfSettings)s.Definition.Settings).PushLibraryEdits)
+                .Where(s => !blockedProviders.Contains(s.Definition.Id))
+                .Where(s => ShouldHandleAuthor(s.Definition, author))
+                .ToList();
+
+            if (!shelves.Any())
+            {
+                return;
+            }
+
+            var books = GetBooks(message)
+                .Select(book => (Book: book, Files: _mediaFileService.GetFilesByBook(book.Id)
+                    .Where(f => f.Path.IsNotNullOrWhiteSpace())
+                    .ToList()))
+                .Where(x => x.Files.Any())
+                .ToList();
+
+            if (!books.Any())
+            {
+                return;
+            }
+
+            foreach (var shelf in shelves)
+            {
+                try
+                {
+                    shelf.PushBooksMetadata(books);
+                    _notificationStatusService.RecordSuccess(shelf.Definition.Id);
+                }
+                catch (Exception ex)
+                {
+                    _notificationStatusService.RecordFailure(shelf.Definition.Id);
+                    _logger.Warn(ex, "Unable to push metadata to AudioBookShelf: " + shelf.Definition.Name);
+                }
+            }
+        }
+
+        private static bool ShouldHandleAuthor(ProviderDefinition definition, Author author)
+        {
+            if (definition.Tags.Empty() || author == null)
+            {
+                return true;
+            }
+
+            return definition.Tags.Intersect(author.Tags).Any();
+        }
+
+        private IEnumerable<Book> GetBooks(MediaCoversUpdatedEvent message)
+        {
+            if (message.Book != null && message.Book.Id > 0)
+            {
+                return new[] { message.Book };
+            }
+
+            var author = message.Author;
+
+            if (author == null || author.Id <= 0)
+            {
+                return Array.Empty<Book>();
+            }
+
+            return _bookService.GetBooksByAuthor(author.Id).Where(b => b != null && b.Id > 0);
+        }
+    }
+}

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
@@ -71,13 +71,13 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             {
                 try
                 {
-                    shelf.PushBooksMetadata(books);
+                    shelf.PushBooksCovers(books);
                     _notificationStatusService.RecordSuccess(shelf.Definition.Id);
                 }
                 catch (Exception ex)
                 {
                     _notificationStatusService.RecordFailure(shelf.Definition.Id);
-                    _logger.Warn(ex, "Unable to push metadata to AudioBookShelf: " + shelf.Definition.Name);
+                    _logger.Warn(ex, "Unable to push covers to AudioBookShelf: " + shelf.Definition.Name);
                 }
             }
         }

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
@@ -34,7 +34,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void Handle(MediaCoversUpdatedEvent message)
         {
-            Author author = message.Author;
+            var author = message.Author;
 
             if (author == null && message.Book != null)
             {
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 return Array.Empty<Book>();
             }
 
-            return _bookService.GetBooksByAuthor(author.Id).Where(b => b != null && b.Id > 0);
+            return _bookService.GetBooksByAuthor(author.Id).Where(b => b.Id > 0);
         }
     }
 }

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfLibraryEditService.cs
@@ -34,9 +34,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void Handle(MediaCoversUpdatedEvent message)
         {
-            // AudioBookShelf keeps its own copy of an item's metadata and only re-reads
-            // it on a rename, so a change Chaptarr makes to a book would otherwise never
-            // show up there.
             Author author = message.Author;
 
             if (author == null && message.Book != null)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
@@ -13,9 +13,30 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
     {
         void ScanLibrary(AudioBookShelfSettings settings);
         void ScanLibrary(AudioBookShelfSettings settings, string libraryId);
+        void RemoveItemsWithIssues(AudioBookShelfSettings settings, string libraryId);
+        List<AudioBookShelfLibraryItemSummary> GetLibraryItems(AudioBookShelfSettings settings, string libraryId);
+        void ScanItem(AudioBookShelfSettings settings, string itemId);
+        void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata);
+        void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath);
         void UpdateWatchedPath(AudioBookShelfSettings settings, string libraryId, string path, string type, string oldPath = null);
         ValidationFailure Test(AudioBookShelfSettings settings);
         List<AudioBookShelfLibrary> GetLibraries(AudioBookShelfSettings settings);
+    }
+
+    public class AudioBookShelfItemMetadata
+    {
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string Publisher { get; set; }
+        public string SeriesName { get; set; }
+        public string SeriesPosition { get; set; }
+        public List<string> Genres { get; set; }
+    }
+
+    public class AudioBookShelfLibraryItemSummary
+    {
+        public string Id { get; set; }
+        public string RelPath { get; set; }
     }
 
     public class AudioBookShelfProxy : IAudioBookShelfProxy
@@ -72,6 +93,26 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
             var request = BuildRequest(settings, $"/api/libraries/{libraryId}/scan");
             request.Method = HttpMethod.Post;
+
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
+        }
+
+        public void RemoveItemsWithIssues(AudioBookShelfSettings settings, string libraryId)
+        {
+            if (string.IsNullOrEmpty(libraryId))
+            {
+                return;
+            }
+
+            // AudioBookShelf marks deleted books as missing instead of removing them;
+            // DELETE /api/libraries/:id/issues purges items whose files are gone.
+            var request = BuildRequest(settings, $"/api/libraries/{libraryId}/issues");
+            request.Method = HttpMethod.Delete;
 
             var response = _httpClient.Execute(request);
 
@@ -170,6 +211,124 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
             var librariesResponse = Json.Deserialize<AudioBookShelfLibrariesResponse>(response.Content);
             return librariesResponse?.Libraries ?? new List<AudioBookShelfLibrary>();
+        }
+
+        public List<AudioBookShelfLibraryItemSummary> GetLibraryItems(AudioBookShelfSettings settings, string libraryId)
+        {
+            var request = BuildRequest(settings, $"/api/libraries/{libraryId}/items?limit=0&minified=1");
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
+
+            var parsed = Json.Deserialize<AudioBookShelfLibraryItemsResponse>(response.Content);
+            return parsed?.Results ?? new List<AudioBookShelfLibraryItemSummary>();
+        }
+
+        public void ScanItem(AudioBookShelfSettings settings, string itemId)
+        {
+            if (string.IsNullOrEmpty(itemId))
+            {
+                return;
+            }
+
+            var request = BuildRequest(settings, $"/api/items/{itemId}/scan");
+            request.Method = HttpMethod.Post;
+
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
+        }
+
+        public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata item)
+        {
+            if (string.IsNullOrEmpty(itemId) || item == null)
+            {
+                return;
+            }
+
+            var metadata = new Dictionary<string, object>();
+
+            if (item.Title.IsNotNullOrWhiteSpace())
+            {
+                metadata["title"] = item.Title;
+            }
+
+            if (item.Description.IsNotNullOrWhiteSpace())
+            {
+                metadata["description"] = item.Description;
+            }
+
+            if (item.Publisher.IsNotNullOrWhiteSpace())
+            {
+                metadata["publisher"] = item.Publisher;
+            }
+
+            if (item.SeriesName.IsNotNullOrWhiteSpace())
+            {
+                metadata["series"] = new[]
+                {
+                    new { name = item.SeriesName, sequence = item.SeriesPosition ?? string.Empty }
+                };
+            }
+
+            // Genres are replaced wholesale: a tag removed in the owning library has
+            // to disappear here too, so an empty list is still worth sending.
+            if (item.Genres != null)
+            {
+                metadata["genres"] = item.Genres;
+            }
+
+            if (metadata.Count == 0)
+            {
+                return;
+            }
+
+            // A rescan deliberately keeps existing metadata, so push the canonical
+            // values into the item instead of hoping a re-read wins.
+            var request = BuildRequest(settings, $"/api/items/{itemId}/media");
+            request.Method = HttpMethod.Patch;
+            request.Headers.ContentType = "application/json";
+            request.SetContent(Json.ToJson(new { metadata }));
+
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
+        }
+
+        public void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath)
+        {
+            if (string.IsNullOrEmpty(itemId) || string.IsNullOrEmpty(coverPath))
+            {
+                return;
+            }
+
+            // AudioBookShelf keeps a private copy of an item's cover and never replaces
+            // it from folder changes; point it at the canonical cover explicitly.
+            var request = BuildRequest(settings, $"/api/items/{itemId}/cover");
+            request.Method = HttpMethod.Patch;
+            request.Headers.ContentType = "application/json";
+            request.SetContent(Json.ToJson(new { cover = coverPath }));
+
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
+        }
+
+        private class AudioBookShelfLibraryItemsResponse
+        {
+            public List<AudioBookShelfLibraryItemSummary> Results { get; set; }
         }
 
         private HttpRequest BuildRequest(AudioBookShelfSettings settings, string resource)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
@@ -109,8 +109,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 return;
             }
 
-            // AudioBookShelf marks deleted books as missing instead of removing them;
-            // DELETE /api/libraries/:id/issues purges items whose files are gone.
+            // ABS marks deleted books missing; this purges items whose files are gone.
             var request = BuildRequest(settings, $"/api/libraries/{libraryId}/issues");
             request.Method = HttpMethod.Delete;
 
@@ -277,8 +276,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 };
             }
 
-            // Genres are replaced wholesale: a tag removed in the owning library has
-            // to disappear here too, so an empty list is still worth sending.
             if (item.Genres != null)
             {
                 metadata["genres"] = item.Genres;
@@ -289,8 +286,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 return;
             }
 
-            // A rescan deliberately keeps existing metadata, so push the canonical
-            // values into the item instead of hoping a re-read wins.
             var request = BuildRequest(settings, $"/api/items/{itemId}/media");
             request.Method = HttpMethod.Patch;
             request.Headers.ContentType = "application/json";
@@ -311,8 +306,6 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
                 return;
             }
 
-            // AudioBookShelf keeps a private copy of an item's cover and never replaces
-            // it from folder changes; point it at the canonical cover explicitly.
             var request = BuildRequest(settings, $"/api/items/{itemId}/cover");
             request.Method = HttpMethod.Patch;
             request.Headers.ContentType = "application/json";

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
@@ -19,6 +19,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
         void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata);
         void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath);
         void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName);
+        void PurgeCoverCache(AudioBookShelfSettings settings);
         void UpdateWatchedPath(AudioBookShelfSettings settings, string libraryId, string path, string type, string oldPath = null);
         ValidationFailure Test(AudioBookShelfSettings settings);
         List<AudioBookShelfLibrary> GetLibraries(AudioBookShelfSettings settings);
@@ -358,6 +359,32 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             if (response.HasHttpError)
             {
                 throw new HttpException(response);
+            }
+        }
+
+        public void PurgeCoverCache(AudioBookShelfSettings settings)
+        {
+            // Updating an item's cover from the same path does not invalidate the
+            // server-side resized thumbnail cache (/metadata/cache/covers/*_400.webp),
+            // so the library grid keeps showing the old art. Purge the cache so the
+            // thumbnails regenerate from the refreshed covers.
+            try
+            {
+                var request = BuildRequest(settings, "/api/cache/purge");
+                request.Method = HttpMethod.Post;
+                request.Headers.ContentType = "application/json";
+                request.SetContent("{}");
+
+                var response = _httpClient.Execute(request);
+
+                if (response.HasHttpError)
+                {
+                    throw new HttpException(response);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, "AudioBookShelf: cover cache purge failed");
             }
         }
 

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
@@ -18,6 +18,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
         void ScanItem(AudioBookShelfSettings settings, string itemId);
         void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata metadata);
         void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath);
+        void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName);
         void UpdateWatchedPath(AudioBookShelfSettings settings, string libraryId, string path, string type, string oldPath = null);
         ValidationFailure Test(AudioBookShelfSettings settings);
         List<AudioBookShelfLibrary> GetLibraries(AudioBookShelfSettings settings);
@@ -322,6 +323,42 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
         private class AudioBookShelfLibraryItemsResponse
         {
             public List<AudioBookShelfLibraryItemSummary> Results { get; set; }
+        }
+
+        // For covers a target cannot fetch itself (e.g. behind another service's auth) the
+        // image bytes are uploaded directly instead of handing AudioBookShelf a URL to pull.
+        public void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName)
+        {
+            if (string.IsNullOrEmpty(itemId) || image == null || image.Length == 0)
+            {
+                return;
+            }
+
+            var extension = System.IO.Path.GetExtension(fileName)?.ToLowerInvariant();
+            var contentType = extension switch
+            {
+                ".png" => "image/png",
+                ".webp" => "image/webp",
+                _ => "image/jpeg"
+            };
+
+            var baseUrl = HttpRequestBuilder.BuildBaseUrl(settings.UseSsl, settings.Host.ToUrlHost(), settings.Port, settings.UrlBase);
+            var request = new HttpRequestBuilder(baseUrl)
+                .Resource($"/api/items/{itemId}/cover")
+                .Post()
+                .AddFormUpload("cover", fileName, image, contentType)
+                .Build();
+
+            request.RequestTimeout = RequestTimeout;
+            request.Headers.Add("User-Agent", "Chaptarr");
+            request.Headers.Add("Authorization", $"Bearer {settings.ApiKey}");
+
+            var response = _httpClient.Execute(request);
+
+            if (response.HasHttpError)
+            {
+                throw new HttpException(response);
+            }
         }
 
         private HttpRequest BuildRequest(AudioBookShelfSettings settings, string resource)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfProxy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using FluentValidation.Results;
 using NLog;
@@ -106,12 +107,12 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void RemoveItemsWithIssues(AudioBookShelfSettings settings, string libraryId)
         {
-            if (string.IsNullOrEmpty(libraryId))
+            if (libraryId.IsNullOrWhiteSpace())
             {
                 return;
             }
 
-            // ABS marks deleted books missing; this purges items whose files are gone.
+            // AudioBookShelf marks the items missing rather than removing them.
             var request = BuildRequest(settings, $"/api/libraries/{libraryId}/issues");
             request.Method = HttpMethod.Delete;
 
@@ -230,7 +231,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void ScanItem(AudioBookShelfSettings settings, string itemId)
         {
-            if (string.IsNullOrEmpty(itemId))
+            if (itemId.IsNullOrWhiteSpace())
             {
                 return;
             }
@@ -248,7 +249,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void UpdateItemMetadata(AudioBookShelfSettings settings, string itemId, AudioBookShelfItemMetadata item)
         {
-            if (string.IsNullOrEmpty(itemId) || item == null)
+            if (itemId.IsNullOrWhiteSpace() || item == null)
             {
                 return;
             }
@@ -303,7 +304,7 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void UpdateItemCover(AudioBookShelfSettings settings, string itemId, string coverPath)
         {
-            if (string.IsNullOrEmpty(itemId) || string.IsNullOrEmpty(coverPath))
+            if (itemId.IsNullOrWhiteSpace() || coverPath.IsNullOrWhiteSpace())
             {
                 return;
             }
@@ -321,21 +322,14 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             }
         }
 
-        private class AudioBookShelfLibraryItemsResponse
-        {
-            public List<AudioBookShelfLibraryItemSummary> Results { get; set; }
-        }
-
-        // For covers a target cannot fetch itself (e.g. behind another service's auth) the
-        // image bytes are uploaded directly instead of handing AudioBookShelf a URL to pull.
         public void UploadItemCover(AudioBookShelfSettings settings, string itemId, byte[] image, string fileName)
         {
-            if (string.IsNullOrEmpty(itemId) || image == null || image.Length == 0)
+            if (itemId.IsNullOrWhiteSpace() || image == null || image.Length == 0)
             {
                 return;
             }
 
-            var extension = System.IO.Path.GetExtension(fileName)?.ToLowerInvariant();
+            var extension = Path.GetExtension(fileName)?.ToLowerInvariant();
             var contentType = extension switch
             {
                 ".png" => "image/png",
@@ -364,10 +358,8 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public void PurgeCoverCache(AudioBookShelfSettings settings)
         {
-            // Updating an item's cover from the same path does not invalidate the
-            // server-side resized thumbnail cache (/metadata/cache/covers/*_400.webp),
-            // so the library grid keeps showing the old art. Purge the cache so the
-            // thumbnails regenerate from the refreshed covers.
+            // Re-pointing an item at the same cover path leaves the server-side resized
+            // thumbnails (/metadata/cache/covers/*_400.webp) showing the old art.
             try
             {
                 var request = BuildRequest(settings, "/api/cache/purge");
@@ -386,6 +378,11 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
             {
                 _logger.Debug(ex, "AudioBookShelf: cover cache purge failed");
             }
+        }
+
+        private class AudioBookShelfLibraryItemsResponse
+        {
+            public List<AudioBookShelfLibraryItemSummary> Results { get; set; }
         }
 
         private HttpRequest BuildRequest(AudioBookShelfSettings settings, string resource)

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfSettings.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfSettings.cs
@@ -68,6 +68,12 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public string EbookLibraryId { get; set; }
 
+        [FieldDefinition(6, Label = "Remove Missing Items After Delete", Type = FieldType.Checkbox, HelpText = "AudioBookShelf marks deleted books as missing instead of removing them. When Chaptarr deletes books or files, also remove library items whose files are gone")]
+        public bool RemoveMissingItems { get; set; }
+
+        [FieldDefinition(7, Label = "Push Library Edits", Type = FieldType.Checkbox, HelpText = "When Chaptarr changes a book - a calibre push, a retag, or an edit - send the current title, description, publisher, series and cover to the matching AudioBookShelf item. AudioBookShelf only re-reads an item when its files are renamed, so without this it keeps whatever it was first scanned with")]
+        public bool PushLibraryEdits { get; set; }
+
         [FieldDefinition(5, Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
         public string LibraryMappingsJson { get; set; }
 

--- a/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfSettings.cs
+++ b/src/NzbDrone.Core/Notifications/AudioBookShelf/AudioBookShelfSettings.cs
@@ -68,14 +68,14 @@ namespace NzbDrone.Core.Notifications.AudioBookShelf
 
         public string EbookLibraryId { get; set; }
 
+        [FieldDefinition(5, Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
+        public string LibraryMappingsJson { get; set; }
+
         [FieldDefinition(6, Label = "Remove Missing Items After Delete", Type = FieldType.Checkbox, HelpText = "AudioBookShelf marks deleted books as missing instead of removing them. When Chaptarr deletes books or files, also remove library items whose files are gone")]
         public bool RemoveMissingItems { get; set; }
 
         [FieldDefinition(7, Label = "Push Library Edits", Type = FieldType.Checkbox, HelpText = "When Chaptarr changes a book - a calibre push, a retag, or an edit - send the current title, description, publisher, series and cover to the matching AudioBookShelf item. AudioBookShelf only re-reads an item when its files are renamed, so without this it keeps whatever it was first scanned with")]
         public bool PushLibraryEdits { get; set; }
-
-        [FieldDefinition(5, Type = FieldType.Textbox, Hidden = HiddenType.Hidden)]
-        public string LibraryMappingsJson { get; set; }
 
         [FieldDefinition(9, Label = "Authenticate with AudioBookShelf (OIDC)", Type = FieldType.OAuth, Hidden = HiddenType.Hidden, HelpText = "Uses AudioBookShelf OpenID Connect (SSO) to generate an API key automatically. This will open a browser popup to the configured AudioBookShelf URL, so it must be reachable from your browser. Your AudioBookShelf server must allow this app's callback URL under OpenID Connect → Mobile Redirect URIs.")]
         public string SignIn { get; set; }

--- a/src/NzbDrone.Core/Notifications/ExternalLibraryEdits.cs
+++ b/src/NzbDrone.Core/Notifications/ExternalLibraryEdits.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using NzbDrone.Core.Books;
+using NzbDrone.Core.MediaFiles;
+using NzbDrone.Core.ThingiProvider;
+
+namespace NzbDrone.Core.Notifications
+{
+    public class ExternalLibraryEditPayload
+    {
+        public string Title { get; set; }
+        public string Subtitle { get; set; }
+        public string Description { get; set; }
+        public string Publisher { get; set; }
+        public DateTime? PublishedDate { get; set; }
+        public string SeriesName { get; set; }
+        public double? SeriesPosition { get; set; }
+        public List<string> Languages { get; set; }
+        public List<string> Genres { get; set; }
+        public Dictionary<string, string> Identifiers { get; set; }
+        public string CoverUrl { get; set; }
+        public byte[] CoverBytes { get; set; }
+    }
+
+    // Seam between library-edit sources (e.g. the Grimmory forwarder) and connections able to
+    // mirror those edits outward. Sources discover targets via the notification factory, so a
+    // provider opts in simply by implementing this on top of NotificationBase; nothing here
+    // references a concrete provider, keeping each side independently mergeable.
+    public interface IExternalLibraryEditTarget
+    {
+        ProviderDefinition Definition { get; }
+        bool AcceptsExternalLibraryEdits { get; }
+        void PushExternalLibraryEdit(Book book, List<BookFile> files, ExternalLibraryEditPayload payload);
+    }
+}


### PR DESCRIPTION
#### Description
AudioBookShelf keeps its own copy of an item's metadata and only re-reads it when files are renamed, so a change Chaptarr makes to a book would otherwise never show up there. This sends the current title, description, publisher, series, and cover to the matching AudioBookShelf item whenever the owning library changes, behind a per-connection setting that says what the push actually carries. Items are matched by library-relative path across the connection's mapped libraries. AudioBookShelf is never read back — it stays a consumer, not a source.

Fixes # - n/a (feature)

#### Database Migration
NO - The setting lives in the connection's existing JSON settings blob

#### How was this tested?
Docker (linux/amd64) on an Ubuntu server host, image built with Dockerfile.build, against a live Audiobookshelf instance.

- Metadata edits propagated: changed fields (description, tags-as-genres, series) arrived on the matching ABS item, located by library-relative path.
- Cover updates delivered via the item cover endpoint from the library's cover URL.
- With the setting off, nothing is pushed — default behaviour unchanged.
- Confirmed no reverse flow: ABS-side edits are never read back into Chaptarr.

#### Screenshots (UI changes only)

<img width="623" height="1023" alt="image" src="https://github.com/user-attachments/assets/92c82f46-691f-48f6-8a64-3a170ade2a3c" />

---

**A note on AI:** We know AI/agentic coding is everywhere and only getting
more popular. We won't insist that you disclose whether you used it or which
models you used, but in the same spirit, please don't take offense if your PR
is scrutinized and changes are requested.

**Review time:** The longer the PR and the more lines changed, the longer the
review will take. Small, focused PRs merge fastest. If yours is big, please be
patient.
