### PR TITLE
fix: bulk delete author files

### DIFF
--- a/src/Chaptarr.Api.V1/Author/AuthorEditorController.cs
+++ b/src/Chaptarr.Api.V1/Author/AuthorEditorController.cs
@@ -340,7 +340,7 @@ namespace Chaptarr.Api.V1.Author
         [HttpDelete]
         public object DeleteAuthor([FromBody] AuthorEditorResource resource)
         {
-            _authorService.DeleteAuthors(resource.AuthorIds, false);
+            _authorService.DeleteAuthors(resource.AuthorIds, resource.DeleteFiles);
 
             return new { };
         }


### PR DESCRIPTION
#### Description
The author editor's delete endpoint passed a hardcoded false for deleteFiles, so "Delete Files" selected in the mass-editor delete dialog was silently discarded and author folders were left on disk. Deleting a single author from its detail page was unaffected, which made the difference look like a UI bug. The resource already carries the flag the client sends; pass it through.

Fixes # - Didn't see an issue for this yet

#### Database Migration
NO

#### How was this tested?
Docker (linux/amd64) on an Ubuntu server host, image built with Dockerfile.build.

Steps to reproduce:

1. Select several authors in the author mass editor, choose Delete, and tick "Delete Files".
2. Before this change: the authors are removed from Chaptarr but their folders remain on disk. After: the folders are deleted along with the authors.
3. Verified the flag still defaults off — a bulk delete without the checkbox leaves files in place, and single-author deletion from the detail page behaves as before.

---

**A note on AI:** We know AI/agentic coding is everywhere and only getting
more popular. We won't insist that you disclose whether you used it or which
models you used, but in the same spirit, please don't take offense if your PR
is scrutinized and changes are requested.

**Review time:** The longer the PR and the more lines changed, the longer the
review will take. Small, focused PRs merge fastest. If yours is big, please be
patient.
